### PR TITLE
fix: add Zod schema validation for judge responses and preflight cost warning

### DIFF
--- a/src/evals/evalRunner.ts
+++ b/src/evals/evalRunner.ts
@@ -25,6 +25,7 @@ import {
   validateJudge,
 } from '../assertions/validators/index.js';
 import { execFileNoThrow } from '../utils/execFileNoThrow.js';
+import { debugEval } from '../debug.js';
 import packageJson from '../../package.json' with { type: 'json' };
 
 /**
@@ -778,6 +779,25 @@ export async function runEvalDataset(
     filterTags && filterTags.length > 0
       ? dataset.cases.filter((c) => c.tags?.some((t) => filterTags.includes(t)))
       : dataset.cases;
+
+  // Preflight cost warning: estimate the number of LLM judge API calls this run will make
+  const estimatedJudgeCalls = casesToRun.reduce((sum, c) => {
+    const effectiveIterations =
+      c.mode === 'llm_host'
+        ? (c.iterations ?? defaultLlmIterations ?? 1)
+        : (c.iterations ?? 1);
+    const judgeReps =
+      c.expect?.passesJudge != null
+        ? (c.expect.passesJudge.reps ?? c.judgeReps ?? defaultJudgeReps ?? 1)
+        : 0;
+    return sum + effectiveIterations * judgeReps;
+  }, 0);
+
+  if (estimatedJudgeCalls > 50) {
+    debugEval(
+      `Warning: This run will make approximately ${estimatedJudgeCalls} LLM judge API calls. This may incur significant costs.`
+    );
+  }
 
   // Build task factories for all cases
   const tasks = casesToRun.map((evalCase) => async () => {

--- a/src/judge/claudeAgentJudge.test.ts
+++ b/src/judge/claudeAgentJudge.test.ts
@@ -424,17 +424,15 @@ describe('claudeAgentJudge', () => {
       ).rejects.toThrow('Failed to parse judge response as JSON');
     });
 
-    it('handles response with score but no pass field', async () => {
-      // JSON parses successfully but has no "pass" key — defaults to false via ?? false
+    it('throws when response is missing required pass field', async () => {
+      // JSON parses successfully but has no "pass" key — schema validation rejects it
       mockQueryResponse('{"score":0.6,"reasoning":"partial credit"}');
 
       const judge = createClaudeAgentJudge({});
-      const result = await judge.evaluate('candidate', 'reference', 'rubric');
 
-      // pass defaults to false when absent
-      expect(result.pass).toBe(false);
-      expect(result.score).toBe(0.6);
-      expect(result.reasoning).toBe('partial credit');
+      await expect(
+        judge.evaluate('candidate', 'reference', 'rubric')
+      ).rejects.toThrow('Judge returned invalid response');
     });
   });
 

--- a/src/judge/claudeAgentJudge.ts
+++ b/src/judge/claudeAgentJudge.ts
@@ -5,6 +5,7 @@ import type {
   JudgeResult,
   UsageMetrics,
 } from './judgeTypes.js';
+import { JudgeResponseSchema } from './judgeTypes.js';
 
 /**
  * Creates a Claude Agent SDK-based LLM judge client
@@ -126,7 +127,7 @@ export function createClaudeAgentJudge(config: JudgeConfig): Judge {
         };
 
         return {
-          pass: parsed.pass ?? false,
+          pass: parsed.pass,
           score: parsed.score,
           reasoning: parsed.reasoning,
           usage,
@@ -197,12 +198,13 @@ function buildJudgePrompt(
 }
 
 /**
- * Parses the JSON response from the judge, handling markdown code blocks
+ * Parses and validates the JSON response from the judge, handling markdown code blocks.
+ * Throws a descriptive error if the response cannot be parsed or fails schema validation.
  */
 function parseJudgeResponse(text: string): {
-  pass?: boolean;
-  score?: number;
-  reasoning?: string;
+  pass: boolean;
+  score: number;
+  reasoning: string;
 } {
   let jsonText = text.trim();
 
@@ -218,23 +220,25 @@ function parseJudgeResponse(text: string): {
   }
   jsonText = jsonText.trim();
 
+  let parsed: unknown;
   try {
-    return JSON.parse(jsonText) as {
-      pass?: boolean;
-      score?: number;
-      reasoning?: string;
-    };
+    parsed = JSON.parse(jsonText);
   } catch {
     // If JSON parsing fails, try to extract from the text
     // Sometimes the model adds extra text before/after JSON
     const jsonMatch = jsonText.match(/\{[\s\S]*"pass"[\s\S]*\}/);
     if (jsonMatch) {
-      return JSON.parse(jsonMatch[0]) as {
-        pass?: boolean;
-        score?: number;
-        reasoning?: string;
-      };
+      parsed = JSON.parse(jsonMatch[0]);
+    } else {
+      throw new Error(`Failed to parse judge response as JSON: ${text}`);
     }
-    throw new Error(`Failed to parse judge response as JSON: ${text}`);
   }
+
+  const result = JudgeResponseSchema.safeParse(parsed);
+  if (!result.success) {
+    throw new Error(
+      `Judge returned invalid response. Expected {pass, score, reasoning} but got: ${jsonText.slice(0, 500)}\nValidation errors: ${JSON.stringify(result.error.issues)}`
+    );
+  }
+  return result.data;
 }

