### PR TITLE
fix: write OAuth token files with 0o600 permissions (owner-only)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "mcp-server-tester": "dist/cli/index.js"
       },
       "devDependencies": {
+        "@ai-sdk/provider-utils": "^4.0.15",
         "@playwright/test": "^1.49.0",
         "@release-it-plugins/lerna-changelog": "^5.0.0",
         "@types/debug": "^4.1.12",
@@ -171,8 +172,8 @@
       "version": "3.0.8",
       "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.8.tgz",
       "integrity": "sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ==",
+      "devOptional": true,
       "license": "Apache-2.0",
-      "optional": true,
       "dependencies": {
         "json-schema": "^0.4.0"
       },
@@ -184,8 +185,8 @@
       "version": "4.0.15",
       "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.15.tgz",
       "integrity": "sha512-8XiKWbemmCbvNN0CLR9u3PQiet4gtEVIrX4zzLxnCj06AwsEDJwJVBbKrEI4t6qE8XRSIvU2irka0dcpziKW6w==",
+      "devOptional": true,
       "license": "Apache-2.0",
-      "optional": true,
       "dependencies": {
         "@ai-sdk/provider": "3.0.8",
         "@standard-schema/spec": "^1.1.0",
@@ -2218,8 +2219,8 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
-      "license": "MIT",
-      "optional": true
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/@szmarczak/http-timer": {
       "version": "5.0.1",
@@ -8285,8 +8286,8 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
       "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
-      "license": "(AFL-2.1 OR BSD-3-Clause)",
-      "optional": true
+      "devOptional": true,
+      "license": "(AFL-2.1 OR BSD-3-Clause)"
     },
     "node_modules/json-schema-traverse": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "react": "^18.3.1"
   },
   "devDependencies": {
+    "@ai-sdk/provider-utils": "^4.0.15",
     "@playwright/test": "^1.49.0",
     "@release-it-plugins/lerna-changelog": "^5.0.0",
     "@types/debug": "^4.1.12",

--- a/src/auth/oauthClientProvider.ts
+++ b/src/auth/oauthClientProvider.ts
@@ -280,12 +280,12 @@ export class PlaywrightOAuthClientProvider implements OAuthClientProvider {
 
     // Ensure directory exists
     const dir = path.dirname(this.config.storagePath);
-    await fs.mkdir(dir, { recursive: true });
+    await fs.mkdir(dir, { recursive: true, mode: 0o700 });
 
     await fs.writeFile(
       this.config.storagePath,
       JSON.stringify(state, null, 2),
-      'utf-8'
+      { encoding: 'utf-8', mode: 0o600 }
     );
   }
 
@@ -381,7 +381,10 @@ export async function saveOAuthState(
 
   // Ensure directory exists
   const dir = path.dirname(storagePath);
-  await fs.mkdir(dir, { recursive: true });
+  await fs.mkdir(dir, { recursive: true, mode: 0o700 });
 
-  await fs.writeFile(storagePath, JSON.stringify(state, null, 2), 'utf-8');
+  await fs.writeFile(storagePath, JSON.stringify(state, null, 2), {
+    encoding: 'utf-8',
+    mode: 0o600,
+  });
 }


### PR DESCRIPTION
## Summary

- `PlaywrightOAuthClientProvider.saveState()` and the standalone `saveOAuthState()` function were writing token files with default umask permissions (typically 0o644 — world-readable), leaking sensitive OAuth tokens to other users on the same machine.
- Both call sites now pass `mode: 0o600` to `fs.writeFile` and `mode: 0o700` to `fs.mkdir`, matching the secure permission model already present in `storage.ts`.
- A new `oauthClientProvider.test.ts` verifies both the class method and the standalone function enforce the correct file and directory permissions.

## Eval Panel Issue

Issue #10: Token File Written Without \`0o600\` Permissions

## Test Plan

- [x] New test file: `src/auth/oauthClientProvider.test.ts` (4 tests)
- [x] Tests verify `writeFile` called with `mode: 0o600` and `mkdir` with `mode: 0o700`
- [x] Both `PlaywrightOAuthClientProvider.saveTokens()` and `saveOAuthState()` are covered
- [x] `pnpm test -- src/auth/oauthClientProvider.test.ts` passes (4 tests)