### PR TITLE
fix: require content array in isCallToolResult type guard per MCP spec

### DIFF
--- a/src/mcp/response.test.ts
+++ b/src/mcp/response.test.ts
@@ -220,13 +220,29 @@ describe('extractText', () => {
       expect(extractText(result)).toBe('Hello from tool');
     });
 
-    it('should recognize CallToolResult by isError property', () => {
+    it('should recognize CallToolResult by content array', () => {
       const result = {
         isError: false,
         content: [{ type: 'text', text: 'Success' }],
       };
 
       expect(extractText(result)).toBe('Success');
+    });
+
+    it('rejects objects with isError but no content array', () => {
+      // Objects with only isError and no content should NOT be treated as CallToolResult
+      // They fall through to generic object handling, not CallToolResult normalization
+      const errorOnly = { isError: true };
+      const errorFalseOnly = { isError: false };
+      const withContent = { content: [], isError: true };
+      const contentOnly = { content: [] };
+
+      // isError alone: falls to generic object, returns JSON stringification
+      expect(extractText(errorOnly)).toBe('{"isError":true}');
+      expect(extractText(errorFalseOnly)).toBe('{"isError":false}');
+      // content array present: correctly identified as CallToolResult
+      expect(extractText(withContent)).toBe('');
+      expect(extractText(contentOnly)).toBe('');
     });
   });
 

--- a/src/mcp/response.ts
+++ b/src/mcp/response.ts
@@ -231,8 +231,8 @@ function isCallToolResult(value: unknown): value is CallToolResult {
     return false;
   }
   const v = value as Record<string, unknown>;
-  // CallToolResult has content array (required) or isError
-  return Array.isArray(v.content) || typeof v.isError === 'boolean';
+  // Per MCP spec, content is required in CallToolResult — isError alone is insufficient
+  return Array.isArray(v.content);
 }
 
 /**


### PR DESCRIPTION
## Summary
- `isCallToolResult` previously accepted objects with only `isError: boolean` and no `content` array, violating the MCP specification which requires `content` to be present in `CallToolResult`
- Changed the guard from `Array.isArray(v.content) || typeof v.isError === 'boolean'` to `Array.isArray(v.content)` — content is required per spec
- Added behavioral tests via `extractText` showing objects with `isError` alone are no longer treated as `CallToolResult`

## Eval Panel Issue
Issue #11: `isCallToolResult` Type Guard Too Loose

## Test Plan
- [x] Added `rejects objects with isError but no content array` test in `src/mcp/response.test.ts`
- [x] Updated misleading test description from "by isError property" to "by content array"
- [x] `pnpm run typecheck` passes
- [x] All 556 unit tests pass