--- a/src/judge/googleJudge.test.ts
+++ b/src/judge/googleJudge.test.ts
@@ -110,8 +110,8 @@ describe('googleJudge', () => {
       expect(result.reasoning).toBe('Too vague');
     });
 
-    it('derives pass from pass field when present, defaults to false when missing', async () => {
-      // When pass field is missing, googleJudge defaults to false
+    it('throws when response is missing required pass field', async () => {
+      // When pass field is missing, schema validation rejects it
       mockGenerateContent.mockResolvedValue(
         makeGenerateResponse(
           JSON.stringify({
@@ -122,25 +122,22 @@ describe('googleJudge', () => {
       );
 
       const judge = createGoogleJudge({});
-      const result = await judge.evaluate('candidate', null, 'rubric');
 
-      // pass = typeof parsed.pass === 'boolean' ? parsed.pass : false
-      expect(result.pass).toBe(false);
-      expect(result.score).toBe(0.85);
+      await expect(judge.evaluate('candidate', null, 'rubric')).rejects.toThrow(
+        'Judge returned invalid response'
+      );
     });
 
-    it('handles invalid JSON response gracefully without throwing', async () => {
+    it('throws on invalid JSON response', async () => {
       mockGenerateContent.mockResolvedValue(
         makeGenerateResponse('This is not valid JSON at all')
       );
 
       const judge = createGoogleJudge({});
-      // googleJudge catches JSON.parse errors and stores in reasoning
-      const result = await judge.evaluate('candidate', null, 'rubric');
 
-      expect(result.pass).toBe(false);
-      expect(result.score).toBe(0);
-      expect(result.reasoning).toContain('Failed to parse judge response');
+      await expect(judge.evaluate('candidate', null, 'rubric')).rejects.toThrow(
+        'Failed to parse judge response as JSON'
+      );
     });
 
     it('propagates API errors (does not swallow them)', async () => {

--- a/src/judge/googleJudge.ts
+++ b/src/judge/googleJudge.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-explicit-any */
 import type { Judge, JudgeConfig, JudgeResult } from './judgeTypes.js';
+import { JudgeResponseSchema } from './judgeTypes.js';
 
 /**
  * Creates a Google Gemini-backed LLM judge.
@@ -70,20 +71,20 @@ export function createGoogleJudge(config: JudgeConfig = {}): Judge {
         .replace(/```\n?/g, '')
         .trim();
 
-      let pass = false;
-      let score = 0;
-      let reasoning = '';
-
+      let parsedRaw: unknown;
       try {
-        const parsed = JSON.parse(cleaned) as Record<string, unknown>;
-        pass = typeof parsed.pass === 'boolean' ? parsed.pass : false;
-        score =
-          typeof parsed.score === 'number' ? parsed.score : pass ? 1.0 : 0.0;
-        reasoning =
-          typeof parsed.reasoning === 'string' ? parsed.reasoning : '';
+        parsedRaw = JSON.parse(cleaned);
       } catch {
-        reasoning = `Failed to parse judge response: ${text}`;
+        throw new Error(`Failed to parse judge response as JSON: ${text}`);
       }
+
+      const validation = JudgeResponseSchema.safeParse(parsedRaw);
+      if (!validation.success) {
+        throw new Error(
+          `Judge returned invalid response. Expected {pass, score, reasoning} but got: ${cleaned.slice(0, 500)}\nValidation errors: ${JSON.stringify(validation.error.issues)}`
+        );
+      }
+      const { pass, score, reasoning } = validation.data;
 
       return {
         pass,

--- a/src/judge/judgeTypes.ts
+++ b/src/judge/judgeTypes.ts
@@ -1,3 +1,20 @@
+import { z } from 'zod';
+
+/**
+ * Zod schema for validating judge LLM responses.
+ * Ensures the response has the required structure before it is used.
+ */
+export const JudgeResponseSchema = z.object({
+  pass: z.boolean(),
+  score: z.number().min(0).max(1),
+  reasoning: z.string(),
+});
+
+/**
+ * The validated shape returned by a judge LLM.
+ */
+export type JudgeResponse = z.infer<typeof JudgeResponseSchema>;
+
 /**
  * Usage metrics from Claude Agent SDK response
  */

--- a/src/judge/openaiJudge.test.ts
+++ b/src/judge/openaiJudge.test.ts
@@ -123,8 +123,8 @@ describe('openaiJudge', () => {
       expect(result.reasoning).toBe('Insufficient');
     });
 
-    it('derives pass from score when pass field is missing', async () => {
-      // When pass field is missing in JSON, it defaults to false regardless of score
+    it('throws when response is missing required pass field', async () => {
+      // When pass field is missing in JSON, schema validation rejects it
       const mockCreate = await getMockCreate();
       mockCreate.mockResolvedValue(
         makeCompletionResponse(
@@ -136,28 +136,23 @@ describe('openaiJudge', () => {
       );
 
       const judge = createOpenAIJudge({});
-      const result = await judge.evaluate('candidate', null, 'rubric');
 
-      // openaiJudge uses: pass = typeof parsed.pass === 'boolean' ? parsed.pass : false
-      // So when pass is missing, it defaults to false, and score stays 0.8
-      expect(result.score).toBe(0.8);
-      // pass defaults to false when the field is absent
-      expect(result.pass).toBe(false);
+      await expect(judge.evaluate('candidate', null, 'rubric')).rejects.toThrow(
+        'Judge returned invalid response'
+      );
     });
 
-    it('handles invalid JSON response gracefully without throwing', async () => {
+    it('throws on invalid JSON response', async () => {
       const mockCreate = await getMockCreate();
       mockCreate.mockResolvedValue(
         makeCompletionResponse('This is not JSON at all')
       );
 
       const judge = createOpenAIJudge({});
-      // openaiJudge's parseJudgeResponse returns {pass:false, score:0} on parse error
-      const result = await judge.evaluate('candidate', null, 'rubric');
 
-      expect(result.pass).toBe(false);
-      expect(result.score).toBe(0);
-      expect(result.reasoning).toContain('Failed to parse judge response');
+      await expect(judge.evaluate('candidate', null, 'rubric')).rejects.toThrow(
+        'Failed to parse judge response as JSON'
+      );
     });
 
     it('propagates API errors (does not swallow them)', async () => {
@@ -236,7 +231,7 @@ describe('openaiJudge', () => {
       );
     });
 
-    it('handles null response content gracefully', async () => {
+    it('throws on null response content', async () => {
       const mockCreate = await getMockCreate();
       mockCreate.mockResolvedValue({
         choices: [{ message: { content: null } }],
@@ -244,10 +239,11 @@ describe('openaiJudge', () => {
       });
 
       const judge = createOpenAIJudge({});
-      const result = await judge.evaluate('candidate', null, 'rubric');
 
-      // Empty string is passed to parseJudgeResponse, which fails to parse -> returns defaults
-      expect(result.pass).toBe(false);
+      // Empty string is passed to parseJudgeResponse, which fails to parse JSON -> throws
+      await expect(judge.evaluate('candidate', null, 'rubric')).rejects.toThrow(
+        'Failed to parse judge response as JSON'
+      );
     });
   });
 });

--- a/src/judge/openaiJudge.ts
+++ b/src/judge/openaiJudge.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-explicit-any */
 import type { Judge, JudgeConfig, JudgeResult } from './judgeTypes.js';
+import { JudgeResponseSchema } from './judgeTypes.js';
 
 /**
  * Creates an OpenAI-backed LLM judge.
@@ -108,19 +109,19 @@ function parseJudgeResponse(text: string): {
     .replace(/```json\n?/g, '')
     .replace(/```\n?/g, '')
     .trim();
+
+  let parsed: unknown;
   try {
-    const parsed = JSON.parse(cleaned) as Record<string, unknown>;
-    const pass = typeof parsed.pass === 'boolean' ? parsed.pass : false;
-    const score =
-      typeof parsed.score === 'number' ? parsed.score : pass ? 1.0 : 0.0;
-    const reasoning =
-      typeof parsed.reasoning === 'string' ? parsed.reasoning : '';
-    return { pass, score, reasoning };
+    parsed = JSON.parse(cleaned);
   } catch {
-    return {
-      pass: false,
-      score: 0,
-      reasoning: `Failed to parse judge response: ${text}`,
-    };
+    throw new Error(`Failed to parse judge response as JSON: ${text}`);
   }
+
+  const result = JudgeResponseSchema.safeParse(parsed);
+  if (!result.success) {
+    throw new Error(
+      `Judge returned invalid response. Expected {pass, score, reasoning} but got: ${cleaned.slice(0, 500)}\nValidation errors: ${JSON.stringify(result.error.issues)}`
+    );
+  }
+  return result.data;
 }


### PR DESCRIPTION
## Summary

- Adds `JudgeResponseSchema` (Zod) to validate judge LLM responses
- Replaces silent fallback (`pass: false, score: 0`) with descriptive thrown errors on invalid responses
- Adds preflight debug warning when estimated LLM judge API calls exceed 50

## Why

**Schema validation:** Previously, malformed judge responses (wrong JSON structure, score out of [0,1] range, missing fields) silently became `{ pass: false, score: 0 }`. Users saw "Test failed" with no indication the judge itself had a problem. Now, invalid responses throw errors that include the raw LLM output for debugging.

**Cost warning:** A case with `iterations: 10` and `reps: 5` makes 50 LLM API calls. On a 100-case dataset, that's 5,000 calls with no warning. The preflight warning helps users understand costs before they start.

## Test Plan

- [x] `npm run typecheck` passes
- [x] `npm test` passes
- [x] `npm run lint` passes
- [x] `npm run format:check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)