### PR TITLE
docs: update quickstart.md to remove deprecated v0.10 API references

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -171,11 +171,16 @@ Create a dataset file manually (e.g., `data/evals.json`):
       "id": "london-weather",
       "toolName": "get_weather",
       "args": { "city": "London" },
-      "expectedSchemaName": "weather-response"
+      "expect": {
+        "schema": "weather-response",
+        "containsText": ["London", "temperature"]
+      }
     }
   ]
 }
 ```
+
+Expectations are declared per-case in the `expect` block. The `schema` field names a Zod schema registered when loading the dataset. See the [Expectations Guide](./expectations.md) for all available fields.
 
 ## Running Evals
 
@@ -183,14 +188,10 @@ Use the `runEvalDataset` function in your tests:
 
 ```typescript
 import { test, expect } from '@gleanwork/mcp-server-tester/fixtures/mcp';
-import {
-  loadEvalDataset,
-  runEvalDataset,
-  createSchemaExpectation,
-} from '@gleanwork/mcp-server-tester';
+import { loadEvalDataset, runEvalDataset } from '@gleanwork/mcp-server-tester';
 import { z } from 'zod';
 
-test('run weather evals', async ({ mcp }) => {
+test('run weather evals', async ({ mcp }, testInfo) => {
   const WeatherSchema = z.object({
     city: z.string(),
     temperature: z.number(),
@@ -201,15 +202,7 @@ test('run weather evals', async ({ mcp }) => {
     schemas: { 'weather-response': WeatherSchema },
   });
 
-  const result = await runEvalDataset(
-    {
-      dataset,
-      expectations: {
-        schema: createSchemaExpectation(dataset),
-      },
-    },
-    { mcp }
-  );
+  const result = await runEvalDataset({ dataset }, { mcp, testInfo });
 
   expect(result.passed).toBe(result.total);
 });


### PR DESCRIPTION
## Summary

- `createSchemaExpectation()` was imported and called in the Running Evals example but has never been exported from `@gleanwork/mcp-server-tester`.
- The dataset JSON example used `expectedSchemaName` (old v0.10 field name) instead of the current `expect.schema` field.
- Both the dataset format and the TypeScript usage example have been updated to reflect the current v0.11 API.

## What was wrong

**Dataset JSON** (line 174):
```json
"expectedSchemaName": "weather-response"
```
This field does not exist in the current `EvalCase` type. The correct field is `expect.schema`.

**TypeScript example** (lines 189–190):
```typescript
import { loadEvalDataset, runEvalDataset, createSchemaExpectation } from '@gleanwork/mcp-server-tester';
```
`createSchemaExpectation` is not exported. The `expectations` key was also removed from `EvalRunnerOptions` in v0.11.

## What changed

- Dataset example: uses `expect` block with `schema` and `containsText` fields
- TypeScript example: removed `createSchemaExpectation` import; updated `runEvalDataset` call to `{ dataset }, { mcp, testInfo }`
- Added `testInfo` to the test function signature (required for snapshot fixtures)

## Eval Panel Issue

Issue #37: Quickstart References Deprecated v0.10 API

## Test Plan

- [x] `pnpm run typecheck` passes
- [x] `createSchemaExpectation` and `expectedSchemaName` confirmed absent from `src/index.ts` and `src/evals/datasetTypes.ts`
- [x] Updated example verified against `EvalRunnerOptions` interface in `src/evals/evalRunner.ts`