### PR TITLE
feat: export SnapshotSanitizers constants for IDE discoverability

### DIFF
--- a/src/assertions/validators/types.ts
+++ b/src/assertions/validators/types.ts
@@ -62,14 +62,34 @@ export interface PatternValidatorOptions {
 }
 
 /**
+ * Built-in snapshot sanitizer names for use with toMatchToolSnapshot.
+ * Pass these values in the sanitizers array to replace non-deterministic
+ * values with stable placeholders before snapshot comparison.
+ *
+ * @example
+ * expect(result).toMatchToolSnapshot('my-snapshot', [
+ *   SnapshotSanitizers.UUID,
+ *   SnapshotSanitizers.ISO_DATE,
+ * ]);
+ */
+export const SnapshotSanitizers = {
+  /** Replaces Unix timestamps (seconds and milliseconds) with a stable placeholder */
+  TIMESTAMP: 'timestamp' as const,
+  /** Replaces UUID v1-v5 strings with a stable placeholder */
+  UUID: 'uuid' as const,
+  /** Replaces ISO 8601 date/datetime strings with a stable placeholder */
+  ISO_DATE: 'iso-date' as const,
+  /** Replaces MongoDB ObjectId strings with a stable placeholder */
+  OBJECT_ID: 'objectId' as const,
+  /** Replaces JWT tokens with a stable placeholder */
+  JWT: 'jwt' as const,
+} as const;
+
+/**
  * Built-in sanitizer names for common variable patterns
  */
 export type BuiltInSanitizer =
-  | 'timestamp' // Unix timestamps (milliseconds and seconds)
-  | 'uuid' // UUIDs v1-v5
-  | 'iso-date' // ISO 8601 date strings
-  | 'objectId' // MongoDB ObjectIds
-  | 'jwt'; // JWT tokens
+  (typeof SnapshotSanitizers)[keyof typeof SnapshotSanitizers];
 
 /**
  * Custom regex-based sanitizer

--- a/src/index.ts
+++ b/src/index.ts
@@ -107,6 +107,7 @@ export {
   normalizeWhitespace,
 } from './assertions/validators/index.js';
 
+export { SnapshotSanitizers } from './assertions/validators/types.js';
 export type {
   ValidationResult,
   TextValidatorOptions,


### PR DESCRIPTION
## Summary
- Exports `SnapshotSanitizers` typed constant object (`TIMESTAMP`, `UUID`, `ISO_DATE`, `OBJECT_ID`, `JWT`) from the main package entry point
- Exports `BuiltInSanitizer` type (now derived from the constant object to stay in sync automatically)
- Eliminates magic string usage for built-in snapshot sanitizers

## Usage
```typescript
import { expect, SnapshotSanitizers } from '@gleanwork/mcp-server-tester';

expect(result).toMatchToolSnapshot('my-snapshot', [
  SnapshotSanitizers.UUID,
  SnapshotSanitizers.ISO_DATE,
]);
```

## Why
Users had to read the README to discover sanitizer names. Now they're self-documenting and IDE-discoverable via autocomplete.

## Test Plan
- [x] `npm run typecheck` passes
- [x] `npm test` passes (704 tests)
- [x] `npm run lint` passes
- [x] `npm run format:check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)