### PR TITLE
fix: set playwright retries to 0 to surface flaky tests

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -12,7 +12,7 @@ export default defineConfig({
   testDir: './tests',
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
-  retries: process.env.CI ? 2 : 0,
+  retries: 0,
   workers: process.env.CI ? 1 : undefined,
   reporter: 'html',
   use: {


### PR DESCRIPTION
## Summary

- Changed `retries: process.env.CI ? 2 : 0` to `retries: 0` in `playwright.config.ts`
- With 2 retries in CI, a test that fails on the first two attempts but passes on the third is reported as "flaky but passing" — hiding reliability issues in CI
- Setting retries to 0 ensures flaky tests fail immediately and loudly in both CI and local runs, making the test suite a reliable signal

## Eval Panel Issue

Issue #46: CI Playwright retries mask flaky tests

## Test Plan

- [x] `pnpm run typecheck` passes
- [x] `pnpm test` passes (555 tests)