### PR TITLE
fix(reporter-ui): aggregate conformance checks across projects conservatively

### DIFF
--- a/src/reporters/ui-src/components/Conformance/ConformancePanel.tsx
+++ b/src/reporters/ui-src/components/Conformance/ConformancePanel.tsx
@@ -23,9 +23,21 @@ export function ConformancePanel({
     }))
   );
 
-  const uniqueChecks = Array.from(
-    new Map(allChecks.map((c) => [c.name, c])).values()
-  );
+  // Group checks by name and aggregate: PASS only if all occurrences pass
+  const checksByName = new Map<string, (typeof allChecks)[number][]>();
+  for (const check of allChecks) {
+    const existing = checksByName.get(check.name) ?? [];
+    existing.push(check);
+    checksByName.set(check.name, existing);
+  }
+  const uniqueChecks = [...checksByName.values()].map((group) => {
+    const allPass = group.every((c) => c.pass);
+    // Prefer the failing entry's message for context when any failed
+    const representative = allPass
+      ? group[0]
+      : (group.find((c) => !c.pass) ?? group[0]);
+    return { ...representative, pass: allPass };
+  });
 
   const allPassed = uniqueChecks.every((check) => check.pass);
   const passedCount = uniqueChecks.filter((check) => check.pass).length;


### PR DESCRIPTION
## Problem

`ConformancePanel.tsx` deduplicated conformance checks by check name using a `Map`, keeping only the **last** occurrence of each name:

```typescript
new Map(allChecks.map((c) => [c.name, c])).values()
```

When multiple Playwright projects run the same conformance checks (e.g., two projects with different auth configs both run `list-tools`), the last project's result silently overwrites the earlier ones. If Project A passes `list-tools` and Project B fails it, the panel displays PASS — hiding the failure entirely.

## Fix (CHK-033 Option A — Aggregate)

Replaced last-wins deduplication with conservative aggregation: a check is shown as **PASS only if every occurrence of that check name passes**. Any single failure surfaces.

Groups all occurrences of each check name, then:
- If all pass: uses the first entry as the representative, marks `pass: true`
- If any fail: uses the first failing entry as the representative (preserving its failure message for context), marks `pass: false`

This means the panel accurately reflects the worst-case outcome across all Playwright projects, which is the correct behavior for a conformance gate.

## Test plan

- [ ] Verify with a single project: behavior is unchanged (one occurrence per check name, result is the same)
- [ ] Verify with two projects running the same checks where one passes and one fails: panel shows FAIL with the failing project's message
- [ ] Verify with two projects both passing the same check: panel shows PASS
- [ ] Run `npm run format && npm run typecheck` — both pass clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)