### PR TITLE
docs: replace dangerous console.log token example in JSDoc with safe usage pattern

### DIFF
--- a/src/auth/storage.ts
+++ b/src/auth/storage.ts
@@ -307,8 +307,9 @@ export async function injectTokens(
  * ```typescript
  * // After running: npx mcp-server-tester login https://api.example.com/mcp
  * const tokens = await loadTokens('https://api.example.com/mcp');
- * if (tokens) {
- *   console.log('Access token:', tokens.accessToken);
+ * if (tokens?.accessToken) {
+ *   // Use the token — never log raw token values
+ *   headers.Authorization = `Bearer ${tokens.accessToken}`;
  * }
  * ```
  */


### PR DESCRIPTION
## Summary

- The `@example` block in `loadTokens()` in `src/auth/storage.ts` showed `console.log('Access token:', tokens.accessToken)`, which would encourage inadvertent logging of raw bearer tokens in production systems
- Replaced with a pattern that uses the token in an `Authorization` header, which is the correct and safe usage

## Eval Panel Issue

Issue #33: JSDoc Example Shows `console.log('Access token:', ...)`

## Test Plan

- [x] `pnpm run typecheck` passes (only pre-existing `vercel.ts` error)
- [x] Documentation-only change — no test changes required