### PR TITLE
chore: update CLAUDE.md LLMProvider list (remove ollama, add vertex-anthropic)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -215,7 +215,7 @@ Use conventional commits: `feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore
 
 Supported `LLMProvider` values for `llmHostConfig.provider` (defined in `src/evals/llmHost/llmHostTypes.ts`):
 
-`'openai' | 'anthropic' | 'azure' | 'google' | 'mistral' | 'ollama' | 'deepseek' | 'openrouter' | 'xai'`
+`'openai' | 'anthropic' | 'azure' | 'google' | 'mistral' | 'deepseek' | 'openrouter' | 'xai' | 'vertex-anthropic'`
 
 To add a new provider:
 


### PR DESCRIPTION
Single-line fix: CLAUDE.md line 218 still listed 'ollama' (removed in #85) and was missing 'vertex-anthropic'. Updated to match actual codebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)