### PR TITLE
fix(reporter-ui): remove redundant guard on ConformanceCheck.message

### DIFF
--- a/src/reporters/ui-src/components/Conformance/ConformancePanel.tsx
+++ b/src/reporters/ui-src/components/Conformance/ConformancePanel.tsx
@@ -90,11 +90,9 @@ export function ConformancePanel({
                   >
                     {check.name}
                   </code>
-                  {check.message && (
-                    <p className="text-sm text-muted-foreground mt-1">
-                      {check.message}
-                    </p>
-                  )}
+                  <p className="text-sm text-muted-foreground mt-1">
+                    {check.message}
+                  </p>
                 </div>
               </div>
             </div>


### PR DESCRIPTION
`MCPConformanceCheck.message` is typed as a required `string`, so the `check.message &&` truthy guard in `ConformancePanel.tsx` was unnecessary and has been removed — the message paragraph now renders unconditionally.