### PR TITLE
fix: replace duplicate UI types with re-exports from canonical source

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -176,10 +176,7 @@ authType?: 'oauth' | 'api-token' | 'none';  // Don't do this!
 
 ### UI Type Synchronization
 
-The UI types in `src/reporters/ui-src/types.ts` must manually stay in sync with backend types. When updating backend types, also update:
-
-1. `src/types/reporter.ts` (canonical backend)
-2. `src/reporters/ui-src/types.ts` (UI copy)
+`src/reporters/ui-src/types.ts` re-exports all types directly from the canonical backend sources (`src/types/index.ts` and `src/types/reporter.ts`). No manual sync is required — update `src/types/reporter.ts` and the UI automatically picks up the changes.
 
 ## Code Style
 

--- a/src/reporters/ui-src/types.ts
+++ b/src/reporters/ui-src/types.ts
@@ -1,194 +1,28 @@
 /**
  * Types for MCP Test Reporter UI
  *
- * These types align exactly with src/types/reporter.ts to ensure consistency
- * between the backend reporter and the React UI.
- *
- * @packageDocumentation
+ * All types are re-exported from the canonical backend sources.
+ * esbuild inlines type imports at bundle time (stripped at runtime — zero overhead).
  */
 
-/**
- * Authentication type for MCP connections
- */
-export type AuthType = 'oauth' | 'api-token' | 'none';
+export type {
+  AuthType,
+  ResultSource,
+  ExpectationType,
+  EvalExpectationResult,
+  ExpectationBreakdown,
+} from '../../types/index.js';
 
-/**
- * Source of test results
- */
-export type ResultSource = 'eval' | 'test';
+export type {
+  MCPConformanceCheck,
+  MCPConformanceResultData,
+  MCPServerCapabilitiesData,
+  EvalCaseResult,
+  MCPEvalRunData,
+  MCPEvalHistoricalSummary,
+  MCPEvalData,
+} from '../../types/reporter.js';
 
-/**
- * Known expectation types
- */
-export type ExpectationType =
-  | 'exact'
-  | 'schema'
-  | 'textContains'
-  | 'regex'
-  | 'snapshot'
-  | 'judge'
-  | 'error'
-  | 'size'
-  | 'toolsTriggered'
-  | 'toolCallCount';
-
-/**
- * Result of an expectation check
- */
-export interface EvalExpectationResult {
-  pass: boolean;
-  details?: string;
-}
-
-/**
- * Individual conformance check result
- */
-export interface MCPConformanceCheck {
-  name: string;
-  pass: boolean;
-  message: string;
-}
-
-/**
- * Conformance check result as stored in reporter data
- */
-export interface MCPConformanceResultData {
-  testTitle: string;
-  pass: boolean;
-  checks: MCPConformanceCheck[];
-  serverInfo?: {
-    name?: string;
-    version?: string;
-  };
-  toolCount: number;
-  authType?: AuthType;
-  project?: string;
-}
-
-/**
- * Server capabilities data from mcp-list-tools attachment
- */
-export interface MCPServerCapabilitiesData {
-  testTitle: string;
-  tools: Array<{
-    name: string;
-    description?: string;
-  }>;
-  toolCount: number;
-  authType?: AuthType;
-  project?: string;
-}
-
-/**
- * Result of a single eval case
- */
-export interface EvalCaseResult {
-  id: string;
-  datasetName: string;
-  toolName: string;
-  source: ResultSource;
-  pass: boolean;
-  response?: unknown;
-  error?: string;
-  expectations: Partial<Record<ExpectationType, EvalExpectationResult>>;
-  authType?: AuthType;
-  project?: string;
-  durationMs: number;
-  // Multi-iteration accuracy fields
-  /**
-   * Assertion pass rate (0–1): passes divided by non-infrastructure iterations.
-   * Infrastructure errors are excluded from the denominator.
-   */
-  assertionPassRate?: number;
-  /** Infrastructure error rate (0–1): infra errors divided by total iterations. */
-  infrastructureErrorRate?: number;
-  /** Alias for assertionPassRate. Kept for backward compatibility. */
-  accuracy?: number;
-  iterationResults?: Array<{
-    pass: boolean;
-    durationMs: number;
-    error?: string;
-    /** When true, this iteration failed due to network/infrastructure issues rather than an assertion failure */
-    isInfrastructureError?: boolean;
-  }>;
-  /** Number of iterations that failed due to infrastructure errors (network, rate limits, etc.) */
-  infrastructureErrorCount?: number;
-  /**
-   * Tags from the source eval case, for filtering and slicing reports.
-   */
-  tags?: string[];
-
-  /**
-   * Precision of tool calls made (0–1).
-   * 1.0 means every tool called was expected; <1.0 means unexpected tools were called.
-   * Only populated when exclusive: true in toolsTriggered and the expectation was evaluated.
-   */
-  toolPrecision?: number;
-
-  /**
-   * Recall of required tool calls (0–1).
-   * 1.0 means all required tools were called; <1.0 means some were missed.
-   * Only populated when toolsTriggered expectation was evaluated.
-   */
-  toolRecall?: number;
-
-  /**
-   * Pass/fail status of this case in the baseline run.
-   * Only present when a baseline was provided to runEvalDataset.
-   */
-  baselinePass?: boolean;
-}
-
-/**
- * Breakdown of expectation types used
- */
-export type ExpectationBreakdown = Record<ExpectationType, number>;
-
-/**
- * Aggregated MCP eval run data
- */
-export interface MCPEvalRunData {
-  timestamp: string;
-  durationMs: number;
-  environment: {
-    ci: boolean;
-    node: string;
-    platform: string;
-  };
-  metrics: {
-    total: number;
-    passed: number;
-    failed: number;
-    passRate: number;
-    datasetBreakdown: Record<string, number>;
-    expectationBreakdown: ExpectationBreakdown;
-  };
-  results: EvalCaseResult[];
-  conformanceChecks?: MCPConformanceResultData[];
-  serverCapabilities?: MCPServerCapabilitiesData[];
-}
-
-/**
- * Historical summary for trend charts
- */
-export interface MCPEvalHistoricalSummary {
-  timestamp: string;
-  total: number;
-  passed: number;
-  failed: number;
-  passRate: number;
-  durationMs: number;
-}
-
-/**
- * Complete data structure passed to UI
- */
-export interface MCPEvalData {
-  runData: MCPEvalRunData;
-  historical: MCPEvalHistoricalSummary[];
-}
-
-// Window interface for global data injection
 declare global {
   interface Window {
     MCP_EVAL_DATA: MCPEvalData;


### PR DESCRIPTION
## Summary

`src/reporters/ui-src/types.ts` contained ~190 lines of types that were copy-pasted duplicates of `src/types/index.ts` and `src/types/reporter.ts`. Any time a field was added to the backend types, this file had to be manually updated in sync — an error-prone process that had already drifted (e.g. `IterationResult` existed in `reporter.ts` but was inlined anonymously in the UI copy).

esbuild resolves imports recursively across any directory, so the duplication was never necessary.

**Changes:**
- Replace the entire content of `src/reporters/ui-src/types.ts` with `export type { ... }` re-exports from the canonical sources
- Preserve the `Window.MCP_EVAL_DATA` global declaration (used at runtime in `App.tsx:16`)
- Update `CLAUDE.md` to remove the now-incorrect manual sync instruction

## Test plan

- [x] `npm run build:ui` — esbuild bundles without errors
- [x] `npm run build` — full build passes
- [x] `npm run typecheck` — passes
- [x] `npm test` — 704 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)