### PR TITLE
test: add unit tests for toMatchToolSnapshot sanitizer logic

### DIFF
--- a/src/assertions/matchers/toMatchToolSnapshot.test.ts
+++ b/src/assertions/matchers/toMatchToolSnapshot.test.ts
@@ -174,7 +174,7 @@ describe('applySanitizers', () => {
       name: 'Carol',
     };
     // Start with a JSON string containing a JWT, then strip the token field
-    let input = JSON.stringify(obj, null, 2);
+    const input = JSON.stringify(obj, null, 2);
 
     // First sanitizer: replace JWTs in the raw text
     // Second sanitizer: remove the token field entirely


### PR DESCRIPTION
## Summary

`src/assertions/matchers/toMatchToolSnapshot.ts` had zero dedicated tests. Its 214 lines include all 5 built-in sanitizer patterns (timestamp, UUID, ISO date, objectId, JWT) and the `applySanitizers` function handling string/RegExp/field-removal sanitizers — all untested.

Adds 22 unit tests for the exported pure functions `BUILT_IN_PATTERNS` and `applySanitizers`:

- Each built-in sanitizer pattern (single and multiple matches)
- Custom regex sanitizer (string pattern, RegExp object)
- Custom replacement string / default `[SANITIZED]`
- Field removal on valid JSON (top-level and dot-notation nested path)
- Field removal on invalid JSON (silently skipped)
- Multiple sanitizers applied in order
- Invalid regex string — documents the existing uncaught `SyntaxError` gap
- Empty sanitizers array — string returned unchanged

`toMatchToolSnapshot` itself requires Playwright test context and is not tested here.

## Test plan
- [x] 22 new tests, all passing
- [x] `npm run typecheck` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)