### PR TITLE
feat(reporter-ui): add ByToolTable, FailureBreakdown, and enhanced MetricsCards

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,6 +101,7 @@
     "eslint": "^8.57.1",
     "ink-testing-library": "^4.0.0",
     "lucide-react": "^0.460.0",
+    "recharts": "^2.12.0",
     "memfs": "^4.51.1",
     "postcss": "^8.4.49",
     "prettier": "^3.4.2",

--- a/src/reporters/ui-src/components/Dashboard/ByToolTable.tsx
+++ b/src/reporters/ui-src/components/Dashboard/ByToolTable.tsx
@@ -1,0 +1,151 @@
+import React, { useMemo } from 'react';
+import type { EvalCaseResult } from '../../types';
+
+interface ToolStats {
+  toolName: string;
+  cases: number;
+  passed: number;
+  passRate: number;
+  avgDurationMs: number;
+  avgRecall: number | null;
+  avgPrecision: number | null;
+}
+
+function computeByTool(results: EvalCaseResult[]): ToolStats[] {
+  const byTool = new Map<string, EvalCaseResult[]>();
+
+  for (const result of results) {
+    const existing = byTool.get(result.toolName);
+    if (existing) {
+      existing.push(result);
+    } else {
+      byTool.set(result.toolName, [result]);
+    }
+  }
+
+  const stats: ToolStats[] = [];
+
+  for (const [toolName, toolResults] of byTool.entries()) {
+    const cases = toolResults.length;
+    const passed = toolResults.filter((r) => r.pass).length;
+    const passRate = cases > 0 ? passed / cases : 0;
+    const avgDurationMs =
+      toolResults.reduce((sum, r) => sum + r.durationMs, 0) / cases;
+
+    const recallValues = toolResults
+      .filter((r) => r.toolRecall !== undefined)
+      .map((r) => r.toolRecall as number);
+    const avgRecall =
+      recallValues.length > 0
+        ? recallValues.reduce((sum, v) => sum + v, 0) / recallValues.length
+        : null;
+
+    const precisionValues = toolResults
+      .filter((r) => r.toolPrecision !== undefined)
+      .map((r) => r.toolPrecision as number);
+    const avgPrecision =
+      precisionValues.length > 0
+        ? precisionValues.reduce((sum, v) => sum + v, 0) / precisionValues.length
+        : null;
+
+    stats.push({
+      toolName,
+      cases,
+      passed,
+      passRate,
+      avgDurationMs,
+      avgRecall,
+      avgPrecision,
+    });
+  }
+
+  return stats.sort((a, b) => a.passRate - b.passRate);
+}
+
+function passRateColor(rate: number): string {
+  if (rate >= 0.8) return 'text-green-600 dark:text-green-400';
+  if (rate < 0.6) return 'text-red-600 dark:text-red-400';
+  return 'text-amber-600 dark:text-amber-400';
+}
+
+function formatMs(ms: number): string {
+  if (ms >= 1000) return `${(ms / 1000).toFixed(1)}s`;
+  return `${Math.round(ms)}ms`;
+}
+
+function formatRatio(value: number | null): string {
+  if (value === null) return '—';
+  return `${(value * 100).toFixed(1)}%`;
+}
+
+export function ByToolTable({ results }: { results: EvalCaseResult[] }) {
+  const toolStats = useMemo(() => computeByTool(results), [results]);
+
+  const distinctTools = useMemo(
+    () => new Set(results.map((r) => r.toolName)).size,
+    [results]
+  );
+
+  if (distinctTools < 2) return null;
+
+  return (
+    <div className="rounded-lg border bg-card shadow-sm">
+      <div className="px-6 py-4 border-b">
+        <h2 className="text-sm font-semibold text-foreground">Performance by Tool</h2>
+      </div>
+      <div className="overflow-x-auto">
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="border-b bg-muted/30">
+              <th className="px-6 py-3 text-left text-xs font-medium text-muted-foreground uppercase tracking-wide">
+                Tool Name
+              </th>
+              <th className="px-4 py-3 text-right text-xs font-medium text-muted-foreground uppercase tracking-wide">
+                Cases
+              </th>
+              <th className="px-4 py-3 text-right text-xs font-medium text-muted-foreground uppercase tracking-wide">
+                Pass Rate
+              </th>
+              <th className="px-4 py-3 text-right text-xs font-medium text-muted-foreground uppercase tracking-wide">
+                Avg Duration
+              </th>
+              <th className="px-4 py-3 text-right text-xs font-medium text-muted-foreground uppercase tracking-wide">
+                Recall
+              </th>
+              <th className="px-4 py-3 text-right text-xs font-medium text-muted-foreground uppercase tracking-wide">
+                Precision
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {toolStats.map((stat, idx) => (
+              <tr
+                key={stat.toolName}
+                className={`border-b last:border-0 ${idx % 2 === 0 ? '' : 'bg-muted/10'} hover:bg-muted/20 transition-colors`}
+              >
+                <td className="px-6 py-3 font-mono text-xs font-medium text-foreground">
+                  {stat.toolName}
+                </td>
+                <td className="px-4 py-3 text-right text-muted-foreground">
+                  {stat.cases}
+                </td>
+                <td className={`px-4 py-3 text-right font-semibold ${passRateColor(stat.passRate)}`}>
+                  {(stat.passRate * 100).toFixed(1)}%
+                </td>
+                <td className="px-4 py-3 text-right text-muted-foreground">
+                  {formatMs(stat.avgDurationMs)}
+                </td>
+                <td className="px-4 py-3 text-right text-muted-foreground">
+                  {formatRatio(stat.avgRecall)}
+                </td>
+                <td className="px-4 py-3 text-right text-muted-foreground">
+                  {formatRatio(stat.avgPrecision)}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/src/reporters/ui-src/components/Dashboard/FailureBreakdown.tsx
+++ b/src/reporters/ui-src/components/Dashboard/FailureBreakdown.tsx
@@ -1,0 +1,59 @@
+import React, { useMemo } from 'react';
+import type { EvalCaseResult } from '../../types';
+import type { ExpectationType } from '../../types';
+
+interface FailureCount {
+  type: ExpectationType;
+  count: number;
+}
+
+function computeFailureCounts(results: EvalCaseResult[]): FailureCount[] {
+  const counts = new Map<ExpectationType, number>();
+
+  for (const result of results) {
+    if (result.pass) continue;
+
+    for (const [type, expectation] of Object.entries(result.expectations) as [
+      ExpectationType,
+      { pass: boolean },
+    ][]) {
+      if (expectation.pass === false) {
+        counts.set(type, (counts.get(type) ?? 0) + 1);
+      }
+    }
+  }
+
+  return Array.from(counts.entries())
+    .map(([type, count]) => ({ type, count }))
+    .sort((a, b) => b.count - a.count);
+}
+
+export function FailureBreakdown({ results }: { results: EvalCaseResult[] }) {
+  const failureCounts = useMemo(() => computeFailureCounts(results), [results]);
+  const totalFailed = useMemo(
+    () => results.filter((r) => !r.pass).length,
+    [results]
+  );
+
+  if (totalFailed === 0) return null;
+
+  return (
+    <div className="rounded-lg border bg-card p-6 shadow-sm">
+      <h2 className="text-sm font-semibold text-foreground mb-3">Why Cases Fail</h2>
+      <div className="flex flex-wrap items-center gap-2">
+        <span className="text-sm text-muted-foreground">
+          {totalFailed} failure{totalFailed !== 1 ? 's' : ''}:
+        </span>
+        {failureCounts.map(({ type, count }) => (
+          <span
+            key={type}
+            className="inline-flex items-center gap-1 rounded-md border border-red-200 bg-red-50 px-2.5 py-1 text-xs font-medium text-red-700 dark:border-red-800 dark:bg-red-950/30 dark:text-red-400"
+          >
+            <span className="font-semibold">{type}</span>
+            <span className="text-red-500 dark:text-red-500">({count})</span>
+          </span>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/reporters/ui-src/components/Dashboard/MetricsCards.tsx
+++ b/src/reporters/ui-src/components/Dashboard/MetricsCards.tsx
@@ -46,13 +46,54 @@ function computeMetrics(results: EvalCaseResult[]): MetricsSummary {
   };
 }
 
+interface ToolDiscoveryMetrics {
+  meanRecall: number;
+  count: number;
+}
+
+interface RegressionMetrics {
+  regressions: number;
+  fixes: number;
+}
+
+function computeToolDiscovery(
+  results: EvalCaseResult[]
+): ToolDiscoveryMetrics | null {
+  const withRecall = results.filter((r) => r.toolRecall !== undefined);
+  if (withRecall.length === 0) return null;
+  const meanRecall =
+    withRecall.reduce((sum, r) => sum + (r.toolRecall ?? 0), 0) /
+    withRecall.length;
+  return { meanRecall, count: withRecall.length };
+}
+
+function computeRegressions(results: EvalCaseResult[]): RegressionMetrics | null {
+  const withBaseline = results.filter((r) => r.baselinePass !== undefined);
+  if (withBaseline.length === 0) return null;
+  const regressions = withBaseline.filter(
+    (r) => r.baselinePass === true && r.pass === false
+  ).length;
+  const fixes = withBaseline.filter(
+    (r) => r.baselinePass === false && r.pass === true
+  ).length;
+  return { regressions, fixes };
+}
+
 export function MetricsCards({ results }: MetricsCardsProps) {
   const overall = useMemo(() => computeMetrics(results), [results]);
+  const toolDiscovery = useMemo(() => computeToolDiscovery(results), [results]);
+  const regressionMetrics = useMemo(() => computeRegressions(results), [results]);
   const showAccuracy = overall.avgAccuracy !== undefined;
+
+  const extraCards =
+    (showAccuracy ? 1 : 0) +
+    (toolDiscovery !== null ? 1 : 0) +
+    (regressionMetrics !== null ? 1 : 0);
+  const totalCols = 4 + extraCards;
 
   return (
     <div
-      className={`grid grid-cols-2 gap-4 ${showAccuracy ? 'lg:grid-cols-5' : 'lg:grid-cols-4'}`}
+      className={`grid grid-cols-2 gap-4 lg:grid-cols-${totalCols}`}
     >
       <MetricCard
         title="Pass Rate"
@@ -72,6 +113,23 @@ export function MetricsCards({ results }: MetricsCardsProps) {
                 : 'error'
           }
         />
+      )}
+      {toolDiscovery !== null && (
+        <MetricCard
+          title="Tool Discovery Rate"
+          value={`${(toolDiscovery.meanRecall * 100).toFixed(1)}%`}
+          subtitle="avg recall across llm_host cases"
+          variant={
+            toolDiscovery.meanRecall >= 0.8
+              ? 'success'
+              : toolDiscovery.meanRecall >= 0.6
+                ? 'warning'
+                : 'error'
+          }
+        />
+      )}
+      {regressionMetrics !== null && (
+        <RegressionCard metrics={regressionMetrics} />
       )}
       <MetricCard
         title="Total Cases"
@@ -93,6 +151,44 @@ export function MetricsCards({ results }: MetricsCardsProps) {
         value={overall.failed.toString()}
         variant={overall.failed === 0 ? 'neutral' : 'error'}
       />
+    </div>
+  );
+}
+
+interface RegressionCardProps {
+  metrics: RegressionMetrics;
+}
+
+function RegressionCard({ metrics }: RegressionCardProps) {
+  const hasRegressions = metrics.regressions > 0;
+
+  return (
+    <div className="rounded-lg border bg-card p-6 shadow-sm hover:shadow-md transition-shadow">
+      <div className="flex flex-col">
+        <span className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
+          Regressions / Fixed
+        </span>
+        <div className="mt-2 flex flex-col gap-1">
+          <span
+            className={`text-sm font-semibold ${
+              hasRegressions
+                ? 'text-red-600 dark:text-red-400'
+                : 'text-muted-foreground'
+            }`}
+          >
+            ▼ {metrics.regressions} regression{metrics.regressions !== 1 ? 's' : ''}
+          </span>
+          <span
+            className={`text-sm font-semibold ${
+              metrics.fixes > 0
+                ? 'text-green-600 dark:text-green-400'
+                : 'text-muted-foreground'
+            }`}
+          >
+            ▲ {metrics.fixes} fixed
+          </span>
+        </div>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
Adds tool discovery rate card, regression/fixed counter, per-tool performance breakdown table, and failure reason categorization to the MCP eval reporter dashboard. Part of the MCP eval UI redesign (Phase 1+2).