### PR TITLE
fix: remove 'claude' judge provider alias, canonicalize on 'anthropic'

### DIFF
--- a/src/judge/judgeClient.test.ts
+++ b/src/judge/judgeClient.test.ts
@@ -3,10 +3,6 @@ import { createJudge } from './judgeClient.js';
 import type { ProviderKind } from './judgeTypes.js';
 
 describe('createJudge provider routing', () => {
-  it('creates a judge without error for provider "claude"', () => {
-    expect(() => createJudge({ provider: 'claude' })).not.toThrow();
-  });
-
   it('creates a judge without error for provider "anthropic"', () => {
     expect(() => createJudge({ provider: 'anthropic' })).not.toThrow();
   });

--- a/src/judge/judgeClient.ts
+++ b/src/judge/judgeClient.ts
@@ -36,12 +36,10 @@ import { createGoogleJudge } from './googleJudge.js';
  * console.log('Tokens:', result.usage?.inputTokens, result.usage?.outputTokens);
  */
 export function createJudge(config: JudgeConfig = {}): Judge {
-  const provider: ProviderKind = config.provider ?? 'claude';
+  const provider: ProviderKind = config.provider ?? 'anthropic';
 
   switch (provider) {
-    case 'claude':
     case 'anthropic':
-      // Both 'claude' and 'anthropic' use Claude Agent SDK
       return createClaudeAgentJudge(config);
 
     case 'openai':

--- a/src/judge/judgeTypes.ts
+++ b/src/judge/judgeTypes.ts
@@ -56,7 +56,7 @@ export interface UsageMetrics {
 }
 
 /** Valid LLM judge provider kinds. */
-export type ProviderKind = 'claude' | 'anthropic' | 'openai' | 'google';
+export type ProviderKind = 'anthropic' | 'openai' | 'google';
 
 /**
  * Configuration for an LLM judge
@@ -64,7 +64,7 @@ export type ProviderKind = 'claude' | 'anthropic' | 'openai' | 'google';
 export interface JudgeConfig {
   /**
    * LLM provider to use
-   * @default 'claude'
+   * @default 'anthropic'
    */
   provider?: ProviderKind;
 


### PR DESCRIPTION
## Summary

Both `'claude'` and `'anthropic'` were accepted as valid `provider` values in `JudgeConfig` and `EvalExpectBlock.passesJudge`, mapping to the same Claude implementation. The alias adds confusion without value.

- Remove `'claude'` from `ProviderKind` in `src/judge/judgeTypes.ts`
- Collapse `case 'claude': case 'anthropic':` fallthrough to a single `case 'anthropic':` branch in `judgeClient.ts`
- Remove `'claude'` from `passesJudge.provider` Zod enum in `datasetTypes.ts`
- Update `@default` JSDoc from `'claude'` to `'anthropic'` throughout

**Breaking change:** Any dataset JSON using `"provider": "claude"` must be updated to `"provider": "anthropic"`. Pre-1.0 so no semver concern.

## Test plan
- [x] `npm run typecheck` — clean
- [x] `npm test` — all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)