### PR TITLE
fix: change autoOpen reporter default from true to false

### DIFF
--- a/src/cli/templates/index.ts
+++ b/src/cli/templates/index.ts
@@ -53,7 +53,6 @@ export default defineConfig({
     ['html'],
     ['@gleanwork/mcp-server-tester/reporters/mcpReporter', {
       outputDir: '.mcp-test-results',
-      autoOpen: true,
       historyLimit: 10
     }]
   ],

--- a/src/reporters/mcpReporter.ts
+++ b/src/reporters/mcpReporter.ts
@@ -23,7 +23,7 @@ import type { MCPConformanceCheck } from '../spec/conformanceChecks.js';
 /**
  * Custom Playwright reporter for MCP eval results
  *
- * Generates HTML reports with historical tracking and auto-opens in browser
+ * Generates HTML reports with historical tracking
  *
  * @example
  * ```typescript
@@ -32,7 +32,6 @@ import type { MCPConformanceCheck } from '../spec/conformanceChecks.js';
  *   reporter: [
  *     ['@gleanwork/mcp-server-tester/reporters/mcpReporter', {
  *       outputDir: '.mcp-test-results',
- *       autoOpen: true,
  *       historyLimit: 10
  *     }]
  *   ]
@@ -49,7 +48,7 @@ export default class MCPReporter implements Reporter {
   constructor(options: MCPEvalReporterConfig = {}) {
     this.config = {
       outputDir: options.outputDir ?? '.mcp-test-results',
-      autoOpen: options.autoOpen ?? true,
+      autoOpen: options.autoOpen ?? false,
       historyLimit: options.historyLimit ?? 10,
       quiet: options.quiet ?? false,
       includeAutoTracking: options.includeAutoTracking ?? true,

--- a/src/reporters/types.ts
+++ b/src/reporters/types.ts
@@ -40,7 +40,7 @@ export interface MCPEvalReporterConfig {
 
   /**
    * Auto-open report in browser after test run
-   * @default true (disabled in CI)
+   * @default false
    */
   autoOpen?: boolean;
 


### PR DESCRIPTION
## Summary

- Changes `autoOpen` reporter option default from `true` to `false`
- Updates the generated config template to remove the now-redundant `autoOpen: true` line
- Updates JSDoc comments that referenced the old default

## Why

Defaulting to opening a browser window is surprising behavior for a testing library. While the existing CI guard (`!process.env.CI`) protects standard CI environments (GitHub Actions, CircleCI, etc.), it does not protect:
- Non-standard CI environments that don't set `CI=true`
- Developer machines where auto-opening is unwanted
- Headless environments and containers

Opt-in is the safer default. Users who want auto-open should set `autoOpen: true` explicitly.

## Test Plan

- [x] `npm run typecheck` passes
- [x] `npm test` passes
- [x] `npm run lint` passes
- [x] `npm run format:check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)