### PR TITLE
fix: Hardens file permissions for token storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,7 +277,21 @@ npx mcp-test login https://api.example.com/mcp
 npx mcp-test login https://api.example.com/mcp --force
 ```
 
-Tokens are cached in `~/.local/state/mcp-tests/` and automatically refreshed.
+### Token Storage
+
+Tokens are cached locally and automatically refreshed when expired.
+
+**Storage locations:**
+- **Linux**: `$XDG_STATE_HOME/mcp-tests/<server-key>/` or `~/.local/state/mcp-tests/<server-key>/`
+- **macOS**: `~/.local/state/mcp-tests/<server-key>/`
+- **Windows**: `%LOCALAPPDATA%\mcp-tests\<server-key>\`
+
+**Security:**
+- Directory permissions: `0700` (owner only)
+- File permissions: `0600` (owner read/write only)
+- Files stored: `tokens.json`, `client.json`, `server.json`
+
+Use `--state-dir` to override the storage location.
 
 ### Programmatic Usage
 

--- a/src/auth/storage.test.ts
+++ b/src/auth/storage.test.ts
@@ -194,11 +194,11 @@ describe('storage', () => {
       // Should create directory
       expect(mocks.mkdir).toHaveBeenCalled();
 
-      // Should write to temp file
+      // Should write to temp file with secure permissions
       expect(mocks.writeFile).toHaveBeenCalledWith(
         expect.stringContaining('tokens.json.tmp'),
         expect.stringContaining('injected-token'),
-        'utf-8'
+        { encoding: 'utf-8', mode: 0o600 }
       );
 
       // Should rename to final path
@@ -215,7 +215,7 @@ describe('storage', () => {
 
       expect(mocks.mkdir).toHaveBeenCalledWith(
         expect.stringContaining('/custom/state'),
-        { recursive: true }
+        { recursive: true, mode: 0o700 }
       );
     });
   });
@@ -270,9 +270,10 @@ describe('storage', () => {
 
         await storage.saveTokens(tokens);
 
-        // Should create directory
+        // Should create directory with secure permissions
         expect(mocks.mkdir).toHaveBeenCalledWith(expect.any(String), {
           recursive: true,
+          mode: 0o700,
         });
 
         // Should write to .tmp file first

--- a/src/auth/storage.ts
+++ b/src/auth/storage.ts
@@ -306,16 +306,17 @@ class FileOAuthStorage implements OAuthStorage {
 
   /**
    * Write data atomically: write to .tmp file, then rename
+   * Files are created with 0o600 permissions (user read/write only)
    */
   private async atomicWrite(filePath: string, data: unknown): Promise<void> {
-    // Ensure directory exists
-    await fs.mkdir(this.stateDir, { recursive: true });
+    // Ensure directory exists with restrictive permissions
+    await fs.mkdir(this.stateDir, { recursive: true, mode: 0o700 });
 
     const tmpPath = `${filePath}.tmp`;
     const content = JSON.stringify(data, null, 2);
 
-    // Write to temp file
-    await fs.writeFile(tmpPath, content, 'utf-8');
+    // Write to temp file with restrictive permissions (user read/write only)
+    await fs.writeFile(tmpPath, content, { encoding: 'utf-8', mode: 0o600 });
 
     // Atomic rename
     await fs.rename(tmpPath, filePath);


### PR DESCRIPTION
This pull request improves the security of token storage by enforcing stricter file and directory permissions, and updates documentation and tests to reflect these changes. The main focus is on ensuring that sensitive authentication files are only accessible by the owner on all supported operating systems.

**Token Storage Security Enhancements:**

* Updated `src/auth/storage.ts` to ensure directories are created with `0700` permissions (owner only), and token files are written with `0600` permissions (owner read/write only). The atomic write method now explicitly sets these permissions when creating directories and files.

* Updated tests in `src/auth/storage.test.ts` to verify that directories are created with `0700` permissions and files with `0600` permissions, matching the new security requirements. [[1]](diffhunk://#diff-17bbcbf6677026d582270fe7e57b9cb6f9c1547a1312208cb8d7ed3f0090d250L197-R201) [[2]](diffhunk://#diff-17bbcbf6677026d582270fe7e57b9cb6f9c1547a1312208cb8d7ed3f0090d250L218-R218) [[3]](diffhunk://#diff-17bbcbf6677026d582270fe7e57b9cb6f9c1547a1312208cb8d7ed3f0090d250L273-R276)

**Documentation Updates:**

* Expanded the token storage section in `README.md` to document the new file and directory permissions, storage locations for Linux, macOS, and Windows, and the use of the `--state-dir` option.