### PR TITLE
docs: correct false claim about automatic reconnection in transports.md

### DIFF
--- a/docs/transports.md
+++ b/docs/transports.md
@@ -233,8 +233,13 @@ The HTTP transport:
 
 - Establishes HTTP connection on first use
 - Maintains SSE stream for server events
-- Automatically reconnects on connection loss
 - Closes connection when tests complete
+
+> **Note:** Automatic reconnection is not currently implemented. If the remote
+> server drops the connection mid-test-suite, subsequent tests will fail with
+> connection errors. For production use against unreliable servers, implement
+> reconnect logic at the Playwright `globalSetup` level or use Playwright's
+> retry mechanism.
 
 ## Multiple Transports
 


### PR DESCRIPTION
## Summary

- The HTTP transport Connection Management section claimed "Automatically reconnects on connection loss". This is false — no reconnection logic exists in the codebase.
- Removed the false bullet point and replaced it with an accurate note explaining the current behavior and suggesting workarounds.

## What was wrong

`docs/transports.md` line 236 stated:

```
- Automatically reconnects on connection loss
```

This claim is not backed by any code in `src/mcp/clientFactory.ts` or any other transport-related file. If the SSE stream drops, the MCP client throws and subsequent tests fail.

## What changed

The bullet is removed and replaced with a `> **Note:**` block explaining:
- Automatic reconnection is not implemented
- Dropped connections cause subsequent test failures
- Workarounds: `globalSetup`-level reconnect logic or Playwright's retry mechanism

## Eval Panel Issue

Issue #7: Docs Falsely Claim Automatic Reconnection

## Test Plan

- [ ] Read updated `docs/transports.md` Connection Management section end-to-end
- [ ] Confirmed no code in the repository implements automatic HTTP reconnection