### PR TITLE
fix(types): correct stale toolPrecision JSDoc

### DIFF
--- a/src/types/reporter.ts
+++ b/src/types/reporter.ts
@@ -228,7 +228,7 @@ export interface EvalCaseResult {
   /**
    * Precision of tool calls made (0–1).
    * 1.0 means every tool called was expected; <1.0 means unexpected tools were called.
-   * Only populated when exclusive: true in toolsTriggered and the expectation was evaluated.
+   * Populated whenever a `toolsTriggered` expectation is evaluated.
    */
   toolPrecision?: number;
 


### PR DESCRIPTION
The `toolPrecision` JSDoc incorrectly stated the field was only populated when `exclusive: true`; since PR #85 precision is always computed whenever a `toolsTriggered` expectation is evaluated, so the comment has been updated to reflect that.