### PR TITLE
chore: bump version to 0.13.0 and update CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,52 @@
 
 
 
+## [0.13.0] - 2026-02-26
+
+### New Features
+- OAuth 2.1 client credentials grant for CI/CD machine-to-machine auth (Issue 15)
+- Wilson score confidence intervals on accuracy reporting (Issue 19)
+- Retry with exponential backoff for transient connection failures (Issue 27)
+- HTTP proxy support via config or environment variables (Issue 16)
+- TLS configuration options (custom CA, client certs) (Issue 29)
+- 5-point judge rubric scale with concrete scoring examples (Issue 20)
+- Experiment tracking metadata in eval results (Issue 23)
+- HTTP-level trace logging via `DEBUG=mcp-server-tester:http`
+- Runtime warnings when eval config violates evals guide recommendations
+- Vercel AI SDK orchestrator for LLM host mode (all 10 providers unified)
+- EvalV2 parity: judge reps, rubric types, inline config, A/B comparison
+- Streamable HTTP transport with SSE fallback
+- `toHaveToolCalls` and `toHaveToolCallCount` Playwright matchers
+- `validateToolCalls` and `validateToolCallCount` validators
+- `defaultLlmIterations` and `defaultJudgeReps` options for eval datasets
+- `vertex-anthropic` provider for LLM host mode
+
+### Bug Fixes
+- SSE transport fallback now correctly passes authProvider (Issue 1)
+- Timeout config is now wired to transport/client (Issue 2)
+- Infrastructure errors excluded from accuracy computation (Issue 3)
+- Multi-iteration results now use first passing iteration as representative (Issue 4)
+- Size expectation counter now incremented in reporter (Issue 5)
+- `isCallToolResult` type guard requires content array per MCP spec (Issue 11)
+- Client version no longer hardcoded as 0.1.0 (Issue 13)
+- `MCPConfig` exported as discriminated union type (Issue 35)
+- Fixed broken `extractTextFromResponse` import in examples and docs (Issue 8)
+- Fixed incorrect function names in api-reference.md (Issue 38)
+- Updated quickstart.md to remove deprecated v0.10 API references (Issue 37)
+- Corrected false claim about automatic reconnection in transports.md (Issue 7)
+- Replaced dangerous `console.log` token example in JSDoc with safe pattern
+
+### Security
+- OAuth state files written with `0o600` permissions (Issue 10)
+- PKCE code verifier cleared after token exchange (Issue 17)
+- OAuth debug logs no longer expose state/code_challenge parameters (Issue 32)
+- XML structural boundaries in judge prompts prevent prompt injection (Issue 18)
+
+### Documentation
+- Added `docs/architecture.md` and `.github/CODEOWNERS` (Issue 47)
+- Documented Node.js >= 22.0.0 requirement in README (Issue 39)
+- Added comprehensive evals guide (`docs/evals-guide.md`)
+
 ## v0.12.0 (2025-12-16)
 
 #### :boom: Breaking Change

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gleanwork/mcp-server-tester",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "description": "Playwright-based testing and evaluation framework for MCP servers",
   "keywords": [
     "playwright",


### PR DESCRIPTION
## Summary

Prepares the 0.13.0 release with all changes from the eval remediation sprint.

**NOTE: Do NOT merge until all remediation PRs (#18–#64) are reviewed and merged first.**
**NOTE: After merging, run \`npm publish\` manually — do not automate this step.**

- \`package.json\`: version bumped \`0.12.0\` → \`0.13.0\`
- \`CHANGELOG.md\`: added \`0.13.0\` section documenting all remediation changes across new features, bug fixes, security improvements, and documentation

## Eval Panel Issue

Issue #12: Published npm Version Behind Local HEAD — Prepare Publish

## Changes

The 0.13.0 release includes approximately 35 commits since 0.12.0:
- New: HTTP trace logging, eval config warnings, Vercel AI SDK orchestrator for LLM host, EvalV2 parity (judge reps, rubric types, A/B comparison), Streamable HTTP with SSE fallback, `toHaveToolCalls`/`toHaveToolCallCount` matchers, `vertex-anthropic` provider
- Fixed: SSE auth passthrough, client version hardcoding, MCPConfig export type, broken imports in examples, deprecated API references in docs
- Security: 0o600 OAuth file permissions, PKCE code verifier clearing, safe debug logs, XML injection boundaries in judge prompts
- Docs: architecture.md, CODEOWNERS, Node 22 requirement, evals guide

## Test Plan

- [ ] All remediation PRs #18–#64 merged before this one
- [ ] pnpm run typecheck passes
- [ ] pnpm test passes
- [ ] Manual: \`npm publish\` (requires human confirmation after merge)