### PR TITLE
feat: set User-Agent header on all HTTP MCP requests

### DIFF
--- a/src/mcp/clientFactory.test.ts
+++ b/src/mcp/clientFactory.test.ts
@@ -215,7 +215,13 @@ describe('clientFactory', () => {
         expect(mocks.MockClient).toHaveBeenCalled();
         expect(mocks.MockStreamableHTTPClientTransport).toHaveBeenCalledWith(
           new URL('http://localhost:3000/mcp'),
-          { requestInit: undefined }
+          {
+            requestInit: {
+              headers: {
+                'User-Agent': `@gleanwork/mcp-server-tester/${packageJson.version}`,
+              },
+            },
+          }
         );
         expect(mocks.mockConnect).toHaveBeenCalled();
       });
@@ -237,6 +243,7 @@ describe('clientFactory', () => {
           {
             requestInit: {
               headers: {
+                'User-Agent': `@gleanwork/mcp-server-tester/${packageJson.version}`,
                 Authorization: 'Bearer token123',
                 'X-Custom-Header': 'value',
               },

--- a/src/mcp/clientFactory.ts
+++ b/src/mcp/clientFactory.ts
@@ -223,8 +223,12 @@ export async function createMCPClientForConfig(
         : undefined
     );
   } else if (isHttpConfig(validatedConfig)) {
-    // Build headers, including static token auth if configured and no authProvider
-    const headers: Record<string, string> = { ...validatedConfig.headers };
+    // Build headers, including static token auth if configured and no authProvider.
+    // User-provided headers take precedence over defaults (spread order).
+    const headers: Record<string, string> = {
+      'User-Agent': `@gleanwork/mcp-server-tester/${packageJson.version}`,
+      ...validatedConfig.headers,
+    };
 
     // If using client credentials grant, fetch a token first
     if (validatedConfig.auth?.clientCredentials && !options?.authProvider) {


### PR DESCRIPTION
## Summary

Adds `User-Agent: @gleanwork/mcp-server-tester/<version>` to every HTTP request made by the MCP client transport. This lets MCP servers identify and filter test-framework traffic from production metrics at the HTTP layer — without any configuration required.

## Behaviour

**Default (automatic):**
```
User-Agent: @gleanwork/mcp-server-tester/1.0.0
```
Sent on every `StreamableHTTP` and `SSE` transport request, including the initial handshake, tool calls, and polling.

**Override per-project:**
```typescript
// playwright.config.ts
mcpConfig: {
  transport: 'http',
  serverUrl: 'https://api.example.com/mcp',
  headers: {
    'User-Agent': 'my-project-tests/1.0',  // takes precedence over default
  },
}
```
User-provided headers always win (spread order: default → `validatedConfig.headers`).

**Note:** For stdio transport, the MCP `clientInfo.name` (`@gleanwork/mcp-server-tester`) sent during the `initialize` handshake already identifies the client at the protocol level. This change adds HTTP-layer identification for servers that track metrics via HTTP access logs or proxies.

## Test plan
- [x] Updated `clientFactory.test.ts` assertions to expect `User-Agent` in `requestInit.headers`
- [x] Verified user-provided headers still take precedence
- [x] `npm run typecheck` — clean
- [x] `npm test` — 778 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)