### PR TITLE
feat: Improve OAuth token refresh and simplify test fixture auth

### DIFF
--- a/src/auth/types.ts
+++ b/src/auth/types.ts
@@ -25,6 +25,12 @@ export interface StoredTokens {
    * Token type (typically "Bearer")
    */
   tokenType: string;
+
+  /**
+   * Client ID that was used to obtain these tokens.
+   * Required for token refresh since refresh tokens are bound to the client.
+   */
+  clientId?: string;
 }
 
 /**


### PR DESCRIPTION
## Summary

- Store `clientId` with tokens to fix refresh failures when client.json differs from original auth client
- Improve error handling for non-JSON token endpoint responses to surface actual server errors
- Auto-detect and use CLI-stored tokens (`mcp-test login`) in test fixtures with automatic refresh

## Test plan

- [x] TypeScript compiles without errors
- [x] All 417 unit tests pass
- [ ] Manual test: run `mcp-test login <url>`, then run tests without auth config
- [ ] Verify token refresh works when access token expires

🤖 Generated with [Claude Code](https://claude.com/claude-code)