### PR TITLE
fix: use package.json version in MCP client info instead of hardcoded 0.1.0

### DIFF
--- a/src/fixtures/mcp.ts
+++ b/src/fixtures/mcp.ts
@@ -14,6 +14,7 @@ import {
 import { PlaywrightOAuthClientProvider } from '../auth/oauthClientProvider.js';
 import { CLIOAuthClient } from '../auth/cli.js';
 import { isHttpConfig, type MCPConfig } from '../config/mcpConfig.js';
+import packageJson from '../../package.json' with { type: 'json' };
 
 /**
  * Internal fixture state for passing auth type between fixtures
@@ -157,7 +158,7 @@ export const test = base.extend<MCPFixtures>({
     const client = await createMCPClientForConfig(effectiveConfig, {
       clientInfo: {
         name: '@gleanwork/mcp-server-tester',
-        version: '0.1.0',
+        version: packageJson.version,
       },
       authProvider,
     });

--- a/src/mcp/clientFactory.test.ts
+++ b/src/mcp/clientFactory.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import packageJson from '../../package.json' with { type: 'json' };
 
 // Use vi.hoisted to define mocks that can be used in vi.mock factories
 const mocks = vi.hoisted(() => ({
@@ -66,7 +67,7 @@ describe('clientFactory', () => {
         expect(mocks.MockClient).toHaveBeenCalledWith(
           {
             name: '@gleanwork/mcp-server-tester',
-            version: '0.1.0',
+            version: packageJson.version,
           },
           {
             capabilities: {},
@@ -255,7 +256,7 @@ describe('clientFactory', () => {
         expect(mocks.MockClient).toHaveBeenCalledWith(
           {
             name: '@gleanwork/mcp-server-tester',
-            version: '0.1.0',
+            version: packageJson.version,
           },
           expect.anything()
         );
@@ -300,7 +301,7 @@ describe('clientFactory', () => {
         expect(mocks.MockClient).toHaveBeenCalledWith(
           {
             name: 'my-custom-client',
-            version: '0.1.0',
+            version: packageJson.version,
           },
           expect.anything()
         );

--- a/src/mcp/clientFactory.ts
+++ b/src/mcp/clientFactory.ts
@@ -11,6 +11,7 @@ import {
 } from '../config/mcpConfig.js';
 import { debugClient, debugHttp } from '../debug.js';
 import { ProxyAgent } from 'undici';
+import packageJson from '../../package.json' with { type: 'json' };
 
 /**
  * Options for creating an MCP client
@@ -75,7 +76,7 @@ export async function createMCPClientForConfig(
   const client = new Client(
     {
       name: options?.clientInfo?.name ?? '@gleanwork/mcp-server-tester',
-      version: options?.clientInfo?.version ?? '0.1.0',
+      version: options?.clientInfo?.version ?? packageJson.version,
     },
     {
       capabilities: validatedConfig.capabilities ?? {},


### PR DESCRIPTION
## Summary
- Both \`src/mcp/clientFactory.ts\` and \`src/fixtures/mcp.ts\` hardcoded the MCP client version as \`'0.1.0'\`
- Added \`import packageJson from '../../package.json' with { type: 'json' }\` in both files
- The version sent to MCP servers during connection now reflects the actual published package version (\`0.12.0\` currently)
- Updated \`clientFactory.test.ts\` to use \`packageJson.version\` in assertions instead of the literal string

## Eval Panel Issue
Issue #13: Client Version Hardcoded as \`0.1.0\`

## Test Plan
- [x] Updated 3 test assertions in \`clientFactory.test.ts\` to use dynamic \`packageJson.version\`
- [x] \`pnpm run typecheck\` passes
- [x] All 555 unit tests pass