### PR TITLE
docs: rewrite README for clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,18 +30,18 @@ Playwright tests are fast, deterministic, and designed for CI. Use them for regr
 
 Available matchers:
 
-| Matcher | Description |
-|---------|-------------|
-| `toContainToolText` | Response contains expected substrings |
-| `toMatchToolSchema` | Response validates against a Zod schema |
-| `toMatchToolPattern` | Response matches a regex pattern |
-| `toMatchToolSnapshot` | Response matches a saved baseline |
-| `toBeToolError` | Response is (or is not) an error |
-| `toHaveToolResponseSize` | Response size is within bounds |
-| `toSatisfyToolPredicate` | Response satisfies a custom function |
-| `toHaveToolCalls` | LLM called the expected tools |
-| `toHaveToolCallCount` | LLM made N tool calls |
-| `toPassToolJudge` | LLM evaluates response quality against a rubric |
+| Matcher                  | Description                                     |
+| ------------------------ | ----------------------------------------------- |
+| `toContainToolText`      | Response contains expected substrings           |
+| `toMatchToolSchema`      | Response validates against a Zod schema         |
+| `toMatchToolPattern`     | Response matches a regex pattern                |
+| `toMatchToolSnapshot`    | Response matches a saved baseline               |
+| `toBeToolError`          | Response is (or is not) an error                |
+| `toHaveToolResponseSize` | Response size is within bounds                  |
+| `toSatisfyToolPredicate` | Response satisfies a custom function            |
+| `toHaveToolCalls`        | LLM called the expected tools                   |
+| `toHaveToolCallCount`    | LLM made N tool calls                           |
+| `toPassToolJudge`        | LLM evaluates response quality against a rubric |
 
 ## Eval Datasets
 
@@ -88,14 +88,14 @@ test('file operations eval', async ({ mcp }, testInfo) => {
 
 Supported assertion types:
 
-| Type | Description |
-|------|-------------|
-| `containsText` | Response includes expected substrings |
-| `schema` | Response validates against a Zod schema |
-| `regex` | Response matches a pattern |
-| `snapshot` | Response matches a saved baseline |
-| `judge` | LLM evaluates response quality against a rubric |
-| `toolsTriggered` | LLM called the expected tools (LLM host mode) |
+| Type             | Description                                     |
+| ---------------- | ----------------------------------------------- |
+| `containsText`   | Response includes expected substrings           |
+| `schema`         | Response validates against a Zod schema         |
+| `regex`          | Response matches a pattern                      |
+| `snapshot`       | Response matches a saved baseline               |
+| `judge`          | LLM evaluates response quality against a rubric |
+| `toolsTriggered` | LLM called the expected tools (LLM host mode)   |
 
 ### LLM host mode
 
@@ -106,7 +106,10 @@ In LLM host mode, a real LLM receives your server's tool list and a natural lang
   "id": "find-config",
   "mode": "llm_host",
   "scenario": "Find the application config file and return its contents",
-  "llmHostConfig": { "provider": "anthropic", "model": "claude-opus-4-20250514" },
+  "llmHostConfig": {
+    "provider": "anthropic",
+    "model": "claude-opus-4-20250514"
+  },
   "expect": {
     "toolsTriggered": {
       "calls": [{ "name": "read_file", "required": true }]


### PR DESCRIPTION
## Summary

- Remove all emojis from feature lists
- Give Playwright tests and eval datasets equal top-level billing as parallel sections
- Add LLM host simulation as a named subsection under eval datasets rather than a buried bullet
- Convert comma-separated matcher list to a formatted table with descriptions, consistent with the eval assertions table
- Consolidate redundant sections (What's Included, Features, Two Ways to Test) into two primary capability sections
- Move CLI OAuth detail out of README body into a single sentence with a doc link
- Drop Upgrading and Credits sections
- Tagline now mentions both testing and evaluation
- Node 22 requirement called out explicitly at installation