### PR TITLE
fix: classify infrastructure errors by err.code and document concurrency safety

### DIFF
--- a/src/evals/evalRunner.test.ts
+++ b/src/evals/evalRunner.test.ts
@@ -706,6 +706,24 @@ describe('runEvalDataset concurrency', () => {
     const result = await runEvalDataset({ dataset }, createContext());
     expect(result.total).toBe(2);
   });
+
+  it('runs all cases without skipping indices when concurrency > 1', async () => {
+    // Regression test for runWithConcurrency: verifies that the `index++`
+    // read-modify-write assigns a unique slot to every task and no results are
+    // dropped or overwritten when multiple workers interleave at await points.
+    const dataset = createDataset(
+      Array.from({ length: 20 }, (_, i) => createEvalCase({ id: `case-${i}` }))
+    );
+
+    const result = await runEvalDataset(
+      { dataset, concurrency: 8 },
+      createContext()
+    );
+
+    // All 20 cases must be present — none skipped or overwritten
+    expect(result.caseResults).toHaveLength(20);
+    expect(result.total).toBe(20);
+  });
 });
 
 describe('runEvalDataset', () => {

--- a/src/evals/evalRunner.ts
+++ b/src/evals/evalRunner.ts
@@ -568,10 +568,12 @@ async function runSingleIteration(
 function isInfrastructureError(err: unknown): boolean {
   let name: string | undefined;
   let msg: string;
+  let code: string = '';
 
   if (err instanceof Error) {
     name = err.name;
     msg = err.message.toLowerCase();
+    code = ((err as NodeJS.ErrnoException).code ?? '').toLowerCase();
   } else if (typeof err === 'string') {
     msg = err.toLowerCase();
   } else {
@@ -586,7 +588,10 @@ function isInfrastructureError(err: unknown): boolean {
     msg.includes('rate limit') ||
     msg.includes('429') ||
     msg.includes('503') ||
-    msg.includes('network')
+    msg.includes('network') ||
+    code.includes('econnreset') ||
+    code.includes('etimedout') ||
+    code.includes('econnrefused')
   );
 }
 
@@ -702,6 +707,9 @@ async function runWithConcurrency<T>(
   let index = 0;
 
   async function worker() {
+    // `index++` is safe here: JavaScript's event loop is single-threaded, so the
+    // read-modify-write of `index` completes atomically before any `await` yields
+    // to another worker. Each worker captures a unique `i` before awaiting the task.
     while (index < tasks.length) {
       const i = index++;
       results[i] = await tasks[i]!();


### PR DESCRIPTION
## Summary

Two fixes in `src/evals/evalRunner.ts`:

### 1. `isInfrastructureError()` — check `err.code` in addition to `err.message`

On Windows and some Node.js versions, network errors surface with a generic message (e.g. "connection reset by peer") but a typed `.code` property (`ECONNRESET`). The existing check only lowercased `err.message`, so errors like these were misclassified as assertion failures — corrupting multi-iteration accuracy numbers on Windows.

Now also checks `(err as NodeJS.ErrnoException).code` lowercased for `econnreset`, `etimedout`, `econnrefused`.

### 2. `runWithConcurrency()` — document the single-threaded safety guarantee

The shared `index++` pattern is safe in JavaScript's event loop (the read-modify-write completes before any `await` yields), but this wasn't obvious. Added a clarifying comment and a regression test: 20 cases at `concurrency=8` — all 20 must be present in results.

## Test plan
- [x] New regression test: `'runs all cases without skipping indices when concurrency > 1'`
- [x] `npm run typecheck` — clean
- [x] `npm test` — all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)