### PR TITLE
feat: add HTTP-level trace logging via DEBUG=mcp-server-tester:http

### DIFF
--- a/src/debug.ts
+++ b/src/debug.ts
@@ -14,6 +14,9 @@
  *
  * # Enable only OAuth logs
  * DEBUG=mcp-server-tester:oauth npm test
+ *
+ * # Enable HTTP-level trace logging (URL, headers, transport selection)
+ * DEBUG=mcp-server-tester:http npx playwright test
  * ```
  */
 
@@ -35,3 +38,16 @@ export const debugOAuth = createDebug(`${NAMESPACE}:oauth`);
  * Debug logger for eval operations
  */
 export const debugEval = createDebug(`${NAMESPACE}:eval`);
+
+/**
+ * Debug logger for HTTP-level trace logging.
+ *
+ * Enable with:
+ * ```bash
+ * DEBUG=mcp-server-tester:http npx playwright test
+ * ```
+ *
+ * Logs: server URL, transport type selected (Streamable HTTP vs SSE),
+ * outgoing request header names, and connection outcomes.
+ */
+export const debugHttp = createDebug(`${NAMESPACE}:http`);

--- a/src/mcp/clientFactory.ts
+++ b/src/mcp/clientFactory.ts
@@ -9,7 +9,7 @@ import {
   isStdioConfig,
   isHttpConfig,
 } from '../config/mcpConfig.js';
-import { debugClient } from '../debug.js';
+import { debugClient, debugHttp } from '../debug.js';
 
 /**
  * Options for creating an MCP client
@@ -118,19 +118,32 @@ export async function createMCPClientForConfig(
       hasAuthProvider: !!options?.authProvider,
     });
 
+    debugHttp('Connecting to %s', validatedConfig.serverUrl);
+    if (Object.keys(headers).length > 0) {
+      debugHttp('Request header names: %O', Object.keys(headers));
+    }
+
     // Try Streamable HTTP first (MCP spec 2025-03-26), fall back to SSE (2024-11-05)
     try {
+      debugHttp('Attempting transport: streamableHttp');
       const streamableTransport = new StreamableHTTPClientTransport(url, {
         requestInit,
         authProvider: options?.authProvider,
       });
       await client.connect(streamableTransport);
       debugClient('Connected via Streamable HTTP');
-    } catch {
+      debugHttp('Connection established via streamableHttp');
+    } catch (err) {
+      debugHttp(
+        'streamableHttp failed (%s), falling back to SSE',
+        (err as Error).message
+      );
       debugClient('Streamable HTTP failed, falling back to SSE transport');
+      debugHttp('Attempting transport: sse');
       const sseTransport = new SSEClientTransport(url, { requestInit });
       await client.connect(sseTransport);
       debugClient('Connected via SSE');
+      debugHttp('Connection established via sse');
     }
   }
 


### PR DESCRIPTION
## Summary

- No HTTP-level trace logging existed — when connecting to remote servers it was hard to diagnose what URL/headers were being used and which transport protocol was selected
- Added `debugHttp` logger with namespace `mcp-server-tester:http` to `src/debug.ts`
- In `createMCPClientForConfig`, the HTTP path now emits trace log entries for:
  - Target server URL
  - Request header names (not values, to avoid leaking auth tokens)
  - Which transport is being attempted (`streamableHttp` or `sse`)
  - Fallback reason (error message) when Streamable HTTP fails
  - Confirmation of the established transport

Enable trace logging with:
```bash
DEBUG=mcp-server-tester:http npx playwright test
```

To enable all logs:
```bash
DEBUG=mcp-server-tester:* npx playwright test
```

## Eval Panel Issue

Issue #30: No HTTP-Level Trace Logging for Remote Debugging

## Test Plan

- [x] `pnpm run typecheck` passes
- [x] `pnpm test` passes (555 tests)
- [x] All existing clientFactory tests pass (the `catch` binding was updated from `catch {}` to `catch (err)` for logging, which is backward-compatible)