### PR TITLE
feat(reporter-ui): respect prefers-reduced-motion OS preference

### DIFF
--- a/src/reporters/ui-src/components/Dashboard/TrendChart.tsx
+++ b/src/reporters/ui-src/components/Dashboard/TrendChart.tsx
@@ -77,6 +77,10 @@ interface TrendChartProps {
 }
 
 export function TrendChart({ historical }: TrendChartProps) {
+  const prefersReducedMotion =
+    typeof window !== 'undefined' &&
+    window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
   const chartData = useMemo(
     () =>
       historical.map((h) => ({
@@ -143,6 +147,7 @@ export function TrendChart({ historical }: TrendChartProps) {
               strokeWidth={2}
               dot={LINE_DOT_STYLE}
               activeDot={LINE_ACTIVE_DOT_STYLE}
+              isAnimationActive={!prefersReducedMotion}
             />
           </LineChart>
         </ResponsiveContainer>

--- a/src/reporters/ui-src/styles.css
+++ b/src/reporters/ui-src/styles.css
@@ -77,3 +77,13 @@
     @apply bg-muted-foreground/30;
   }
 }
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
+}


### PR DESCRIPTION
## Summary

- Adds a `@media (prefers-reduced-motion: reduce)` rule to `styles.css` that collapses animation and transition durations to 0.01ms for all elements. Using 0.01ms rather than 0 follows the WCAG-recommended pattern: transitions still complete (preventing layout jumps in elements that depend on transition-end events) but are imperceptible to users.
- Reads `window.matchMedia('(prefers-reduced-motion: reduce)')` synchronously at render time in `TrendChart.tsx` and passes `isAnimationActive={!prefersReducedMotion}` to the Recharts `Line` component, disabling the line draw animation for users who have opted out of motion.

## Why

Users with vestibular disorders, epilepsy, or general motion sensitivity set `prefers-reduced-motion: reduce` in their OS accessibility preferences. Before this change the reporter UI ignored that preference: Tailwind `transition-*` utilities and Recharts chart animations ran unconditionally. This brings the reporter into WCAG 2.1 SC 2.3.3 (Animation from Interactions, AAA) and general accessibility best-practice compliance.

## Test plan

- [ ] Verify the CSS rule is present in the built stylesheet
- [ ] Enable "Reduce motion" in macOS System Settings → Accessibility → Display and open a report in a browser with devtools — confirm Tailwind transitions on hover/focus are near-instant
- [ ] In Chrome DevTools → Rendering → Emulate CSS media feature `prefers-reduced-motion: reduce`, open a report with historical data and confirm the TrendChart line does not animate on load
- [ ] Confirm no visual regressions with reduced-motion off (default behaviour unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)