### PR TITLE
feat: add 'open' command to view MCP reporter UI in browser

### DIFF
--- a/src/cli/commands/open/index.ts
+++ b/src/cli/commands/open/index.ts
@@ -1,0 +1,38 @@
+/**
+ * CLI open command for viewing the MCP eval reporter UI in the browser.
+ */
+
+import { existsSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+
+export interface OpenOptions {
+  dir?: string;
+}
+
+/**
+ * Open command action handler.
+ *
+ * Resolves the report output directory, checks that an index.html exists under
+ * `latest/`, and opens it in the default browser.
+ */
+export async function open(options: OpenOptions): Promise<void> {
+  const outputDir = resolve(options.dir ?? '.mcp-test-results');
+  const reportPath = join(outputDir, 'latest', 'index.html');
+
+  if (!existsSync(reportPath)) {
+    console.error(`No report found at ${reportPath}`);
+    console.error('Run your Playwright tests first to generate a report.');
+    process.exit(1);
+  }
+
+  console.log(`Opening report: ${reportPath}`);
+
+  try {
+    const { default: openBrowser } = await import('open');
+    await openBrowser(reportPath);
+  } catch (error) {
+    console.error('Failed to open report in browser:', error);
+    console.error(`Open manually: file://${reportPath}`);
+    process.exit(1);
+  }
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -7,6 +7,7 @@ import { init } from './commands/init/index.js';
 import { generate } from './commands/generate/index.js';
 import { login } from './commands/login/index.js';
 import { token } from './commands/token/index.js';
+import { open } from './commands/open/index.js';
 import packageJson from '../../package.json' with { type: 'json' };
 
 const program = new Command();
@@ -59,5 +60,12 @@ program
   )
   .option('--state-dir <dir>', 'Custom directory for token storage')
   .action(token);
+
+// Open command
+program
+  .command('open')
+  .description('Open the MCP eval reporter UI in your browser')
+  .option('-d, --dir <directory>', 'Report output directory', '.mcp-test-results')
+  .action(open);
 
 program.parse();


### PR DESCRIPTION
## Summary

Adds `mcp-server-tester open` — a one-liner to view the last reporter output without digging through the filesystem.

```bash
mcp-server-tester open                   # opens .mcp-test-results/latest/index.html
mcp-server-tester open --dir my-output   # custom dir
```

**Before:** find `.mcp-test-results/latest/index.html` and open it manually, or set `autoOpen: true` in config (opens after every run, suppressed in CI).

**After:** `mcp-server-tester open` from anywhere in the project.

If no report exists yet, the command exits with a clear message directing the user to run their Playwright tests first. If the browser can't be opened (headless environment), it prints the `file://` path to open manually.

## Test plan
- [x] `npm run typecheck` — clean
- [x] `npm test` — 778 tests pass
- [x] `npm run build` — clean
- [x] `node dist/cli/index.js open --help` — correct output

🤖 Generated with [Claude Code](https://claude.com/claude-code)