### PR TITLE
fix: compute tool call precision accurately in non-exclusive mode

### DIFF
--- a/src/assertions/validators/toolCalls.test.ts
+++ b/src/assertions/validators/toolCalls.test.ts
@@ -130,12 +130,15 @@ describe('validateToolCalls precision and recall metrics', () => {
     expect(result.metrics?.recall).toBe(1.0);
   });
 
-  it('precision is 1.0 when exclusive is false (default)', () => {
+  it('precision reflects actual tool call efficiency even when exclusive is false (default)', () => {
     const result = validateToolCalls(makeResult(['search', 'unexpected']), {
       calls: [{ name: 'search', required: true }],
       exclusive: false,
     });
-    expect(result.metrics?.precision).toBe(1.0);
+    // 1 of 2 actual calls matched an expected call → precision = 0.5
+    // The case still passes (exclusive=false means no failure on unexpected calls)
+    expect(result.pass).toBe(true);
+    expect(result.metrics?.precision).toBe(0.5);
   });
 
   it('precision is 0.5 when exclusive is true and half of calls were unexpected', () => {

--- a/src/assertions/validators/toolCalls.ts
+++ b/src/assertions/validators/toolCalls.ts
@@ -104,11 +104,12 @@ export function validateToolCalls(
   const recall =
     requiredCalls.length > 0 ? calledRequiredCount / requiredCalls.length : 1.0;
 
-  // Compute precision: fraction of actual calls that were expected
-  // Only applies when exclusive=true; otherwise precision is 1.0
+  // Compute precision: fraction of actual calls that were expected.
+  // Always computed so the metric reflects actual tool call efficiency.
+  // Whether unexpected calls cause a FAILURE is controlled separately by exclusive=true (lines below).
   const allowedNames = new Set(expectation.calls.map((c) => c.name));
   const precision =
-    actual.length > 0 && expectation.exclusive === true
+    actual.length > 0
       ? actual.filter((c) => allowedNames.has(c.name)).length / actual.length
       : 1.0;
 


### PR DESCRIPTION
## Summary

`validateToolCalls` previously hardcoded `precision = 1.0` whenever `exclusive !== true` (the default). This meant the precision metric was meaningless — an LLM calling 5 tools when only 1 was expected still showed precision=1.0.

**Fix:** Always compute actual precision as `(calls matching expected) / (total calls made)`. The pass/fail enforcement via `exclusive: true` is already handled separately (lines 155–165) and is unchanged.

**Before:** `exclusive: false`, LLM calls `[search, browse, fetch]` expecting `[search]` → precision reported as 1.0  
**After:** Same scenario → precision correctly reported as 0.33

## Test plan
- [x] Updated test: `"precision is 1.0 when exclusive is false (default)"` → now asserts correct 0.5 precision when 1 of 2 calls matches
- [x] `npm run typecheck` — clean
- [x] `npm test` — all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)