### PR TITLE
fix: move zod to dependencies (runtime requirement)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,8 @@
         "oauth4webapi": "^3.0.0",
         "open": "^10.1.0",
         "react": "^18.3.1",
-        "undici": "^7.22.0"
+        "undici": "^7.22.0",
+        "zod": "^3.24.1"
       },
       "bin": {
         "mcp-server-tester": "dist/cli/index.js"
@@ -49,8 +50,7 @@
         "tsup": "^8.3.5",
         "tsx": "^4.19.2",
         "typescript": "^5.7.2",
-        "vitest": "^2.1.8",
-        "zod": "^3.24.1"
+        "vitest": "^2.1.8"
       },
       "engines": {
         "node": ">=22.0.0"
@@ -65,8 +65,7 @@
         "@ai-sdk/anthropic": "^3.0.0",
         "@ai-sdk/openai": "^3.0.0",
         "@playwright/test": "^1.40.0",
-        "ai": "^6.0.0",
-        "zod": "^3.0.0"
+        "ai": "^6.0.0"
       },
       "peerDependenciesMeta": {
         "@ai-sdk/anthropic": {

--- a/package.json
+++ b/package.json
@@ -81,7 +81,8 @@
     "oauth4webapi": "^3.0.0",
     "open": "^10.1.0",
     "react": "^18.3.1",
-    "undici": "^7.22.0"
+    "undici": "^7.22.0",
+    "zod": "^3.24.1"
   },
   "devDependencies": {
     "@ai-sdk/provider-utils": "^4.0.15",
@@ -108,15 +109,13 @@
     "tsup": "^8.3.5",
     "tsx": "^4.19.2",
     "typescript": "^5.7.2",
-    "vitest": "^2.1.8",
-    "zod": "^3.24.1"
+    "vitest": "^2.1.8"
   },
   "peerDependencies": {
     "@ai-sdk/anthropic": "^3.0.0",
     "@ai-sdk/openai": "^3.0.0",
     "@playwright/test": "^1.40.0",
-    "ai": "^6.0.0",
-    "zod": "^3.0.0"
+    "ai": "^6.0.0"
   },
   "peerDependenciesMeta": {
     "ai": {


### PR DESCRIPTION
## Summary

- Moves `zod` from `devDependencies` to `dependencies`
- Removes `zod` from `peerDependencies`
- Zod is used at runtime in config validation, dataset loading, and assertion validators

## Why

With `zod` in `devDependencies` only, consumers who install in production (without `--include=dev`) get a runtime `Cannot find module 'zod'` error. This is a deployment bug.

## Test Plan

- [x] `npm run typecheck` passes
- [x] `npm test` passes
- [x] `npm run lint` passes
- [x] `npm run format:check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)