### PR TITLE
fix: guard toMatchToolSnapshot against invalid regex + confirm partialMatch key-order safety

### DIFF
--- a/src/assertions/matchers/toMatchToolSnapshot.test.ts
+++ b/src/assertions/matchers/toMatchToolSnapshot.test.ts
@@ -185,14 +185,12 @@ describe('applySanitizers', () => {
     expect(parsed.name).toBe('Carol');
   });
 
-  it('does not crash on an invalid regex string (documents current behavior)', () => {
-    // The implementation wraps the string pattern with `new RegExp(pattern, 'g')`.
-    // An invalid regex string will throw a SyntaxError at construction time,
-    // which is NOT currently caught by applySanitizers.
-    // This test documents the existing gap: callers must supply valid patterns.
+  it('throws a descriptive error for an invalid regex string', () => {
+    // The implementation wraps new RegExp() in a try/catch and re-throws
+    // with a clear message so callers know which pattern caused the problem.
     expect(() =>
       applySanitizers('some input', [{ pattern: '[invalid regex' }])
-    ).toThrow(SyntaxError);
+    ).toThrow(/invalid regex pattern/);
   });
 
   it('returns the string unchanged when the sanitizers array is empty', () => {

--- a/src/assertions/matchers/toMatchToolSnapshot.ts
+++ b/src/assertions/matchers/toMatchToolSnapshot.ts
@@ -90,10 +90,18 @@ function applySanitizers(
 
     // Handle regex sanitizers
     if (isRegexSanitizer(sanitizer)) {
-      const pattern =
-        sanitizer.pattern instanceof RegExp
-          ? sanitizer.pattern
-          : new RegExp(sanitizer.pattern, 'g');
+      let pattern: RegExp;
+      if (sanitizer.pattern instanceof RegExp) {
+        pattern = sanitizer.pattern;
+      } else {
+        try {
+          pattern = new RegExp(sanitizer.pattern, 'g');
+        } catch {
+          throw new Error(
+            `toMatchToolSnapshot: invalid regex pattern "${sanitizer.pattern}" in sanitizer`
+          );
+        }
+      }
       const replacement = sanitizer.replacement ?? '[SANITIZED]';
       result = result.replace(pattern, replacement);
       continue;

--- a/src/assertions/validators/toolCalls.test.ts
+++ b/src/assertions/validators/toolCalls.test.ts
@@ -59,6 +59,16 @@ describe('validateToolCalls', () => {
     expect(v.pass).toBe(false);
   });
 
+  it('argument matching is not sensitive to key declaration order', () => {
+    // actual call has keys in { a, b } order; expected spec declares them as { b, a }
+    // partialMatch recurses into nested objects so key order never reaches JSON.stringify
+    const result = makeResult([{ name: 'search', arguments: { a: 1, b: 2 } }]);
+    const v = validateToolCalls(result, {
+      calls: [{ name: 'search', arguments: { b: 2, a: 1 } }],
+    });
+    expect(v.pass).toBe(true);
+  });
+
   it('enforces strict order when order is strict', () => {
     const result = makeResult([{ name: 'search' }, { name: 'fetch' }]);
     const v = validateToolCalls(result, {

--- a/src/assertions/validators/toolCalls.ts
+++ b/src/assertions/validators/toolCalls.ts
@@ -53,6 +53,9 @@ function partialMatch(
         v as Record<string, unknown>
       );
     }
+    // Key order in nested objects is handled by recursion — this branch only
+    // reaches leaf primitives (strings, numbers, booleans, null) and arrays,
+    // where JSON.stringify comparison is correct.
     return JSON.stringify(actualVal) === JSON.stringify(v);
   });
 }


### PR DESCRIPTION
## Summary

Two correctness improvements to the assertion layer:

### 1. `toMatchToolSnapshot` — invalid regex now throws descriptively

`new RegExp(sanitizer.pattern, 'g')` was bare — an invalid pattern string silently propagated a raw `SyntaxError` with no context. Now wrapped in try/catch that re-throws with a clear message:

```
toMatchToolSnapshot: invalid regex pattern "[invalid regex" in sanitizer
```

Test updated: the documented-gap test (`toThrow(SyntaxError)`) is now a proper assertion (`toThrow(/invalid regex pattern/)`).

### 2. `partialMatch` key-order safety confirmed + documented

The eval-methodology panel flagged potential key-order sensitivity in `partialMatch`. On review: nested object key order is handled by recursion — the `JSON.stringify` comparison only reaches leaf primitives and arrays where order is semantically correct. Added an explanatory comment and a new test:

```ts
// Argument matching: {b:2, a:1} must match expected {a:1, b:2}
expect(validateToolCalls(result, { calls: [{ name: 'search', arguments: { b: 2, a: 1 } }] }).pass).toBe(true);
```

## Test plan
- [x] `npm run typecheck` — clean
- [x] `npm test` — all tests pass
- [x] `npm run lint` — clean
- [x] `npm run format:check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)