### PR TITLE
feat: re-export test fixtures from top-level package path

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -143,6 +143,12 @@ export type {
 export { createMCPFixture } from './mcp/fixtures/mcpFixture.js';
 export { test, expect } from './fixtures/mcp.js';
 
+// Auth fixtures — re-exported from main path for convenience.
+// The auth `test` is aliased to avoid a name collision with the MCP `test` above.
+// Use `mcpAuthTest` when you need to extend auth fixtures (e.g., base.extend<MCPAuthFixtures>).
+export type { MCPAuthFixtures } from './fixtures/mcpAuth.js';
+export { test as mcpAuthTest } from './fixtures/mcpAuth.js';
+
 // Canonical Types (single source of truth)
 export type {
   ResultSource,


### PR DESCRIPTION
## Summary

Previously users had to know which subpath to import from:
```ts
// Before
import { test, expect } from '@gleanwork/mcp-server-tester/fixtures/mcp';
import { test as authTest } from '@gleanwork/mcp-server-tester/fixtures/mcpAuth';
```

Everything is now importable from the top-level path:
```ts
// After
import { test, expect, mcpAuthTest, MCPAuthFixtures } from '@gleanwork/mcp-server-tester';
```

**Notes:**
- `mcpAuthTest` is the alias for the auth fixture `test` — both fixture files export `test`, so the auth one is renamed to avoid a collision
- Existing subpath imports (`/fixtures/mcp`, `/fixtures/mcpAuth`) are kept — no breaking change
- `./reporters/mcpReporter` stays as a subpath — Playwright reporters are referenced as string module paths in config files, not JS imports; this is a framework constraint not a user-facing import

## Test plan
- [x] `npm run typecheck` — clean
- [x] `npm test` — all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)