### PR TITLE
fix: remove accuracy alias, document snapshot context, complete README matcher table

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,18 +30,19 @@ Playwright tests are fast, deterministic, and designed for CI. Use them for regr
 
 Available matchers:
 
-| Matcher                  | Description                                     |
-| ------------------------ | ----------------------------------------------- |
-| `toContainToolText`      | Response contains expected substrings           |
-| `toMatchToolSchema`      | Response validates against a Zod schema         |
-| `toMatchToolPattern`     | Response matches a regex pattern                |
-| `toMatchToolSnapshot`    | Response matches a saved baseline               |
-| `toBeToolError`          | Response is (or is not) an error                |
-| `toHaveToolResponseSize` | Response size is within bounds                  |
-| `toSatisfyToolPredicate` | Response satisfies a custom function            |
-| `toHaveToolCalls`        | LLM called the expected tools                   |
-| `toHaveToolCallCount`    | LLM made N tool calls                           |
-| `toPassToolJudge`        | LLM evaluates response quality against a rubric |
+| Matcher                  | Description                                          |
+| ------------------------ | ---------------------------------------------------- |
+| `toMatchToolResponse`    | Response exactly matches expected value (deep equal) |
+| `toContainToolText`      | Response contains expected substrings                |
+| `toMatchToolSchema`      | Response validates against a Zod schema              |
+| `toMatchToolPattern`     | Response matches a regex pattern                     |
+| `toMatchToolSnapshot`    | Response matches a saved baseline                    |
+| `toBeToolError`          | Response is (or is not) an error                     |
+| `toHaveToolResponseSize` | Response size is within bounds                       |
+| `toSatisfyToolPredicate` | Response satisfies a custom function                 |
+| `toHaveToolCalls`        | LLM called the expected tools                        |
+| `toHaveToolCallCount`    | LLM made N tool calls                                |
+| `toPassToolJudge`        | LLM evaluates response quality against a rubric      |
 
 ## Eval Datasets
 

