### PR TITLE
fix: warn on low iterations in llm_host mode and poor baseline coverage

### DIFF
--- a/src/evals/evalRunner.test.ts
+++ b/src/evals/evalRunner.test.ts
@@ -1113,6 +1113,78 @@ describe('saveResultsTo and baselineResultsFrom', () => {
 
     consoleSpy.mockRestore();
   });
+
+  it('warns when more than 20% of current cases have no baseline entry', async () => {
+    const consoleSpy = vi
+      .spyOn(console, 'warn')
+      .mockImplementation(() => undefined);
+    const mcp = createMockMCP({ content: [{ type: 'text', text: 'hello' }] });
+
+    // Save a baseline with only one case
+    const baselinePath = join(tmpDir, 'sparse-baseline.json');
+    const baselineDataset = createDataset([
+      createEvalCase({ id: 'case-1', expect: { containsText: 'hello' } }),
+    ]);
+    await runEvalDataset(
+      { dataset: baselineDataset, saveResultsTo: baselinePath },
+      createContext(mcp)
+    );
+
+    // Run with a dataset that has 5 cases, only 1 of which matches the baseline
+    const currentDataset = createDataset([
+      createEvalCase({ id: 'case-1', expect: { containsText: 'hello' } }),
+      createEvalCase({ id: 'case-2', expect: { containsText: 'hello' } }),
+      createEvalCase({ id: 'case-3', expect: { containsText: 'hello' } }),
+      createEvalCase({ id: 'case-4', expect: { containsText: 'hello' } }),
+      createEvalCase({ id: 'case-5', expect: { containsText: 'hello' } }),
+    ]);
+    await runEvalDataset(
+      { dataset: currentDataset, baselineResultsFrom: baselinePath },
+      createContext(mcp)
+    );
+
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining('have no baseline entry')
+    );
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining('4 of 5 cases')
+    );
+
+    consoleSpy.mockRestore();
+  });
+
+  it('does not warn when 20% or fewer current cases have no baseline entry', async () => {
+    const consoleSpy = vi
+      .spyOn(console, 'warn')
+      .mockImplementation(() => undefined);
+    const mcp = createMockMCP({ content: [{ type: 'text', text: 'hello' }] });
+
+    // Save a baseline with 5 cases
+    const baselinePath = join(tmpDir, 'full-baseline.json');
+    const baselineDataset = createDataset([
+      createEvalCase({ id: 'case-1', expect: { containsText: 'hello' } }),
+      createEvalCase({ id: 'case-2', expect: { containsText: 'hello' } }),
+      createEvalCase({ id: 'case-3', expect: { containsText: 'hello' } }),
+      createEvalCase({ id: 'case-4', expect: { containsText: 'hello' } }),
+      createEvalCase({ id: 'case-5', expect: { containsText: 'hello' } }),
+    ]);
+    await runEvalDataset(
+      { dataset: baselineDataset, saveResultsTo: baselinePath },
+      createContext(mcp)
+    );
+
+    // Run with the same 5 cases — 0% unmatched, no warning
+    await runEvalDataset(
+      { dataset: baselineDataset, baselineResultsFrom: baselinePath },
+      createContext(mcp)
+    );
+
+    expect(consoleSpy).not.toHaveBeenCalledWith(
+      expect.stringContaining('have no baseline entry')
+    );
+
+    consoleSpy.mockRestore();
+  });
 });
 
 describe('evals guide iteration count guardrail warnings', () => {
@@ -1138,10 +1210,10 @@ describe('evals guide iteration count guardrail warnings', () => {
     await runEvalDataset({ dataset }, createContext());
 
     expect(consoleSpy).toHaveBeenCalledWith(
-      expect.stringContaining('3 iteration(s)')
+      expect.stringContaining('running 3 iterations in llm_host mode')
     );
     expect(consoleSpy).toHaveBeenCalledWith(
-      expect.stringContaining('evals guide recommends >= 10')
+      expect.stringContaining('Consider using 10+ iterations')
     );
     expect(consoleSpy).toHaveBeenCalledWith(
       expect.stringContaining('low-iter-case')
@@ -1150,7 +1222,7 @@ describe('evals guide iteration count guardrail warnings', () => {
     consoleSpy.mockRestore();
   });
 
-  it('warns when an llm_host case defaults to 1 iteration (no explicit iterations)', async () => {
+  it('does not warn when an llm_host case uses a single iteration (default smoke-test pattern)', async () => {
     const consoleSpy = vi
       .spyOn(console, 'warn')
       .mockImplementation(() => undefined);
@@ -1166,8 +1238,8 @@ describe('evals guide iteration count guardrail warnings', () => {
 
     await runEvalDataset({ dataset }, createContext());
 
-    expect(consoleSpy).toHaveBeenCalledWith(
-      expect.stringContaining('1 iteration(s)')
+    expect(consoleSpy).not.toHaveBeenCalledWith(
+      expect.stringContaining('may not be statistically reliable')
     );
 
     consoleSpy.mockRestore();
@@ -1191,7 +1263,7 @@ describe('evals guide iteration count guardrail warnings', () => {
     await runEvalDataset({ dataset }, createContext());
 
     expect(consoleSpy).not.toHaveBeenCalledWith(
-      expect.stringContaining('evals guide recommends')
+      expect.stringContaining('may not be statistically reliable')
     );
 
     consoleSpy.mockRestore();
@@ -1215,7 +1287,7 @@ describe('evals guide iteration count guardrail warnings', () => {
     await runEvalDataset({ dataset }, createContext(mcp));
 
     expect(consoleSpy).not.toHaveBeenCalledWith(
-      expect.stringContaining('evals guide recommends')
+      expect.stringContaining('may not be statistically reliable')
     );
 
     consoleSpy.mockRestore();
@@ -1242,7 +1314,7 @@ describe('evals guide iteration count guardrail warnings', () => {
     );
 
     expect(consoleSpy).not.toHaveBeenCalledWith(
-      expect.stringContaining('evals guide recommends')
+      expect.stringContaining('may not be statistically reliable')
     );
 
     consoleSpy.mockRestore();

--- a/src/evals/evalRunner.ts
+++ b/src/evals/evalRunner.ts
@@ -822,15 +822,17 @@ export async function runEvalDataset(
         ? { ...evalCase, iterations: defaultLlmIterations }
         : evalCase;
 
-    // Warn when an llm_host case runs fewer than the guide-recommended iterations.
-    // The evals guide recommends >= 10 iterations for statistical reliability.
+    // Warn when an llm_host case opts into multi-iteration accuracy measurement
+    // but uses fewer iterations than the guide-recommended minimum.
+    // Single-iteration llm_host runs (the default) are a valid smoke-test pattern
+    // and are not warned about — the warning is scoped to cases that have
+    // explicitly chosen a multi-iteration count that is too small to be reliable.
     if (evalCase.mode === 'llm_host') {
       const effectiveIterations = withIterations.iterations ?? 1;
-      if (effectiveIterations < 10) {
+      if (effectiveIterations > 1 && effectiveIterations < 10) {
         console.warn(
-          `[mcp-server-tester] Eval case "${evalCase.id}" uses llm_host mode with only ` +
-            `${effectiveIterations} iteration(s). The evals guide recommends >= 10 iterations. ` +
-            `See docs/evals-guide.md for guidance on statistical reliability.`
+          `[mcp-server-tester] Eval case "${evalCase.id}": running ${effectiveIterations} iterations in llm_host mode ` +
+            `may not be statistically reliable. Consider using 10+ iterations for accuracy measurements you can trust.`
         );
       }
     }
@@ -896,6 +898,20 @@ export async function runEvalDataset(
       const baselinePassRate =
         baseline.total > 0 ? baseline.passed / baseline.total : 0;
       const baselineMap = buildBaselinePassMap(baseline);
+
+      const currentCaseIds = result.caseResults.map((cr) => cr.id);
+      const unmatchedCount = currentCaseIds.filter(
+        (id) => !baselineMap.has(id)
+      ).length;
+      const unmatchedRatio =
+        currentCaseIds.length > 0 ? unmatchedCount / currentCaseIds.length : 0;
+      if (unmatchedRatio > 0.2) {
+        console.warn(
+          `[mcp-server-tester] Baseline comparison: ${unmatchedCount} of ${currentCaseIds.length} cases ` +
+            `(${Math.round(unmatchedRatio * 100)}%) have no baseline entry. ` +
+            `This may indicate the dataset structure has changed. Results for unmatched cases cannot be compared.`
+        );
+      }
 
       for (const cr of result.caseResults) {
         const baselinePass = baselineMap.get(cr.id);


### PR DESCRIPTION
## Summary

Two eval framework guardrails that surface common misuse patterns before they produce misleading results:

### 1. Low-iteration warning for `llm_host` mode

Multi-iteration accuracy is only meaningful in `llm_host` mode (where LLM tool selection is non-deterministic). Running 3-5 iterations gives a very wide confidence interval. A warning now fires when:
- `mode === 'llm_host'` AND
- `iterations > 1` AND `iterations < 10`

Single-iteration runs (`iterations === 1`, the default) are a valid smoke-test pattern and are intentionally excluded.

```
[mcp-server-tester] Eval case "search-test": running 3 iterations in llm_host mode
may not be statistically reliable. Consider using 10+ iterations for accuracy
measurements you can trust.
```

### 2. Baseline coverage warning

When a baseline is provided for A/B comparison, if >20% of current case IDs have no entry in the baseline map, it likely means the dataset changed and the comparison will silently skip those cases:

```
[mcp-server-tester] Baseline comparison: 4 of 5 cases (80%) have no baseline entry.
This may indicate the dataset structure has changed. Results for unmatched cases
cannot be compared.
```

## Test plan
- [x] Updated existing tests to match new message strings
- [x] New test: single-iteration run does NOT trigger the warning
- [x] New tests: baseline coverage warning fires at >20%, silent at 0%
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean
- [x] `npm run format:check` — clean
- [x] All 72 `evalRunner.test.ts` tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)