### PR TITLE
feat: aggregate tool precision/recall/F1 at dataset level in EvalRunnerResult

### DIFF
--- a/src/evals/evalRunner.test.ts
+++ b/src/evals/evalRunner.test.ts
@@ -1225,3 +1225,115 @@ describe('evals guide iteration count guardrail warnings', () => {
     consoleSpy.mockRestore();
   });
 });
+
+describe('dataset-level tool precision/recall/F1 aggregation', () => {
+  function createDataset(cases: EvalCase[]): EvalDataset {
+    return { name: 'test-dataset', cases };
+  }
+
+  function createSimulationMCP(
+    toolCalls: Array<{ name: string; arguments: Record<string, unknown> }>
+  ): MCPFixtureApi {
+    const mcp = createMockMCP();
+    vi.mocked(mcp.callTool).mockResolvedValue({
+      success: true,
+      toolCalls,
+      response: 'Done',
+    } as unknown as Awaited<ReturnType<typeof mcp.callTool>>);
+    return mcp;
+  }
+
+  it('computes datasetToolPrecision and datasetToolRecall when cases have toolsTriggered', async () => {
+    // Case 1: calls exactly [search], expects [search] required → precision=1, recall=1
+    // Case 2: calls [search, extra], exclusive=true, expects [search] required → recall=1, precision=0.5
+    const mcp1 = createSimulationMCP([{ name: 'search', arguments: {} }]);
+    const mcp2 = createSimulationMCP([
+      { name: 'search', arguments: {} },
+      { name: 'extra', arguments: {} },
+    ]);
+
+    // Use separate runs so we can control the mock per case
+    const case1 = createEvalCase({
+      id: 'case-1',
+      expect: {
+        toolsTriggered: {
+          calls: [{ name: 'search', required: true }],
+          exclusive: true,
+        },
+      },
+    });
+    const case2 = createEvalCase({
+      id: 'case-2',
+      expect: {
+        toolsTriggered: {
+          calls: [{ name: 'search', required: true }],
+          exclusive: true,
+        },
+      },
+    });
+
+    const result1 = await runEvalDataset(
+      { dataset: createDataset([case1]) },
+      createContext(mcp1)
+    );
+    const result2 = await runEvalDataset(
+      { dataset: createDataset([case2]) },
+      createContext(mcp2)
+    );
+
+    // Case 1: all expected, exclusive — precision 1.0, recall 1.0
+    expect(result1.datasetToolPrecision).toBeCloseTo(1.0);
+    expect(result1.datasetToolRecall).toBeCloseTo(1.0);
+    expect(result1.datasetToolF1).toBeCloseTo(1.0);
+
+    // Case 2: extra tool called (exclusive), recall=1 but precision=0.5
+    expect(result2.datasetToolPrecision).toBeCloseTo(0.5);
+    expect(result2.datasetToolRecall).toBeCloseTo(1.0);
+    // F1 = 2 * 0.5 * 1.0 / (0.5 + 1.0) = 1.0 / 1.5 ≈ 0.667
+    expect(result2.datasetToolF1).toBeCloseTo(0.667, 2);
+  });
+
+  it('does not set dataset tool metrics when no cases have toolsTriggered', async () => {
+    const mcp = createMockMCP({ content: [{ type: 'text', text: 'hello' }] });
+    const dataset = createDataset([
+      createEvalCase({ id: 'case-1', expect: { containsText: 'hello' } }),
+    ]);
+
+    const result = await runEvalDataset({ dataset }, createContext(mcp));
+
+    expect(result.datasetToolPrecision).toBeUndefined();
+    expect(result.datasetToolRecall).toBeUndefined();
+    expect(result.datasetToolF1).toBeUndefined();
+  });
+
+  it('averages precision/recall across multiple cases with toolsTriggered', async () => {
+    // Both cases call only the expected tool (recall=1, precision=1)
+    const mcp = createSimulationMCP([{ name: 'search', arguments: {} }]);
+    const dataset = createDataset([
+      createEvalCase({
+        id: 'case-1',
+        expect: {
+          toolsTriggered: {
+            calls: [{ name: 'search', required: true }],
+            exclusive: true,
+          },
+        },
+      }),
+      createEvalCase({
+        id: 'case-2',
+        expect: {
+          toolsTriggered: {
+            calls: [{ name: 'search', required: true }],
+            exclusive: true,
+          },
+        },
+      }),
+    ]);
+
+    const result = await runEvalDataset({ dataset }, createContext(mcp));
+
+    expect(result.datasetToolPrecision).toBeCloseTo(1.0);
+    expect(result.datasetToolRecall).toBeCloseTo(1.0);
+    expect(result.datasetToolF1).toBeCloseTo(1.0);
+  });
+});

