### PR TITLE
fix: sync CLI and template version from package.json

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -7,13 +7,14 @@ import { init } from './commands/init/index.js';
 import { generate } from './commands/generate/index.js';
 import { login } from './commands/login/index.js';
 import { token } from './commands/token/index.js';
+import packageJson from '../../package.json' with { type: 'json' };
 
 const program = new Command();
 
 program
   .name('mcp-server-tester')
   .description('CLI tools for MCP server evaluation and testing')
-  .version('0.1.0');
+  .version(packageJson.version);
 
 // Init command
 program

--- a/src/cli/templates/index.ts
+++ b/src/cli/templates/index.ts
@@ -1,6 +1,7 @@
 /**
  * Template generators for project scaffolding
  */
+import packageJson from '../../../package.json' with { type: 'json' };
 
 interface ProjectAnswers {
   projectName: string;
@@ -197,7 +198,7 @@ export function getPackageJsonTemplate(projectName: string): string {
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.0.4",
     "@playwright/test": "^1.49.0",
-    "@gleanwork/mcp-server-tester": "^0.9.0",
+    "@gleanwork/mcp-server-tester": "^${packageJson.version}",
     "zod": "^3.24.1"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary

- `src/cli/index.ts`: replaced hardcoded `.version('0.1.0')` with `packageJson.version` imported from `package.json` — CLI was reporting `0.1.0` while the package is `0.12.0`
- `src/cli/templates/index.ts`: replaced stale `^0.9.0` in the `init` scaffold with `^${packageJson.version}` so users who run `mcp-server-tester init` get a correctly pinned dependency

Both files use the same `import packageJson from '../../package.json' with { type: 'json' }` pattern already established in `clientFactory.ts`.

## Test plan

- [x] `npm run typecheck` — passes
- [x] `npm test` — 704 tests pass
- [x] `npm run lint` — clean
- [x] `npm run build` — clean
- [x] `node dist/cli/index.js --version` outputs `0.12.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)