### PR TITLE
docs: update CONTRIBUTING.md to require Node 22+ (was Node 18+)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,8 +14,8 @@ Thank you for your interest in contributing! This project is experimental and co
 
 ### Prerequisites
 
-- Node.js 18 or higher
-- npm or yarn
+- Node.js 22 or higher (required for the `import ... with { type: 'json' }` import assertions syntax used in this project; Node 18/20 do not support it)
+- pnpm (this project uses pnpm as its package manager)
 
 ### Setup
 
@@ -27,11 +27,11 @@ Thank you for your interest in contributing! This project is experimental and co
    ```
 3. Install dependencies:
    ```bash
-   npm install
+   pnpm install
    ```
 4. Build the project:
    ```bash
-   npm run build
+   pnpm run build
    ```
 
 ## Development Workflow
@@ -40,14 +40,14 @@ Thank you for your interest in contributing! This project is experimental and co
 
 ```bash
 # Unit tests (Vitest)
-npm test
-npm run test:watch
+pnpm test
+pnpm run test:watch
 
 # Integration tests (Playwright)
-npm run test:playwright
+pnpm run test:playwright
 
 # All tests
-npm test && npm run test:playwright
+pnpm test && pnpm run test:playwright
 ```
 
 ### Code Quality
@@ -55,11 +55,11 @@ npm test && npm run test:playwright
 Before submitting a PR, ensure:
 
 ```bash
-npm run typecheck  # TypeScript validation
-npm run lint       # ESLint checks
-npm run format     # Prettier formatting
-npm test          # All tests pass
-npm run build     # Build succeeds
+pnpm run typecheck  # TypeScript validation
+pnpm run lint       # ESLint checks
+pnpm run format     # Prettier formatting
+pnpm test          # All tests pass
+pnpm run build     # Build succeeds
 ```
 
 ### Making Changes

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -380,7 +380,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
 
       - run: npm ci
       - run: npx playwright install --with-deps
@@ -407,7 +407,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
 
       - run: npm ci
       - run: npx playwright install --with-deps
@@ -445,7 +445,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
 
       - run: npm ci
       - run: npx playwright install --with-deps


### PR DESCRIPTION
## Summary

- `CONTRIBUTING.md` stated "Node.js 18 or higher" which contradicts `package.json`'s `engines: { node: ">=22.0.0" }` requirement
- Node 22 is required because this project uses `import ... with { type: 'json' }` import assertion syntax, unsupported in Node 18/20
- Updated prerequisites from "Node.js 18" to "Node.js 22" with an explanation of why
- Updated recommended package manager from "npm or yarn" to "pnpm" (the actual package manager used in this project)
- Updated all `npm run` / `npm install` commands in the dev workflow to `pnpm`
- Updated `node-version: '20'` in CI examples in `docs/authentication.md` to `'22'`

## Eval Panel Issue

Issue #48: `CONTRIBUTING.md` documents Node 18, package requires Node 22

## Test Plan

- [x] Read the updated `CONTRIBUTING.md` to verify accuracy
- [x] No code changes — documentation only