### PR TITLE
feat(reporter-ui): show CI badge in report header for CI-generated reports

### DIFF
--- a/src/reporters/ui-src/App.tsx
+++ b/src/reporters/ui-src/App.tsx
@@ -98,6 +98,7 @@ function App() {
         timestamp={data.runData.timestamp}
         platform={data.runData.environment.platform}
         durationMs={data.runData.durationMs}
+        ci={data.runData.environment.ci}
       >
         {/* Tab navigation — underline style, familiar from VS Code / Chrome DevTools */}
         <div className="border-b border-border px-6">

--- a/src/reporters/ui-src/components/Layout.tsx
+++ b/src/reporters/ui-src/components/Layout.tsx
@@ -6,6 +6,7 @@ interface LayoutProps {
   timestamp: string;
   platform: string;
   durationMs: number;
+  ci?: boolean;
   children: React.ReactNode;
 }
 
@@ -13,6 +14,7 @@ export function Layout({
   timestamp,
   platform,
   durationMs,
+  ci,
   children,
 }: LayoutProps) {
   return (
@@ -26,9 +28,16 @@ export function Layout({
           </div>
           <div className="flex items-center gap-6">
             <div className="flex flex-col text-right">
-              <span className="text-sm font-semibold">
-                {new Date(timestamp).toLocaleString()}
-              </span>
+              <div className="flex items-center justify-end gap-2">
+                <span className="text-sm font-semibold">
+                  {new Date(timestamp).toLocaleString()}
+                </span>
+                {ci && (
+                  <span className="inline-flex items-center rounded px-1.5 py-0.5 text-xs font-medium bg-blue-500/10 text-blue-600 dark:text-blue-400 border border-blue-500/20">
+                    CI
+                  </span>
+                )}
+              </div>
               <span className="text-xs text-muted-foreground">
                 {(durationMs / 1000).toFixed(1)}s · {platform}
               </span>


### PR DESCRIPTION
The reporter already captures `environment.ci` (`!!process.env.CI`) and includes it in `MCPEvalRunData`, but the `Layout` component never surfaced this flag in the UI. This PR adds a small "CI" badge rendered inline with the timestamp in the report header whenever `environment.ci` is `true`, making it immediately visible whether a report was produced in a CI environment or a local developer run. The badge uses a subtle blue tint with a matching border so it is noticeable without being distracting, and it is hidden entirely on local reports where `ci` is `false` or absent.