### PR TITLE
docs: document Node 22 requirement and add startup version check to CLI

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,8 +14,8 @@ Thank you for your interest in contributing! This project is experimental and co
 
 ### Prerequisites
 
-- Node.js 18 or higher
-- npm or yarn
+- Node.js >= 22.0.0 (required; see [Requirements](./README.md#requirements))
+- pnpm (for development)
 
 ### Setup
 

--- a/README.md
+++ b/README.md
@@ -71,6 +71,11 @@ Direct mode is the default for most tests. LLM host mode (`mode: "llm_host"` in 
 
 > **Cost note:** LLM host mode makes real API calls to the configured provider on every iteration. See the [LLM Host Guide](docs/llm-host.md) for cost management guidance.
 
+## Requirements
+
+- **Node.js >= 22.0.0** — Required for import assertions syntax (`import ... with { type: 'json' }`). Node 20 LTS is not supported.
+- **pnpm** (for development) or **npm/yarn** (for consumption)
+
 ## Installation
 
 ```bash

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1,5 +1,9 @@
 /**
  * CLI entry point for @gleanwork/mcp-server-tester
+ *
+ * Node.js >= 22.0.0 is required. The version check below runs after ESM
+ * module linking, so it catches cases where a user bypasses the `engines`
+ * field and invokes the CLI with an unsupported Node version.
  */
 
 import { Command } from 'commander';
@@ -7,6 +11,16 @@ import { init } from './commands/init/index.js';
 import { generate } from './commands/generate/index.js';
 import { login } from './commands/login/index.js';
 import { token } from './commands/token/index.js';
+
+const nodeMajor = parseInt(process.versions.node.split('.')[0] ?? '0', 10);
+if (nodeMajor < 22) {
+  process.stderr.write(
+    `Error: @gleanwork/mcp-server-tester requires Node.js >= 22.0.0.\n` +
+      `You are running Node.js ${process.versions.node}.\n` +
+      `Please upgrade to Node.js 22 LTS or higher.\n`
+  );
+  process.exit(1);
+}
 
 const program = new Command();
 


### PR DESCRIPTION
## Summary

- Adds a `## Requirements` section to `README.md` documenting that Node.js >= 22.0.0 is required (not Node 20 LTS), and that pnpm is the development package manager.
- Corrects the `CONTRIBUTING.md` prerequisites section, which incorrectly stated "Node.js 18 or higher".
- Adds a runtime version guard in `src/cli/index.ts` that prints a clear error message and exits with code 1 if the CLI is invoked with Node < 22.

The guard runs after ESM module linking, so it won't catch parse-time failures on very old Node, but it does surface a clear diagnostic for cases where a user bypasses the `engines` field enforcement.

## Eval Panel Issue

Issue #39: Node 22 Requirement is Undocumented

## Test Plan

- [ ] pnpm run typecheck passes
- [ ] pnpm test passes