--- a/docs/expectations.md
+++ b/docs/expectations.md
@@ -233,6 +233,12 @@ const UserSchema = z.object({
 
 Captures and compares tool responses against stored snapshots using Playwright's built-in snapshot functionality. Best for deterministic responses where you want to detect any changes.
 
+> **Requires Playwright test context.** `toMatchToolSnapshot()` calls Playwright's native
+> snapshot infrastructure internally and only works inside a Playwright test function.
+> If you call it outside a test or in a programmatic validator, you will get a cryptic
+> context error. To use sanitizer logic outside tests, import `applySanitizers` directly
+> from the matchers module.
+
 > **Important:** Snapshot testing works best with deterministic, stable responses. For responses containing timestamps, IDs, or live data, use [sanitizers](#snapshot-sanitizers) or consider [Schema Validation](#schema-validation) instead.
 
 ### When to Use Snapshots

--- a/src/assertions/matchers/toMatchToolSnapshot.ts
+++ b/src/assertions/matchers/toMatchToolSnapshot.ts
@@ -162,6 +162,14 @@ function removeFields(obj: unknown, paths: string[]): void {
 /**
  * Creates the toMatchToolSnapshot matcher function
  *
+ * @remarks
+ * **Requires Playwright test context.** This matcher calls `expect(content).toMatchSnapshot()`
+ * internally, which only works inside a Playwright test (i.e., when `testInfo` is available).
+ * Calling it outside a Playwright test will throw a cryptic context error.
+ *
+ * To test sanitizer logic without a Playwright context, use the exported `applySanitizers`
+ * function directly.
+ *
  * Note: This is an async matcher that uses Playwright's snapshot testing.
  */
 export async function toMatchToolSnapshot(

--- a/src/evals/datasetTypes.ts
+++ b/src/evals/datasetTypes.ts
@@ -77,7 +77,7 @@ export interface EvalCase {
 
   /**
    * Number of times to run this case and compute an accuracy score.
-   * When > 1, `EvalCaseResult.accuracy` is populated and `pass` is determined
+   * When > 1, `EvalCaseResult.assertionPassRate` is populated and `pass` is determined
    * by `accuracyThreshold` rather than a single run.
    * @default 1
    */

--- a/src/evals/evalRunner.test.ts
+++ b/src/evals/evalRunner.test.ts
@@ -395,8 +395,8 @@ describe('multi-iteration cases', () => {
 
     const result = await runEvalCase(evalCase, createContext(mcp));
 
-    expect(result.accuracy).toBeDefined();
-    expect(result.accuracy).toBe(0.5); // 2 of 4 pass
+    expect(result.assertionPassRate).toBeDefined();
+    expect(result.assertionPassRate).toBe(0.5); // 2 of 4 pass
     expect(result.pass).toBe(true); // 0.5 >= 0.5 threshold
     expect(result.iterationResults).toHaveLength(4);
     expect(result.iterationResults?.filter((r) => r.pass)).toHaveLength(2);
@@ -411,14 +411,14 @@ describe('multi-iteration cases', () => {
     });
 
     const result = await runEvalCase(evalCase, createContext(mcp));
-    expect(result.accuracy).toBe(0);
+    expect(result.assertionPassRate).toBe(0);
     expect(result.pass).toBe(false);
   });
 
-  it('should not set accuracy for single-iteration cases', async () => {
+  it('should not set assertionPassRate for single-iteration cases', async () => {
     const evalCase = createEvalCase();
     const result = await runEvalCase(evalCase, createContext());
-    expect(result.accuracy).toBeUndefined();
+    expect(result.assertionPassRate).toBeUndefined();
     expect(result.iterationResults).toBeUndefined();
   });
 
@@ -447,9 +447,9 @@ describe('multi-iteration cases', () => {
     const result = await runEvalCase(evalCase, createContext(mcp));
 
     // The infrastructure error is excluded from the denominator
-    // Only 1 assertion result (the second iteration), and it passes → accuracy = 1.0
+    // Only 1 assertion result (the second iteration), and it passes → assertionPassRate = 1.0
     expect(result.infrastructureErrorCount).toBe(1);
-    expect(result.accuracy).toBe(1.0);
+    expect(result.assertionPassRate).toBe(1.0);
     expect(result.pass).toBe(true);
     expect(result.iterationResults).toHaveLength(2);
     expect(result.iterationResults?.[0]?.isInfrastructureError).toBe(true);
@@ -645,7 +645,7 @@ describe('runEvalDataset defaultLlmIterations', () => {
 
     // Direct mode case should NOT have iterationResults (only ran once)
     expect(result.caseResults[0]!.iterationResults).toBeUndefined();
-    expect(result.caseResults[0]!.accuracy).toBeUndefined();
+    expect(result.caseResults[0]!.assertionPassRate).toBeUndefined();
     expect(result.passed).toBe(1);
   });
 

--- a/src/evals/evalRunner.ts
+++ b/src/evals/evalRunner.ts
@@ -664,7 +664,6 @@ export async function runEvalCase(
   const assertionPassRate =
     assertionResults.length > 0 ? passCount / assertionResults.length : 0;
   const infrastructureErrorRate = infraErrors.length / iterations;
-  const accuracy = assertionPassRate; // backward compat
   const threshold = evalCase.accuracyThreshold ?? 1.0;
 
   // Fall back to a synthetic result if all iterations threw infrastructure errors
@@ -684,10 +683,9 @@ export async function runEvalCase(
 
   return {
     ...baseResult,
-    pass: accuracy >= threshold,
+    pass: assertionPassRate >= threshold,
     assertionPassRate,
     infrastructureErrorRate,
-    accuracy,
     iterationResults,
     infrastructureErrorCount: infraErrors.length,
     durationMs: iterationResults.reduce((sum, r) => sum + r.durationMs, 0),

--- a/src/reporters/ui-src/components/Dashboard/MetricsCards.tsx
+++ b/src/reporters/ui-src/components/Dashboard/MetricsCards.tsx
@@ -20,11 +20,15 @@ function computeMetrics(results: EvalCaseResult[]): MetricsSummary {
   const failed = results.filter((r) => !r.pass).length;
   const total = results.length;
 
-  const multiIterResults = results.filter((r) => r.accuracy !== undefined);
+  const multiIterResults = results.filter(
+    (r) => r.assertionPassRate !== undefined
+  );
   const avgAccuracy =
     multiIterResults.length > 0
-      ? multiIterResults.reduce((sum, r) => sum + (r.accuracy ?? 0), 0) /
-        multiIterResults.length
+      ? multiIterResults.reduce(
+          (sum, r) => sum + (r.assertionPassRate ?? 0),
+          0
+        ) / multiIterResults.length
       : undefined;
 
   const totalIterations = results.reduce(

--- a/src/reporters/ui-src/components/Results/DetailModal.tsx
+++ b/src/reporters/ui-src/components/Results/DetailModal.tsx
@@ -73,7 +73,7 @@ export function DetailModal({ result, onClose }: DetailModalProps) {
   const hasAssertions = Object.keys(result.expectations ?? {}).length > 0;
   const hasIterations =
     result.iterationResults && result.iterationResults.length > 0;
-  const displayRate = result.assertionPassRate ?? result.accuracy;
+  const displayRate = result.assertionPassRate;
   const infraErrorRate = result.infrastructureErrorRate;
 
   return (

--- a/src/reporters/ui-src/components/Results/ResultsTable.tsx
+++ b/src/reporters/ui-src/components/Results/ResultsTable.tsx
@@ -304,18 +304,18 @@ export function ResultsTable({ results, onSelectResult }: ResultsTableProps) {
                             </span>
 
                             {/* Accuracy badge — only for multi-iteration cases */}
-                            {result.accuracy !== undefined && (
+                            {result.assertionPassRate !== undefined && (
                               <span
                                 className={`inline-flex items-center gap-1 px-2 py-0.5 rounded text-xs font-semibold shrink-0 ${
-                                  result.accuracy >= 0.8
+                                  result.assertionPassRate >= 0.8
                                     ? 'bg-green-500/15 text-green-700 dark:text-green-400'
-                                    : result.accuracy >= 0.5
+                                    : result.assertionPassRate >= 0.5
                                       ? 'bg-amber-500/15 text-amber-700 dark:text-amber-400'
                                       : 'bg-red-500/15 text-red-700 dark:text-red-400'
                                 }`}
                                 title={`${result.iterationResults?.filter((r) => r.pass).length ?? '?'}/${result.iterationResults?.length ?? '?'} iterations passed`}
                               >
-                                {(result.accuracy * 100).toFixed(0)}%
+                                {(result.assertionPassRate * 100).toFixed(0)}%
                                 <span className="opacity-60 font-normal">
                                   {result.iterationResults
                                     ? ` ${result.iterationResults.filter((r) => r.pass).length}/${result.iterationResults.length}`

--- a/src/types/reporter.ts
+++ b/src/types/reporter.ts
@@ -215,13 +215,6 @@ export interface EvalCaseResult {
   infrastructureErrorRate?: number;
 
   /**
-   * Accuracy score (0–1) across all iterations.
-   * Alias for `assertionPassRate`. Only present when the case was run with `iterations > 1`.
-   * @deprecated Use `assertionPassRate` for clarity; this field is kept for backward compatibility.
-   */
-  accuracy?: number;
-
-  /**
    * Per-iteration pass/fail breakdown.
    * Only present when the case was run with `iterations > 1`.
    */

--- a/tests/eval-verification.spec.ts
+++ b/tests/eval-verification.spec.ts
@@ -32,7 +32,7 @@ test.describe('Eval Enhancement Verification', () => {
     // All cases should pass
     expect(result.passed).toBe(result.total);
 
-    // Multi-iteration cases should have accuracy and iterationResults
+    // Multi-iteration cases should have assertionPassRate and iterationResults
     const multiIterCases = result.caseResults.filter(
       (r) => r.iterationResults !== undefined
     );
@@ -40,18 +40,18 @@ test.describe('Eval Enhancement Verification', () => {
     expect(multiIterCases.length).toBeGreaterThan(0);
 
     for (const r of multiIterCases) {
-      expect(r.accuracy).toBeDefined();
-      expect(r.accuracy).toBeGreaterThanOrEqual(0);
-      expect(r.accuracy).toBeLessThanOrEqual(1);
+      expect(r.assertionPassRate).toBeDefined();
+      expect(r.assertionPassRate).toBeGreaterThanOrEqual(0);
+      expect(r.assertionPassRate).toBeLessThanOrEqual(1);
       expect(Array.isArray(r.iterationResults)).toBe(true);
     }
 
-    // Log accuracy results for inspection
-    console.log('Accuracy results:');
+    // Log assertionPassRate results for inspection
+    console.log('Assertion pass rate results:');
     for (const r of multiIterCases) {
       const iterCount = r.iterationResults?.length ?? 0;
       console.log(
-        `  ${r.id}: accuracy=${(r.accuracy ?? 0).toFixed(2)}, iterations=${iterCount}, pass=${r.pass}`
+        `  ${r.id}: assertionPassRate=${(r.assertionPassRate ?? 0).toFixed(2)}, iterations=${iterCount}, pass=${r.pass}`
       );
     }
   });
@@ -69,7 +69,7 @@ test.describe('Eval Enhancement Verification', () => {
       (r) => r.id === 'multi-iter-echo-always-passes'
     );
     expect(echoCase).toBeDefined();
-    expect(echoCase?.accuracy).toBe(1.0);
+    expect(echoCase?.assertionPassRate).toBe(1.0);
     expect(echoCase?.iterationResults).toHaveLength(3);
     expect(echoCase?.iterationResults?.every((iter) => iter.pass)).toBe(true);
     expect(echoCase?.pass).toBe(true);
@@ -88,12 +88,12 @@ test.describe('Eval Enhancement Verification', () => {
       (r) => r.id === 'multi-iter-calculate-addition'
     );
     expect(calcCase).toBeDefined();
-    expect(calcCase?.accuracy).toBe(1.0); // 7+3=10 is always correct
+    expect(calcCase?.assertionPassRate).toBe(1.0); // 7+3=10 is always correct
     expect(calcCase?.iterationResults).toHaveLength(5);
     expect(calcCase?.pass).toBe(true); // 1.0 >= 0.8 threshold
   });
 
-  test('single-iteration case: no accuracy fields (backward compat)', async ({
+  test('single-iteration case: no assertionPassRate fields', async ({
     mcp,
   }, testInfo) => {
     const dataset = await loadEvalDataset(
@@ -106,7 +106,7 @@ test.describe('Eval Enhancement Verification', () => {
       (r) => r.id === 'single-iter-baseline'
     );
     expect(baselineCase).toBeDefined();
-    expect(baselineCase?.accuracy).toBeUndefined();
+    expect(baselineCase?.assertionPassRate).toBeUndefined();
     expect(baselineCase?.iterationResults).toBeUndefined();
     expect(baselineCase?.pass).toBe(true);
   });
@@ -141,7 +141,7 @@ test.describe('Eval Enhancement Verification', () => {
       (r) => r.id === 'multi-iter-calculate-addition'
     );
     expect(calcCase).toBeDefined();
-    expect(calcCase?.accuracy).toBe(1.0); // 7+3=10 is always correct
+    expect(calcCase?.assertionPassRate).toBe(1.0); // 7+3=10 is always correct
     expect(calcCase?.iterationResults).toHaveLength(5);
     expect(calcCase?.pass).toBe(true); // 1.0 >= 0.8 threshold
   });


### PR DESCRIPTION
## Summary

Three pre-release polish fixes identified by the 1.0.0 readiness panel:

### 1. Remove deprecated `accuracy` field from `EvalCaseResult`

`accuracy` was a deprecated alias for `assertionPassRate`. Pre-1.0 is the last window for breaking changes — carrying the alias into 1.0.0 would mean maintaining it under semver. Removed from `src/types/reporter.ts` and all references updated throughout (`evalRunner.ts`, UI components, tests).

### 2. Add Playwright context warning to `toMatchToolSnapshot`

`toMatchToolSnapshot` calls Playwright's internal `expect(content).toMatchSnapshot()` which requires a Playwright test context (`testInfo`). Calling it outside a test produces a cryptic error. Added a `@remarks` block to the JSDoc and a warning callout in `docs/expectations.md` pointing users to `applySanitizers` as the programmatic escape hatch.

### 3. Add `toMatchToolResponse` to README matcher table

The README listed 10 matchers; 11 exist. `toMatchToolResponse` (exact match, the most basic matcher) was missing. Added as the first row.

## Test plan
- [x] `npm run typecheck` — clean
- [x] `npm run format:check` — clean
- [x] `npm test` — 778 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)