--- a/src/evals/evalRunner.ts
+++ b/src/evals/evalRunner.ts
@@ -94,6 +94,26 @@ export interface EvalRunnerResult {
    * Only present when `baselineResultsFrom` was provided.
    */
   improvements?: number;
+
+  /**
+   * Average tool precision across all llm_host cases that have a
+   * `toolsTriggered` expectation (precision = fraction of called tools
+   * that were expected). Only present when at least one such case ran.
+   */
+  datasetToolPrecision?: number;
+
+  /**
+   * Average tool recall across all llm_host cases that have a
+   * `toolsTriggered` expectation (recall = fraction of required tools
+   * that were actually called). Only present when at least one such case ran.
+   */
+  datasetToolRecall?: number;
+
+  /**
+   * Harmonic mean of `datasetToolPrecision` and `datasetToolRecall`.
+   * Only present when at least one case contributes precision/recall data.
+   */
+  datasetToolF1?: number;
 }
 
 /**
@@ -813,6 +833,25 @@ export async function runEvalDataset(
           `${err instanceof Error ? err.message : String(err)}`
       );
     }
+  }
+
+  // Aggregate tool precision/recall/F1 across cases that have those metrics
+  const llmHostCases = caseResults.filter(
+    (r) => r.toolPrecision !== undefined || r.toolRecall !== undefined
+  );
+  if (llmHostCases.length > 0) {
+    const avgPrec =
+      llmHostCases.reduce((s, r) => s + (r.toolPrecision ?? 0), 0) /
+      llmHostCases.length;
+    const avgRecall =
+      llmHostCases.reduce((s, r) => s + (r.toolRecall ?? 0), 0) /
+      llmHostCases.length;
+    result.datasetToolPrecision = avgPrec;
+    result.datasetToolRecall = avgRecall;
+    result.datasetToolF1 =
+      avgPrec + avgRecall > 0
+        ? (2 * avgPrec * avgRecall) / (avgPrec + avgRecall)
+        : 0;
   }
 
   // Save results to file if requested


### PR DESCRIPTION
## Summary

- Per-case tool precision and recall were computed but never surfaced at the dataset level, making it impossible to track aggregate tool-calling quality across a dataset
- Added three optional fields to \`EvalRunnerResult\`:
  - \`datasetToolPrecision\`: mean precision across cases with a \`toolsTriggered\` expectation
  - \`datasetToolRecall\`: mean recall across cases with a \`toolsTriggered\` expectation
  - \`datasetToolF1\`: harmonic mean of the above
- Aggregation filters to cases where \`toolPrecision\` or \`toolRecall\` are defined (i.e., cases with an evaluated \`toolsTriggered\` block); cases without those metrics are not counted

## Eval Panel Issue

Issue #24: Tool Precision/Recall Not Aggregated at Dataset Level

## Test Plan

- [x] pnpm run typecheck passes
- [x] pnpm test passes (60 evalRunner tests, 3 new)
- [x] datasetToolPrecision/Recall/F1 are populated when cases have toolsTriggered expectations
- [x] Fields are undefined when no cases have tool metrics
- [x] Averaging works correctly across multiple cases