### PR TITLE
fix: remove unused proxy credentials and sanitize proxy debug log

### DIFF
--- a/src/config/mcpConfig.ts
+++ b/src/config/mcpConfig.ts
@@ -208,19 +208,10 @@ export interface HttpMCPConfig {
    */
   proxy?: {
     /**
-     * Proxy URL (e.g., http://proxy.example.com:8080)
+     * Proxy URL. Credentials can be embedded directly if required:
+     * `http://user:pass@proxy.example.com:8080`
      */
     url: string;
-
-    /**
-     * Proxy username for authentication
-     */
-    username?: string;
-
-    /**
-     * Proxy password for authentication
-     */
-    password?: string;
   };
 
   /**
@@ -372,8 +363,6 @@ const HttpConfigSchema = z.object({
   proxy: z
     .object({
       url: z.string().url('proxy.url must be a valid URL'),
-      username: z.string().optional(),
-      password: z.string().optional(),
     })
     .optional(),
   retryAttempts: z.number().int().min(0).optional(),

--- a/src/mcp/clientFactory.ts
+++ b/src/mcp/clientFactory.ts
@@ -265,7 +265,17 @@ export async function createMCPClientForConfig(
 
     if (proxyUrl) {
       const proxyAgent = new ProxyAgent(proxyUrl);
-      debugClient('Using proxy: %s', proxyUrl);
+      try {
+        const sanitized = new URL(proxyUrl);
+        debugClient(
+          'Using proxy: %s://%s:%s',
+          sanitized.protocol.slice(0, -1),
+          sanitized.hostname,
+          sanitized.port
+        );
+      } catch {
+        debugClient('Using proxy (unparseable URL)');
+      }
       requestInit = {
         ...requestInit,
         dispatcher: proxyAgent,


### PR DESCRIPTION
## Summary

- **`src/config/mcpConfig.ts`**: removed `username` and `password` from the `HttpMCPConfig.proxy` TypeScript interface and from the Zod validation schema. These fields were defined but never read — `clientFactory.ts` only ever passed `proxy.url` to `ProxyAgent`. Updated the JSDoc to note that credentials can be embedded directly in the URL (`http://user:pass@proxy:8080`).
- **`src/mcp/clientFactory.ts`**: replaced the raw `debugClient('Using proxy: %s', proxyUrl)` call with a sanitizing block that parses the URL and logs only `protocol://hostname:port`, preventing any embedded credentials from appearing in debug output.

## Test plan

- [x] `npm run typecheck` — passes
- [x] `npm test` — 704 tests pass (including `mcpConfig.test.ts`)
- [x] `npm run lint` — clean
- [x] Confirmed no source file references `proxy.username` or `proxy.password`

🤖 Generated with [Claude Code](https://claude.com/claude-code)