### PR TITLE
feat: add runtime warnings when eval config violates evals guide recommendations

### DIFF
--- a/src/evals/evalRunner.test.ts
+++ b/src/evals/evalRunner.test.ts
@@ -1057,3 +1057,137 @@ describe('saveResultsTo and baselineResultsFrom', () => {
     consoleSpy.mockRestore();
   });
 });
+
+describe('evals guide iteration count guardrail warnings', () => {
+  function createDataset(cases: EvalCase[]): EvalDataset {
+    return { name: 'test-dataset', cases };
+  }
+
+  it('warns when an llm_host case has fewer than 10 iterations (explicit)', async () => {
+    const consoleSpy = vi
+      .spyOn(console, 'warn')
+      .mockImplementation(() => undefined);
+
+    const dataset = createDataset([
+      createEvalCase({
+        id: 'low-iter-case',
+        mode: 'llm_host',
+        scenario: 'find something',
+        llmHostConfig: { provider: 'openai' },
+        iterations: 3,
+      }),
+    ]);
+
+    await runEvalDataset({ dataset }, createContext());
+
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining('3 iteration(s)')
+    );
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining('evals guide recommends >= 10')
+    );
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining('low-iter-case')
+    );
+
+    consoleSpy.mockRestore();
+  });
+
+  it('warns when an llm_host case defaults to 1 iteration (no explicit iterations)', async () => {
+    const consoleSpy = vi
+      .spyOn(console, 'warn')
+      .mockImplementation(() => undefined);
+
+    const dataset = createDataset([
+      createEvalCase({
+        id: 'default-iter-case',
+        mode: 'llm_host',
+        scenario: 'find something',
+        llmHostConfig: { provider: 'openai' },
+      }),
+    ]);
+
+    await runEvalDataset({ dataset }, createContext());
+
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining('1 iteration(s)')
+    );
+
+    consoleSpy.mockRestore();
+  });
+
+  it('does not warn when an llm_host case has 10 or more iterations', async () => {
+    const consoleSpy = vi
+      .spyOn(console, 'warn')
+      .mockImplementation(() => undefined);
+
+    const dataset = createDataset([
+      createEvalCase({
+        id: 'sufficient-iter-case',
+        mode: 'llm_host',
+        scenario: 'find something',
+        llmHostConfig: { provider: 'openai' },
+        iterations: 10,
+      }),
+    ]);
+
+    await runEvalDataset({ dataset }, createContext());
+
+    expect(consoleSpy).not.toHaveBeenCalledWith(
+      expect.stringContaining('evals guide recommends')
+    );
+
+    consoleSpy.mockRestore();
+  });
+
+  it('does not warn for direct mode cases regardless of iterations', async () => {
+    const consoleSpy = vi
+      .spyOn(console, 'warn')
+      .mockImplementation(() => undefined);
+
+    const mcp = createMockMCP({ content: [{ type: 'text', text: 'hello' }] });
+    const dataset = createDataset([
+      createEvalCase({
+        id: 'direct-case',
+        toolName: 'test-tool',
+        args: { input: 'test' },
+        iterations: 1,
+      }),
+    ]);
+
+    await runEvalDataset({ dataset }, createContext(mcp));
+
+    expect(consoleSpy).not.toHaveBeenCalledWith(
+      expect.stringContaining('evals guide recommends')
+    );
+
+    consoleSpy.mockRestore();
+  });
+
+  it('does not warn when defaultLlmIterations raises the count to >= 10', async () => {
+    const consoleSpy = vi
+      .spyOn(console, 'warn')
+      .mockImplementation(() => undefined);
+
+    const dataset = createDataset([
+      createEvalCase({
+        id: 'default-raised-case',
+        mode: 'llm_host',
+        scenario: 'find something',
+        llmHostConfig: { provider: 'openai' },
+        // No explicit iterations — defaultLlmIterations will apply
+      }),
+    ]);
+
+    await runEvalDataset(
+      { dataset, defaultLlmIterations: 10 },
+      createContext()
+    );
+
+    expect(consoleSpy).not.toHaveBeenCalledWith(
+      expect.stringContaining('evals guide recommends')
+    );
+
+    consoleSpy.mockRestore();
+  });
+});

--- a/src/evals/evalRunner.ts
+++ b/src/evals/evalRunner.ts
@@ -659,6 +659,19 @@ export async function runEvalDataset(
         ? { ...evalCase, iterations: defaultLlmIterations }
         : evalCase;
 
+    // Warn when an llm_host case runs fewer than the guide-recommended iterations.
+    // The evals guide recommends >= 10 iterations for statistical reliability.
+    if (evalCase.mode === 'llm_host') {
+      const effectiveIterations = withIterations.iterations ?? 1;
+      if (effectiveIterations < 10) {
+        console.warn(
+          `[mcp-server-tester] Eval case "${evalCase.id}" uses llm_host mode with only ` +
+            `${effectiveIterations} iteration(s). The evals guide recommends >= 10 iterations. ` +
+            `See docs/evals-guide.md for guidance on statistical reliability.`
+        );
+      }
+    }
+
     // Apply defaultJudgeReps to any case without explicit judgeReps
     const effectiveCase =
       withIterations.judgeReps === undefined && defaultJudgeReps !== undefined


### PR DESCRIPTION
## Summary

- The evals guide recommends >= 10 iterations for \`llm_host\` cases to ensure statistical reliability, but the runner never enforced this
- Added a guardrail \`console.warn\` that fires when an \`llm_host\` case has fewer than 10 effective iterations
- The effective count includes \`defaultLlmIterations\` (dataset-level default), so if the dataset sets 10 iterations globally, per-case warnings are suppressed
- Direct mode cases are unaffected — the warning only fires for \`mode === 'llm_host'\`
- Warning message names the case ID, the actual iteration count, and points to \`docs/evals-guide.md\`

## Eval Panel Issue

Issue #25: Evals Guide Recommends Things the Code Doesn't Enforce

## Test Plan

- [x] pnpm run typecheck passes
- [x] pnpm test passes (62 evalRunner tests, 5 new)
- [x] Warning fires for llm_host case with < 10 iterations (explicit)
- [x] Warning fires for llm_host case with default 1 iteration
- [x] No warning when iterations >= 10
- [x] No warning for direct mode cases
- [x] No warning when defaultLlmIterations raises count to >= 10