### PR TITLE
fix(reporter-ui): show performance table for single-tool MCP servers

### DIFF
--- a/src/reporters/ui-src/components/Dashboard/ByToolTable.tsx
+++ b/src/reporters/ui-src/components/Dashboard/ByToolTable.tsx
@@ -79,17 +79,12 @@ export function ByToolTable({
 }) {
   const toolStats = useMemo(() => computeByTool(results), [results]);
 
-  const distinctTools = useMemo(
-    () => new Set(results.map((r) => r.toolName)).size,
-    [results]
-  );
-
   // Always use a neutral blue — the panel is a data view, not a status indicator.
   // Individual rows already color-code pass rates; the header doesn't need to warn.
   const headerColor = 'bg-blue-500/10 border-blue-500/20 hover:bg-blue-500/15';
   const badgeColor = 'text-blue-600 dark:text-blue-400';
 
-  if (distinctTools < 2) return null;
+  if (toolStats.length === 0) return null;
 
   return (
     <div className="rounded-lg border bg-card shadow-sm overflow-hidden">


### PR DESCRIPTION
## Summary

- Single-tool MCP servers (e.g. a focused search API) caused the **Performance by Tool** panel in the Evals tab to disappear entirely with no explanation, because `ByToolTable` returned `null` when `distinctTools < 2`.
- The `if (distinctTools < 2) return null` guard and its associated `distinctTools` useMemo have been removed.
- The panel now renders whenever there is at least one tool with results (`toolStats.length > 0`), which correctly covers both single-tool and multi-tool servers. The pre-existing `toolStats.length === 0` guard (replacing the old one) still suppresses the panel when there are no results at all.

## Test plan

- [ ] Run the reporter UI against a dataset that targets a single tool — the Performance by Tool panel should now appear with one row.
- [ ] Run against a dataset with zero results — the panel should still be hidden.
- [ ] Run `npm run format && npm run typecheck` — both pass cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)