### PR TITLE
fix: remove sampling capability declaration when no handler is registered

### DIFF
--- a/src/mcp/clientFactory.ts
+++ b/src/mcp/clientFactory.ts
@@ -30,6 +30,15 @@ export interface CreateMCPClientOptions {
    * This takes precedence over static token auth in config.auth.accessToken.
    */
   authProvider?: OAuthClientProvider;
+
+  /**
+   * Sampling handler callback for LLM sampling requests from the server.
+   *
+   * When provided, the client will advertise sampling capability to the server.
+   * When absent, sampling is removed from declared capabilities so the client
+   * does not falsely advertise support it cannot fulfill.
+   */
+  samplingHandler?: unknown;
 }
 
 /**
@@ -77,7 +86,14 @@ export async function createMCPClientForConfig(
       version: options?.clientInfo?.version ?? '0.1.0',
     },
     {
-      capabilities: validatedConfig.capabilities ?? {},
+      capabilities: {
+        ...(validatedConfig.capabilities ?? {}),
+        // Only advertise sampling if a handler has been registered;
+        // declaring sampling capability without a handler violates the MCP spec
+        sampling: options?.samplingHandler
+          ? (validatedConfig.capabilities?.sampling ?? {})
+          : undefined,
+      },
     }
   );
 


### PR DESCRIPTION
## Summary
- The MCP client was advertising \`sampling\` capability in all cases, even when no sampling request handler was registered
- This violates the MCP protocol spec: clients must not advertise capabilities they cannot fulfill
- Added \`samplingHandler?: unknown\` to \`CreateMCPClientOptions\` as a placeholder for the SDK sampling callback
- When \`samplingHandler\` is absent, \`sampling\` is excluded from the capabilities advertised to the server
- When \`samplingHandler\` is present, \`sampling\` uses the value from config (defaulting to \`{}\`)

## Eval Panel Issue
Issue #14: Sampling Capability Declared with No Handler

## Test Plan
- [x] All 17 \`clientFactory.test.ts\` tests pass
- [x] All 555 unit tests pass
- [x] \`pnpm run typecheck\` passes