### PR TITLE
fix: add HTTPS validation for OAuth discovery endpoints and scope downgrade warning

### DIFF
--- a/src/auth/discovery.ts
+++ b/src/auth/discovery.ts
@@ -9,6 +9,45 @@ import * as oauth from 'oauth4webapi';
 import type { AuthServerMetadata } from './oauthFlow.js';
 
 /**
+ * Returns true if the hostname refers to the loopback interface
+ */
+function isLocalhostUrl(url: string): boolean {
+  try {
+    const parsed = new URL(url);
+    const h = parsed.hostname;
+    return h === 'localhost' || h === '127.0.0.1' || h === '::1';
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Validates that critical OAuth endpoints returned by discovery use HTTPS.
+ * Localhost URLs are exempt to support local development and testing.
+ *
+ * @throws Error if any endpoint uses a non-HTTPS, non-localhost scheme
+ */
+function validateAuthServerEndpoints(authServer: {
+  authorization_endpoint?: string;
+  token_endpoint?: string;
+  issuer?: string;
+}): void {
+  const endpoints = [
+    { name: 'authorization_endpoint', url: authServer.authorization_endpoint },
+    { name: 'token_endpoint', url: authServer.token_endpoint },
+  ];
+
+  for (const { name, url } of endpoints) {
+    if (url && !url.startsWith('https://') && !isLocalhostUrl(url)) {
+      throw new Error(
+        `OAuth discovery returned an insecure ${name}: "${url}". ` +
+          `Only HTTPS endpoints are permitted for OAuth flows to prevent token interception.`
+      );
+    }
+  }
+}
+
+/**
  * MCP Protocol version header value
  */
 export const MCP_PROTOCOL_VERSION = '2025-06-18';
@@ -196,6 +235,8 @@ export async function discoverAuthorizationServer(
   });
 
   const metadata = await oauth.processDiscoveryResponse(issuer, response);
+
+  validateAuthServerEndpoints(metadata);
 
   return {
     server: metadata,

--- a/src/auth/oauthFlow.ts
+++ b/src/auth/oauthFlow.ts
@@ -5,7 +5,10 @@
  */
 
 import * as oauth from 'oauth4webapi';
+import createDebug from 'debug';
 import type { TokenResult } from './types.js';
+
+const debug = createDebug('mcp-server-tester:oauth-flow');
 
 /**
  * Discovered OAuth authorization server metadata
@@ -424,6 +427,26 @@ export async function performClientCredentialsFlow(
     client,
     response
   );
+
+  const requestedScopes = new Set(
+    config.scopes && config.scopes.length > 0 ? config.scopes : []
+  );
+  const grantedScopes = new Set(
+    (result.scope ?? '').split(' ').filter(Boolean)
+  );
+  const missingScopes = [...requestedScopes].filter(
+    (s) => !grantedScopes.has(s)
+  );
+  if (
+    missingScopes.length > 0 &&
+    requestedScopes.size > 0 &&
+    grantedScopes.size > 0
+  ) {
+    debug(
+      '[oauth] Warning: Token server granted fewer scopes than requested. Missing: %s',
+      missingScopes.join(', ')
+    );
+  }
 
   return {
     accessToken: result.access_token,


### PR DESCRIPTION
## Summary

- Validates that OAuth discovery `authorization_endpoint` and `token_endpoint` use HTTPS (localhost exempt)
- Adds debug warning when client credentials token response grants fewer scopes than requested
- Prevents tokens from being sent over insecure connections due to misconfigured servers

## Why

**HTTPS validation:** The OAuth discovery flow fetches metadata from an MCP server and uses the returned `authorization_endpoint` and `token_endpoint` without validating their scheme. A malicious or misconfigured server could return `http://` endpoints, causing auth codes and tokens to transit over unencrypted HTTP.

**Scope warning:** The client credentials flow silently accepts tokens with reduced scopes. If a developer configures `scope: 'read write'` but the server only grants `read`, subsequent write operations fail with confusing auth errors instead of a clear diagnostic at token acquisition time.

## Test Plan

- [x] `npm run typecheck` passes
- [x] `npm test` passes
- [x] `npm run lint` passes
- [x] `npm run format:check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)