### PR TITLE
fix: export MCPConfig as discriminated union type for compile-time transport validation

### DIFF
--- a/src/config/mcpConfig.test.ts
+++ b/src/config/mcpConfig.test.ts
@@ -31,7 +31,7 @@ describe('MCPConfig', () => {
         const result = validateMCPConfig(config);
 
         expect(result.transport).toBe('stdio');
-        expect(result.command).toBe('npx');
+        expect(isStdioConfig(result) && result.command).toBe('npx');
       });
 
       it('should validate stdio config with capabilities', () => {

--- a/src/config/mcpConfig.ts
+++ b/src/config/mcpConfig.ts
@@ -78,40 +78,34 @@ export interface MCPHostCapabilities {
 }
 
 /**
- * Configuration for MCP client connection
- *
- * Supports both stdio (local) and HTTP (remote) transports
+ * Configuration for MCP client connection via stdio transport (local process)
  */
-export interface MCPConfig {
+export interface StdioMCPConfig {
   /**
-   * Transport type
+   * Transport type discriminant
    */
-  transport: 'http' | 'stdio';
+  transport: 'stdio';
 
   /**
-   * Server URL (required when transport === 'http')
+   * Command to execute (required for stdio transport)
    */
-  serverUrl?: string;
+  command: string;
 
   /**
-   * HTTP headers (optional for http transport, e.g., Authorization)
-   */
-  headers?: Record<string, string>;
-
-  /**
-   * Command to execute (required when transport === 'stdio')
-   */
-  command?: string;
-
-  /**
-   * Command arguments (optional for stdio)
+   * Command arguments
    */
   args?: Array<string>;
 
   /**
-   * Working directory for the command (optional for stdio)
+   * Working directory for the command
    */
   cwd?: string;
+
+  /**
+   * Suppress stderr output from the server process.
+   * When true, server stderr is ignored instead of inherited.
+   */
+  quiet?: boolean;
 
   /**
    * Host capabilities to register with the server
@@ -127,18 +121,57 @@ export interface MCPConfig {
    * Request timeout in milliseconds
    */
   requestTimeoutMs?: number;
+}
 
+/**
+ * Configuration for MCP client connection via HTTP transport (remote server)
+ */
+export interface HttpMCPConfig {
   /**
-   * Suppress stderr output from the server process (stdio only)
-   * When true, server stderr is ignored instead of inherited
+   * Transport type discriminant
    */
-  quiet?: boolean;
+  transport: 'http';
 
   /**
-   * Authentication configuration (optional for http transport)
+   * Server URL (required for http transport)
+   */
+  serverUrl: string;
+
+  /**
+   * HTTP headers (e.g., Authorization)
+   */
+  headers?: Record<string, string>;
+
+  /**
+   * Authentication configuration
    */
   auth?: MCPAuthConfig;
+
+  /**
+   * Host capabilities to register with the server
+   */
+  capabilities?: MCPHostCapabilities;
+
+  /**
+   * Connection timeout in milliseconds
+   */
+  connectTimeoutMs?: number;
+
+  /**
+   * Request timeout in milliseconds
+   */
+  requestTimeoutMs?: number;
 }
+
+/**
+ * Configuration for MCP client connection.
+ *
+ * This is a discriminated union — narrow with `isStdioConfig()` or `isHttpConfig()`
+ * before accessing transport-specific fields.
+ *
+ * Supports both stdio (local) and HTTP (remote) transports.
+ */
+export type MCPConfig = StdioMCPConfig | HttpMCPConfig;
 
 /**
  * Zod schema for MCPHostCapabilities
@@ -227,17 +260,13 @@ export function validateMCPConfig(config: unknown): MCPConfig {
 /**
  * Type guard to check if a config is for stdio transport
  */
-export function isStdioConfig(
-  config: MCPConfig
-): config is MCPConfig & { transport: 'stdio'; command: string } {
-  return config.transport === 'stdio' && typeof config.command === 'string';
+export function isStdioConfig(config: MCPConfig): config is StdioMCPConfig {
+  return config.transport === 'stdio';
 }
 
 /**
  * Type guard to check if a config is for HTTP transport
  */
-export function isHttpConfig(
-  config: MCPConfig
-): config is MCPConfig & { transport: 'http'; serverUrl: string } {
-  return config.transport === 'http' && typeof config.serverUrl === 'string';
+export function isHttpConfig(config: MCPConfig): config is HttpMCPConfig {
+  return config.transport === 'http';
 }

--- a/src/fixtures/mcp.ts
+++ b/src/fixtures/mcp.ts
@@ -97,16 +97,19 @@ export const test = base.extend<MCPFixtures>({
     // Track resolved auth type
     let resolvedAuthType: AuthType = 'none';
 
+    // Narrow to HTTP config once for all auth-related logic (auth is HTTP-only)
+    const httpConfig = isHttpConfig(mcpConfig) ? mcpConfig : null;
+
     // Create auth provider if OAuth authStatePath is configured
     let authProvider: OAuthClientProvider | undefined;
-    if (mcpConfig.auth?.oauth?.authStatePath) {
+    if (httpConfig?.auth?.oauth?.authStatePath) {
       authProvider = new PlaywrightOAuthClientProvider({
-        storagePath: mcpConfig.auth.oauth.authStatePath,
+        storagePath: httpConfig.auth.oauth.authStatePath,
         redirectUri:
-          mcpConfig.auth.oauth.redirectUri ??
+          httpConfig.auth.oauth.redirectUri ??
           'http://localhost:3000/oauth/callback',
-        clientId: mcpConfig.auth.oauth.clientId,
-        clientSecret: mcpConfig.auth.oauth.clientSecret,
+        clientId: httpConfig.auth.oauth.clientId,
+        clientSecret: httpConfig.auth.oauth.clientSecret,
       });
       resolvedAuthType = 'oauth';
     }
@@ -115,19 +118,19 @@ export const test = base.extend<MCPFixtures>({
     let effectiveConfig = mcpConfig;
 
     // Check for explicit static API token
-    if (mcpConfig.auth?.accessToken) {
+    if (httpConfig?.auth?.accessToken) {
       resolvedAuthType = 'api-token';
     }
 
     // If HTTP transport with no explicit auth, try to use CLI-stored tokens
     // This enables the simple flow: `mcp-server-tester login <url>` then run tests
     if (
-      isHttpConfig(mcpConfig) &&
-      !mcpConfig.auth?.accessToken &&
-      !mcpConfig.auth?.oauth?.authStatePath
+      httpConfig &&
+      !httpConfig.auth?.accessToken &&
+      !httpConfig.auth?.oauth?.authStatePath
     ) {
       const cliClient = new CLIOAuthClient({
-        mcpServerUrl: mcpConfig.serverUrl,
+        mcpServerUrl: httpConfig.serverUrl,
       });
 
       // Try to get a valid token (will refresh if expired)
@@ -136,9 +139,9 @@ export const test = base.extend<MCPFixtures>({
       if (tokenResult) {
         // Use the CLI token as static auth
         effectiveConfig = {
-          ...mcpConfig,
+          ...httpConfig,
           auth: {
-            ...mcpConfig.auth,
+            ...httpConfig.auth,
             accessToken: tokenResult.accessToken,
           },
         };

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,8 @@
 // Config
 export type {
   MCPConfig,
+  StdioMCPConfig,
+  HttpMCPConfig,
   MCPHostCapabilities,
   MCPAuthConfig,
   MCPOAuthConfig,


### PR DESCRIPTION
## Summary
- \`MCPConfig\` was a single flat interface with both \`serverUrl?\` (HTTP-only) and \`command?\` (stdio-only) as optional fields, making it impossible for the type system to enforce correctness
- Replaced with two distinct interfaces: \`StdioMCPConfig\` (requires \`command\`, has \`args/cwd/quiet\`) and \`HttpMCPConfig\` (requires \`serverUrl\`, has \`headers/auth\`)
- \`MCPConfig\` is now \`type MCPConfig = StdioMCPConfig | HttpMCPConfig\` — a proper discriminated union on \`transport\`
- Updated \`isStdioConfig\` and \`isHttpConfig\` type guards to return narrowed interface types instead of intersection types
- Fixed \`src/fixtures/mcp.ts\`: extracted \`httpConfig\` early via \`isHttpConfig\` to narrow before accessing \`auth\` fields
- Fixed \`src/config/mcpConfig.test.ts\`: use \`isStdioConfig\` before accessing \`result.command\`
- Exported \`StdioMCPConfig\` and \`HttpMCPConfig\` from \`src/index.ts\`
- The Zod schemas (\`StdioConfigSchema\`, \`HttpConfigSchema\`, \`MCPConfigSchema\`) and \`validateMCPConfig\` are unchanged

## Eval Panel Issue
Issue #35: \`MCPConfig\` TypeScript Type is a Flat Interface

## Test Plan
- [x] \`pnpm run typecheck\` passes with zero errors
- [x] All 555 unit tests pass
- [x] Type narrowing required in 2 callsites (mcp.ts and mcpConfig.test.ts) — both correctly fixed