### PR TITLE
docs: document clientCredentials, baseline regression, and server comparison

### DIFF
--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -7,6 +7,7 @@ This guide covers authentication options for testing MCP servers that require au
 - [Overview](#overview)
 - [Static Token Authentication](#static-token-authentication)
 - [OAuth 2.1 Authentication](#oauth-21-authentication)
+- [Client Credentials Grant](#client-credentials-grant)
 - [Playwright Global Setup for OAuth](#playwright-global-setup-for-oauth)
 - [GitHub Actions CI/CD](#github-actions-cicd)
 - [API Reference](#api-reference)
@@ -14,17 +15,19 @@ This guide covers authentication options for testing MCP servers that require au
 
 ## Overview
 
-`@gleanwork/mcp-server-tester` supports two authentication modes:
+`@gleanwork/mcp-server-tester` supports three authentication modes:
 
-| Mode             | Use Case                                   | Setup Complexity |
-| ---------------- | ------------------------------------------ | ---------------- |
-| **Static Token** | Pre-acquired API tokens, service accounts  | Simple           |
-| **OAuth 2.1**    | Full OAuth flow with PKCE and optional DCR | Advanced         |
+| Mode                   | Use Case                                           | Setup Complexity |
+| ---------------------- | -------------------------------------------------- | ---------------- |
+| **Static Token**       | Pre-acquired API tokens, service accounts          | Simple           |
+| **OAuth 2.1**          | Full OAuth flow with PKCE and optional DCR         | Advanced         |
+| **Client Credentials** | Machine-to-machine (CI/CD), no browser interaction | Moderate         |
 
 Choose based on your server's authentication requirements:
 
-- **Static Token**: Use when you have an API key or service account token
-- **OAuth 2.1**: Use when the server requires OAuth authentication with user login
+- **Static Token**: Use when you have a pre-issued API key or service account token
+- **OAuth 2.1**: Use when the server requires OAuth authentication with a user login step
+- **Client Credentials**: Use when running in CI/CD or as a service and the server accepts OAuth 2.1 client credentials tokens
 
 ## Static Token Authentication
 
@@ -207,6 +210,103 @@ interface MCPOAuthConfig {
 }
 ```
 
+## Client Credentials Grant
+
+The client credentials grant (OAuth 2.1, RFC 6749 §4.4) is designed for machine-to-machine communication. The library fetches a token from the authorization server's token endpoint before connecting to the MCP server, then attaches it as a `Bearer` token on every request. There is no browser, no redirect, and no user interaction.
+
+### When to use it
+
+- Running tests in CI/CD pipelines where no browser is available
+- Authenticating as a service account or bot identity rather than a human user
+- The MCP server accepts tokens issued by an OAuth authorization server, and you hold a registered client ID and secret
+- You want credentials managed through environment variables without modifying `playwright.config.ts`
+
+If you already have a token in hand (from a secrets store or a separate provisioning step), use `auth.accessToken` instead — it is simpler. If the server requires a user to log in interactively, use `auth.oauth` instead.
+
+### Configuration
+
+```typescript snippet=snippets/auth-client-credentials.ts
+import { defineConfig } from '@playwright/test';
+import type { MCPClientCredentialsConfig } from '@gleanwork/mcp-server-tester';
+
+const clientCredentials: MCPClientCredentialsConfig = {
+  // clientId and clientSecret can be omitted when MCP_CLIENT_ID / MCP_CLIENT_SECRET
+  // environment variables are set. Provide them here to override the env vars.
+  clientId: process.env.MCP_CLIENT_ID,
+  clientSecret: process.env.MCP_CLIENT_SECRET,
+  tokenEndpoint: 'https://auth.example.com/oauth/token',
+  scopes: ['mcp:read', 'mcp:write'],
+};
+
+export default defineConfig({
+  projects: [
+    {
+      name: 'mcp-client-credentials',
+      use: {
+        mcpConfig: {
+          transport: 'http',
+          serverUrl: 'https://api.example.com/mcp',
+          auth: {
+            clientCredentials,
+          },
+        },
+      },
+    },
+  ],
+});
+```
+
+### Configuration fields
+
+| Field           | Type       | Required | Description                                                      |
+| --------------- | ---------- | -------- | ---------------------------------------------------------------- |
+| `tokenEndpoint` | `string`   | Yes      | Full URL of the OAuth token endpoint (e.g. `.../oauth/token`)    |
+| `clientId`      | `string`   | No\*     | OAuth client ID. Falls back to `MCP_CLIENT_ID` env var           |
+| `clientSecret`  | `string`   | No\*     | OAuth client secret. Falls back to `MCP_CLIENT_SECRET` env var   |
+| `scopes`        | `string[]` | No       | Scopes to request. Omit to use the server's default grant scopes |
+
+\* `clientId` and `clientSecret` are optional in the config object but **one of the two sources must supply a value at runtime** — either the config field or the corresponding environment variable. If either value is missing when the client connects, an error is thrown.
+
+### Environment variable fallbacks
+
+The client factory resolves credentials at connection time using this precedence:
+
+1. Value set directly in `auth.clientCredentials` (`clientId`, `clientSecret`)
+2. `MCP_CLIENT_ID` / `MCP_CLIENT_SECRET` environment variables
+
+This means you can keep `playwright.config.ts` free of secrets and supply credentials only through environment variables:
+
+```bash
+# .env or CI environment
+MCP_CLIENT_ID=my-service-client
+MCP_CLIENT_SECRET=s3cr3t
+```
+
+```typescript
+// playwright.config.ts — no secrets in source
+auth: {
+  clientCredentials: {
+    tokenEndpoint: 'https://auth.example.com/oauth/token',
+    scopes: ['mcp:read'],
+  },
+}
+```
+
+The library uses `client_secret_basic` authentication (credentials in the `Authorization: Basic` header per RFC 6749 §2.3.1) rather than placing the secret in the request body.
+
+### Choosing between auth modes
+
+| Scenario                                            | Recommended mode         |
+| --------------------------------------------------- | ------------------------ |
+| You have a pre-issued API key or bearer token       | `auth.accessToken`       |
+| A human must log in via browser during test setup   | `auth.oauth`             |
+| CI/CD pipeline, service account, no browser         | `auth.clientCredentials` |
+| Token is managed externally and injected at runtime | `auth.accessToken`       |
+| Server supports OAuth but issues long-lived tokens  | `auth.accessToken`       |
+| Server issues short-lived tokens requiring refresh  | `auth.clientCredentials` |
+
+`auth.clientCredentials` sits between the other two in terms of setup cost: it requires a registered OAuth client (client ID and secret) and a reachable token endpoint, but it needs no browser automation, no auth state file, and no global setup step.
+
 ## Playwright Global Setup for OAuth
 
 Create a global setup file to perform the OAuth flow before tests run.
@@ -266,10 +366,11 @@ export default async function globalSetup() {
 
 For complex login flows (MFA, custom consent screens), use `PlaywrightOAuthClientProvider` in a `globalSetup` and automate the browser interaction with Playwright. `PlaywrightOAuthClientProvider` handles PKCE, state management, token exchange, and storage — you only need to automate the IdP-specific UI steps.
 
-```typescript
-// global-setup.ts
+```typescript snippet=snippets/auth-playwright-oauth-provider.ts
 import { chromium } from '@playwright/test';
 import { PlaywrightOAuthClientProvider } from '@gleanwork/mcp-server-tester';
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 
 export default async function globalSetup() {
   const provider = new PlaywrightOAuthClientProvider({
@@ -282,13 +383,9 @@ export default async function globalSetup() {
   const browser = await chromium.launch({ headless: true });
   const page = await browser.newPage();
 
-  // Navigate to the authorization URL produced by the provider
-  const authUrl = await provider.getAuthorizationUrl(
-    'https://api.example.com/mcp'
-  );
-  await page.goto(authUrl.toString());
-
-  // Automate your IdP's login UI
+  // Automate your IdP's login UI to acquire OAuth tokens.
+  // The provider handles PKCE, state management, token exchange, and storage.
+  await page.goto('https://auth.example.com/login');
   await page.fill('#username', process.env.TEST_USERNAME!);
   await page.fill('#password', process.env.TEST_PASSWORD!);
   await page.click('#submit-button');
@@ -302,11 +399,17 @@ export default async function globalSetup() {
     await page.click('#authorize-button');
   }
 
-  // Wait for the callback and let the provider complete the token exchange
-  await page.waitForURL(/localhost:3000\/oauth\/callback/);
-  await provider.handleCallback(new URL(page.url()));
-
   await browser.close();
+
+  // Use the provider as the authProvider for StreamableHTTPClientTransport
+  const serverUrl = new URL('https://api.example.com/mcp');
+  const transport = new StreamableHTTPClientTransport(serverUrl, {
+    authProvider: provider,
+  });
+
+  const client = new Client({ name: 'test-client', version: '1.0.0' });
+  await client.connect(transport);
+  await client.close();
 }
 ```
 
@@ -486,8 +589,9 @@ import type {
 
 ### OAuth Client Provider
 
-```typescript
+```typescript snippet=snippets/auth-oauth-provider-transport.ts
 import { PlaywrightOAuthClientProvider } from '@gleanwork/mcp-server-tester';
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
 
 // Create provider for MCP SDK
 const provider = new PlaywrightOAuthClientProvider({
@@ -498,11 +602,12 @@ const provider = new PlaywrightOAuthClientProvider({
 });
 
 // Use with StreamableHTTPClientTransport
-import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
-
+const serverUrl = new URL('https://api.example.com/mcp');
 const transport = new StreamableHTTPClientTransport(serverUrl, {
   authProvider: provider,
 });
+
+export { provider, transport };
 ```
 
 ### Auth Fixture

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -471,7 +471,7 @@ jobs:
 
 Instead of environment variables, you can inject tokens in your test setup:
 
-```typescript
+```typescript snippet=snippets/auth-inject-tokens.ts
 // globalSetup.ts
 import { injectTokens } from '@gleanwork/mcp-server-tester';
 
@@ -487,7 +487,7 @@ export default async function globalSetup() {
 
 You can also use the OAuth client directly in code:
 
-```typescript
+```typescript snippet=snippets/auth-cli-oauth-client.ts
 import { CLIOAuthClient } from '@gleanwork/mcp-server-tester';
 
 const client = new CLIOAuthClient({
@@ -497,7 +497,7 @@ const client = new CLIOAuthClient({
 // Get a valid access token (cached, refreshed, or new)
 const result = await client.getAccessToken();
 console.log(`Token: ${result.accessToken}`);
-console.log(`Expires: ${new Date(result.expiresAt).toLocaleString()}`);
+console.log(`Expires: ${new Date(result.expiresAt!).toLocaleString()}`);
 ```
 
 ### Troubleshooting

--- a/docs/evals-guide.md
+++ b/docs/evals-guide.md
@@ -459,6 +459,270 @@ test('my evals', async ({ mcp }, testInfo) => {
 
 ---
 
+## Baseline Regression Detection
+
+Running an eval once tells you whether your server is passing today. Running it across code changes tells you whether it is still passing. Baseline regression detection automates that comparison: save the results of a known-good run, then compare future runs against it to surface regressions immediately.
+
+### How it works
+
+`runEvalDataset` accepts two options for this workflow:
+
+- `saveResultsTo` — after the run completes, write the full result to a JSON file at the given path. Parent directories are created automatically.
+- `baselineResultsFrom` — before the run, load the JSON file at the given path and compare each case result against it by case ID.
+
+When `baselineResultsFrom` is set, the returned `EvalRunnerResult` gains three additional fields:
+
+| Field           | Type     | Meaning                                                                                    |
+| --------------- | -------- | ------------------------------------------------------------------------------------------ |
+| `regressions`   | `number` | Cases that passed in the baseline but failed now                                           |
+| `improvements`  | `number` | Cases that failed in the baseline but pass now                                             |
+| `deltaPassRate` | `number` | Current pass rate minus baseline pass rate (positive = improvement, negative = regression) |
+
+Each `EvalCaseResult` in `caseResults` also gains a `baselinePass?: boolean` field, so you can see the per-case baseline status in the reporter or inspect it programmatically.
+
+If more than 20% of current case IDs have no matching baseline entry, the runner emits a warning. This usually means the dataset structure changed and the baseline needs to be regenerated.
+
+### The `saveBaseline` and `loadBaseline` functions
+
+These are the low-level functions underlying the `saveResultsTo` / `baselineResultsFrom` options. Export them when you need to manage baselines programmatically — for example, in a CI script that only promotes the baseline after a full suite passes.
+
+```typescript
+import { saveBaseline, loadBaseline } from '@gleanwork/mcp-server-tester';
+
+// Write a result to disk.
+await saveBaseline(result, '.mcp-test-results/baseline.json');
+
+// Read it back.
+const saved = await loadBaseline('.mcp-test-results/baseline.json');
+console.log(`Baseline: ${saved.passed}/${saved.total} passing`);
+```
+
+`saveBaseline` serializes the entire `EvalRunnerResult` as JSON. `loadBaseline` reads and deserializes it. Both accept any file path; `saveBaseline` creates intermediate directories.
+
+### Practical workflow
+
+**Step 1: Capture the baseline on your main branch.**
+
+Run your eval suite after a known-good state and write the results to a file. Commit that file (or store it in CI artifacts) so future runs can reference it.
+
+```typescript
+const result = await runEvalDataset(
+  {
+    dataset,
+    saveResultsTo: '.mcp-test-results/baseline.json',
+  },
+  { mcp, testInfo }
+);
+```
+
+**Step 2: Re-run after changes and compare.**
+
+On the next run — after modifying tool implementations, descriptions, or server logic — load the baseline and check for regressions:
+
+```typescript
+const result = await runEvalDataset(
+  {
+    dataset,
+    baselineResultsFrom: '.mcp-test-results/baseline.json',
+  },
+  { mcp, testInfo }
+);
+
+// Fail the test if any previously passing case now fails.
+expect(result.regressions).toBe(0);
+```
+
+**Step 3: Refresh the baseline when you intentionally change behavior.**
+
+After a deliberate improvement that changes pass/fail outcomes, run with `saveResultsTo` again to update the file. Treat this the same way you would treat a snapshot update — review the diff, confirm it reflects intended changes, and commit.
+
+The combination of `saveResultsTo` and `baselineResultsFrom` can be used in the same run to simultaneously update the baseline and compare against the previous one. Pass both options if you want a rolling comparison.
+
+### Full example
+
+<!-- snippet=snippets/baseline-comparison.ts -->
+
+```typescript
+import { test, expect } from '@gleanwork/mcp-server-tester/fixtures/mcp';
+import {
+  loadEvalDataset,
+  runEvalDataset,
+  saveBaseline,
+  loadBaseline,
+} from '@gleanwork/mcp-server-tester';
+
+// Capture a baseline after a known-good run.
+// Run this once on your main branch before making changes.
+test('capture baseline', async ({ mcp }, testInfo) => {
+  const dataset = await loadEvalDataset('./data/evals.json');
+
+  const result = await runEvalDataset(
+    {
+      dataset,
+      saveResultsTo: '.mcp-test-results/baseline.json',
+    },
+    { mcp, testInfo }
+  );
+
+  expect(result.passed).toBe(result.total);
+});
+
+// Re-run after code or description changes and compare against the baseline.
+test('detect regressions', async ({ mcp }, testInfo) => {
+  const dataset = await loadEvalDataset('./data/evals.json');
+
+  const result = await runEvalDataset(
+    {
+      dataset,
+      baselineResultsFrom: '.mcp-test-results/baseline.json',
+    },
+    { mcp, testInfo }
+  );
+
+  // Fail the test if any previously passing case now fails.
+  expect(result.regressions).toBe(0);
+
+  // Log a summary of the comparison.
+  if (result.deltaPassRate !== undefined) {
+    const delta = (result.deltaPassRate * 100).toFixed(1);
+    const sign = result.deltaPassRate >= 0 ? '+' : '';
+    console.log(`Pass rate delta vs baseline: ${sign}${delta}%`);
+    console.log(`Regressions: ${result.regressions ?? 0}`);
+    console.log(`Improvements: ${result.improvements ?? 0}`);
+  }
+});
+
+// Use saveBaseline and loadBaseline directly for custom scripting.
+test('manual baseline management', async ({ mcp }, testInfo) => {
+  const dataset = await loadEvalDataset('./data/evals.json');
+  const result = await runEvalDataset({ dataset }, { mcp, testInfo });
+
+  // Write the result as the new baseline.
+  await saveBaseline(result, '.mcp-test-results/baseline.json');
+
+  // Load it back and inspect it.
+  const saved = await loadBaseline('.mcp-test-results/baseline.json');
+  console.log(`Baseline has ${saved.total} cases, ${saved.passed} passing`);
+});
+```
+
+---
+
+## Server Comparison (A/B Testing)
+
+`runServerComparison` runs the same eval dataset against two MCP server configurations in parallel and returns a detailed per-case breakdown of which server won, lost, or tied on each case. Use it when you want to compare two versions of a server, two different tool description sets, or any other pair of configurations.
+
+### How it works
+
+`runServerComparison` takes the same options as `runEvalDataset` (minus the baseline-specific fields) and two `EvalContext` objects — one for each server. It runs both servers concurrently with identical cases, then compares results case by case.
+
+For each case, the outcome is one of:
+
+| Outcome     | Meaning                          |
+| ----------- | -------------------------------- |
+| `A_WINS`    | Server A passed, server B failed |
+| `B_WINS`    | Server B passed, server A failed |
+| `TIE`       | Both passed                      |
+| `BOTH_FAIL` | Both failed                      |
+
+The aggregate `ServerComparisonResult` contains:
+
+| Field              | Type                     | Meaning                                                    |
+| ------------------ | ------------------------ | ---------------------------------------------------------- |
+| `aWins`            | `number`                 | Cases where server A passed and B failed                   |
+| `bWins`            | `number`                 | Cases where server B passed and A failed                   |
+| `ties`             | `number`                 | Cases where both passed                                    |
+| `bothFail`         | `number`                 | Cases where both failed                                    |
+| `decidedCases`     | `number`                 | `aWins + bWins + ties` (excludes `BOTH_FAIL`)              |
+| `aWinRate`         | `number`                 | `aWins / decidedCases`                                     |
+| `bWinRate`         | `number`                 | `bWins / decidedCases`                                     |
+| `tieRate`          | `number`                 | `ties / decidedCases`                                      |
+| `failureAlignment` | `number`                 | `bothFail / total` — fraction of cases both servers failed |
+| `cases`            | `CaseComparisonResult[]` | Per-case outcomes with full result objects                 |
+
+Win rates exclude `BOTH_FAIL` cases from the denominator. A high `failureAlignment` indicates that the failing cases are a dataset quality problem, not a difference between servers.
+
+### When to use it
+
+- **Comparing server versions before and after a refactor.** Run your eval suite with the old server as A and the new server as B. Cases where B wins are improvements; cases where A wins are regressions.
+- **A/B testing tool descriptions.** Point A at a server running with your current descriptions and B at a variant. Win rates quantify which description set performs better on real scenarios.
+- **Validating that a new transport or auth layer is equivalent.** Connect A via HTTP and B via stdio (or A with token auth and B with OAuth). A perfect result is all ties.
+
+### Configuration
+
+`runServerComparison` accepts `ServerComparisonOptions`, which is `EvalRunnerOptions` without `saveResultsTo` or `baselineResultsFrom` (baseline fields do not apply to comparisons). All other options — `concurrency`, `defaultLlmIterations`, `filterTags`, etc. — are shared between both server runs.
+
+To construct the second context, create a client with `createMCPClientForConfig` and wrap it with `createMCPFixture`:
+
+```typescript
+const clientB = await createMCPClientForConfig({
+  transport: 'stdio',
+  command: 'node',
+  args: ['server-v2.js'],
+});
+const mcpB = createMCPFixture(clientB);
+```
+
+Remember to close the second client in a `finally` block.
+
+### Full example
+
+<!-- snippet=snippets/server-comparison.ts -->
+
+```typescript
+import { test } from '@gleanwork/mcp-server-tester/fixtures/mcp';
+import {
+  loadEvalDataset,
+  runServerComparison,
+  createMCPClientForConfig,
+  createMCPFixture,
+  closeMCPClient,
+} from '@gleanwork/mcp-server-tester';
+
+test('compare two server versions', async ({ mcp: mcpA }, testInfo) => {
+  const dataset = await loadEvalDataset('./data/evals.json');
+
+  // Build a second MCP context for server B.
+  const clientB = await createMCPClientForConfig({
+    transport: 'stdio',
+    command: 'node',
+    args: ['server-v2.js'],
+  });
+  const mcpB = createMCPFixture(clientB);
+
+  try {
+    const comparison = await runServerComparison(
+      { dataset },
+      { mcp: mcpA, testInfo },
+      { mcp: mcpB }
+    );
+
+    console.log(`Total cases compared: ${comparison.total}`);
+    console.log(
+      `Server A win rate: ${(comparison.aWinRate * 100).toFixed(1)}%`
+    );
+    console.log(
+      `Server B win rate: ${(comparison.bWinRate * 100).toFixed(1)}%`
+    );
+    console.log(`Tie rate: ${(comparison.tieRate * 100).toFixed(1)}%`);
+    console.log(
+      `Both failed: ${comparison.bothFail} cases (${(comparison.failureAlignment * 100).toFixed(1)}% failure alignment)`
+    );
+
+    // Inspect decisive per-case outcomes.
+    for (const c of comparison.cases) {
+      if (c.outcome !== 'TIE' && c.outcome !== 'BOTH_FAIL') {
+        console.log(`  ${c.id}: ${c.outcome}`);
+      }
+    }
+  } finally {
+    await closeMCPClient(clientB);
+  }
+});
+```
+
+---
+
 ## Where to Go From Here
 
 1. **Start with direct mode** — Build smoke tests for every tool before adding LLM host cases. You need to know the tools work before testing whether they're discoverable.

--- a/docs/transports.md
+++ b/docs/transports.md
@@ -29,7 +29,7 @@ The stdio transport starts a local MCP server as a child process and communicate
 
 ### Basic Configuration
 
-```typescript
+```typescript snippet=snippets/transport-stdio-config.ts
 // playwright.config.ts
 import { defineConfig } from '@playwright/test';
 
@@ -148,7 +148,7 @@ The HTTP transport connects to a remote MCP server via HTTP and Server-Sent Even
 
 ### Basic Configuration
 
-```typescript
+```typescript snippet=snippets/transport-http-config.ts
 // playwright.config.ts
 import { defineConfig } from '@playwright/test';
 
@@ -245,7 +245,7 @@ The HTTP transport:
 
 Test against multiple server configurations using Playwright projects:
 
-```typescript
+```typescript snippet=snippets/transport-multi-config.ts
 import { defineConfig } from '@playwright/test';
 
 export default defineConfig({

--- a/snippets/auth-cli-oauth-client.ts
+++ b/snippets/auth-cli-oauth-client.ts
@@ -1,0 +1,10 @@
+import { CLIOAuthClient } from '@gleanwork/mcp-server-tester';
+
+const client = new CLIOAuthClient({
+  mcpServerUrl: 'https://api.example.com/mcp',
+});
+
+// Get a valid access token (cached, refreshed, or new)
+const result = await client.getAccessToken();
+console.log(`Token: ${result.accessToken}`);
+console.log(`Expires: ${new Date(result.expiresAt!).toLocaleString()}`);

--- a/snippets/auth-client-credentials.ts
+++ b/snippets/auth-client-credentials.ts
@@ -1,0 +1,28 @@
+import { defineConfig } from '@playwright/test';
+import type { MCPClientCredentialsConfig } from '@gleanwork/mcp-server-tester';
+
+const clientCredentials: MCPClientCredentialsConfig = {
+  // clientId and clientSecret can be omitted when MCP_CLIENT_ID / MCP_CLIENT_SECRET
+  // environment variables are set. Provide them here to override the env vars.
+  clientId: process.env.MCP_CLIENT_ID,
+  clientSecret: process.env.MCP_CLIENT_SECRET,
+  tokenEndpoint: 'https://auth.example.com/oauth/token',
+  scopes: ['mcp:read', 'mcp:write'],
+};
+
+export default defineConfig({
+  projects: [
+    {
+      name: 'mcp-client-credentials',
+      use: {
+        mcpConfig: {
+          transport: 'http',
+          serverUrl: 'https://api.example.com/mcp',
+          auth: {
+            clientCredentials,
+          },
+        },
+      },
+    },
+  ],
+});

--- a/snippets/auth-inject-tokens.ts
+++ b/snippets/auth-inject-tokens.ts
@@ -1,0 +1,9 @@
+// globalSetup.ts
+import { injectTokens } from '@gleanwork/mcp-server-tester';
+
+export default async function globalSetup() {
+  await injectTokens('https://api.example.com/mcp', {
+    accessToken: process.env.MCP_ACCESS_TOKEN!,
+    tokenType: 'Bearer',
+  });
+}

--- a/snippets/auth-oauth-provider-transport.ts
+++ b/snippets/auth-oauth-provider-transport.ts
@@ -1,0 +1,18 @@
+import { PlaywrightOAuthClientProvider } from '@gleanwork/mcp-server-tester';
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
+
+// Create provider for MCP SDK
+const provider = new PlaywrightOAuthClientProvider({
+  storagePath: 'playwright/.auth/mcp-oauth-state.json',
+  redirectUri: 'http://localhost:3000/oauth/callback',
+  clientId: process.env.MCP_OAUTH_CLIENT_ID,
+  clientSecret: process.env.MCP_OAUTH_CLIENT_SECRET,
+});
+
+// Use with StreamableHTTPClientTransport
+const serverUrl = new URL('https://api.example.com/mcp');
+const transport = new StreamableHTTPClientTransport(serverUrl, {
+  authProvider: provider,
+});
+
+export { provider, transport };

--- a/snippets/auth-playwright-oauth-provider.ts
+++ b/snippets/auth-playwright-oauth-provider.ts
@@ -1,0 +1,44 @@
+import { chromium } from '@playwright/test';
+import { PlaywrightOAuthClientProvider } from '@gleanwork/mcp-server-tester';
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+
+export default async function globalSetup() {
+  const provider = new PlaywrightOAuthClientProvider({
+    storagePath: 'playwright/.auth/mcp-oauth-state.json',
+    redirectUri: 'http://localhost:3000/oauth/callback',
+    clientId: process.env.MCP_OAUTH_CLIENT_ID,
+    clientSecret: process.env.MCP_OAUTH_CLIENT_SECRET,
+  });
+
+  const browser = await chromium.launch({ headless: true });
+  const page = await browser.newPage();
+
+  // Automate your IdP's login UI to acquire OAuth tokens.
+  // The provider handles PKCE, state management, token exchange, and storage.
+  await page.goto('https://auth.example.com/login');
+  await page.fill('#username', process.env.TEST_USERNAME!);
+  await page.fill('#password', process.env.TEST_PASSWORD!);
+  await page.click('#submit-button');
+
+  if (await page.isVisible('#mfa-input')) {
+    await page.fill('#mfa-input', process.env.TEST_MFA_CODE!);
+    await page.click('#verify-mfa');
+  }
+
+  if (await page.isVisible('#consent-form')) {
+    await page.click('#authorize-button');
+  }
+
+  await browser.close();
+
+  // Use the provider as the authProvider for StreamableHTTPClientTransport
+  const serverUrl = new URL('https://api.example.com/mcp');
+  const transport = new StreamableHTTPClientTransport(serverUrl, {
+    authProvider: provider,
+  });
+
+  const client = new Client({ name: 'test-client', version: '1.0.0' });
+  await client.connect(transport);
+  await client.close();
+}

--- a/snippets/baseline-comparison.ts
+++ b/snippets/baseline-comparison.ts
@@ -1,0 +1,61 @@
+import { test, expect } from '@gleanwork/mcp-server-tester/fixtures/mcp';
+import {
+  loadEvalDataset,
+  runEvalDataset,
+  saveBaseline,
+  loadBaseline,
+} from '@gleanwork/mcp-server-tester';
+
+// Capture a baseline after a known-good run.
+// Run this once on your main branch before making changes.
+test('capture baseline', async ({ mcp }, testInfo) => {
+  const dataset = await loadEvalDataset('./data/evals.json');
+
+  const result = await runEvalDataset(
+    {
+      dataset,
+      saveResultsTo: '.mcp-test-results/baseline.json',
+    },
+    { mcp, testInfo }
+  );
+
+  expect(result.passed).toBe(result.total);
+});
+
+// Re-run after code or description changes and compare against the baseline.
+test('detect regressions', async ({ mcp }, testInfo) => {
+  const dataset = await loadEvalDataset('./data/evals.json');
+
+  const result = await runEvalDataset(
+    {
+      dataset,
+      baselineResultsFrom: '.mcp-test-results/baseline.json',
+    },
+    { mcp, testInfo }
+  );
+
+  // Fail the test if any previously passing case now fails.
+  expect(result.regressions).toBe(0);
+
+  // Log a summary of the comparison.
+  if (result.deltaPassRate !== undefined) {
+    const delta = (result.deltaPassRate * 100).toFixed(1);
+    const sign = result.deltaPassRate >= 0 ? '+' : '';
+    console.log(`Pass rate delta vs baseline: ${sign}${delta}%`);
+    console.log(`Regressions: ${result.regressions ?? 0}`);
+    console.log(`Improvements: ${result.improvements ?? 0}`);
+  }
+});
+
+// Use saveBaseline and loadBaseline directly for custom scripting.
+test('manual baseline management', async ({ mcp }, testInfo) => {
+  const dataset = await loadEvalDataset('./data/evals.json');
+  const result = await runEvalDataset({ dataset }, { mcp, testInfo });
+
+  // Write the result as the new baseline.
+  await saveBaseline(result, '.mcp-test-results/baseline.json');
+
+  // Load it back and inspect it.
+  const saved = await loadBaseline('.mcp-test-results/baseline.json');
+  console.log(`Baseline has ${saved.total} cases, ${saved.passed} passing`);
+});

--- a/snippets/server-comparison.ts
+++ b/snippets/server-comparison.ts
@@ -1,0 +1,49 @@
+import { test } from '@gleanwork/mcp-server-tester/fixtures/mcp';
+import {
+  loadEvalDataset,
+  runServerComparison,
+  createMCPClientForConfig,
+  createMCPFixture,
+  closeMCPClient,
+} from '@gleanwork/mcp-server-tester';
+
+test('compare two server versions', async ({ mcp: mcpA }, testInfo) => {
+  const dataset = await loadEvalDataset('./data/evals.json');
+
+  // Build a second MCP context for server B.
+  const clientB = await createMCPClientForConfig({
+    transport: 'stdio',
+    command: 'node',
+    args: ['server-v2.js'],
+  });
+  const mcpB = createMCPFixture(clientB);
+
+  try {
+    const comparison = await runServerComparison(
+      { dataset },
+      { mcp: mcpA, testInfo },
+      { mcp: mcpB }
+    );
+
+    console.log(`Total cases compared: ${comparison.total}`);
+    console.log(
+      `Server A win rate: ${(comparison.aWinRate * 100).toFixed(1)}%`
+    );
+    console.log(
+      `Server B win rate: ${(comparison.bWinRate * 100).toFixed(1)}%`
+    );
+    console.log(`Tie rate: ${(comparison.tieRate * 100).toFixed(1)}%`);
+    console.log(
+      `Both failed: ${comparison.bothFail} cases (${(comparison.failureAlignment * 100).toFixed(1)}% failure alignment)`
+    );
+
+    // Inspect decisive per-case outcomes.
+    for (const c of comparison.cases) {
+      if (c.outcome !== 'TIE' && c.outcome !== 'BOTH_FAIL') {
+        console.log(`  ${c.id}: ${c.outcome}`);
+      }
+    }
+  } finally {
+    await closeMCPClient(clientB);
+  }
+});

--- a/snippets/transport-http-config.ts
+++ b/snippets/transport-http-config.ts
@@ -1,0 +1,16 @@
+// playwright.config.ts
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  projects: [
+    {
+      name: 'mcp-remote',
+      use: {
+        mcpConfig: {
+          transport: 'http',
+          serverUrl: 'http://localhost:3000/mcp',
+        },
+      },
+    },
+  ],
+});

--- a/snippets/transport-multi-config.ts
+++ b/snippets/transport-multi-config.ts
@@ -1,0 +1,59 @@
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  projects: [
+    // Local development server
+    {
+      name: 'local-dev',
+      use: {
+        mcpConfig: {
+          transport: 'stdio',
+          command: 'node',
+          args: ['dist/server.js'],
+          env: { NODE_ENV: 'development' },
+        },
+      },
+    },
+
+    // Local production build
+    {
+      name: 'local-prod',
+      use: {
+        mcpConfig: {
+          transport: 'stdio',
+          command: 'node',
+          args: ['dist/server.js'],
+          env: { NODE_ENV: 'production' },
+        },
+      },
+    },
+
+    // Staging server
+    {
+      name: 'staging',
+      use: {
+        mcpConfig: {
+          transport: 'http',
+          serverUrl: 'https://staging.example.com/mcp',
+          headers: {
+            Authorization: `Bearer ${process.env.STAGING_TOKEN}`,
+          },
+        },
+      },
+    },
+
+    // Production server
+    {
+      name: 'production',
+      use: {
+        mcpConfig: {
+          transport: 'http',
+          serverUrl: 'https://api.example.com/mcp',
+          headers: {
+            Authorization: `Bearer ${process.env.PROD_TOKEN}`,
+          },
+        },
+      },
+    },
+  ],
+});

--- a/snippets/transport-stdio-config.ts
+++ b/snippets/transport-stdio-config.ts
@@ -1,0 +1,17 @@
+// playwright.config.ts
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  projects: [
+    {
+      name: 'mcp-local',
+      use: {
+        mcpConfig: {
+          transport: 'stdio',
+          command: 'node',
+          args: ['path/to/server.js'],
+        },
+      },
+    },
+  ],
+});

--- a/snippets/transport-stdio-options.ts
+++ b/snippets/transport-stdio-options.ts
@@ -1,0 +1,12 @@
+import type { StdioMCPConfig } from '@gleanwork/mcp-server-tester';
+
+export function getStdioConfig(): StdioMCPConfig {
+  return {
+    transport: 'stdio',
+    command: 'node',
+    args: ['server.js'],
+    env: {
+      NODE_ENV: 'test',
+    },
+  };
+}


### PR DESCRIPTION
## Summary

Three previously undocumented exported features now have full docs and compilable snippet files.

## Client Credentials Grant (`docs/authentication.md`)

- New section with field table for all `MCPClientCredentialsConfig` fields
- Env var fallback precedence (`MCP_CLIENT_ID` / `MCP_CLIENT_SECRET`)
- Auth mode comparison table for choosing between client credentials, OAuth, and static token

## Baseline Regression Detection (`docs/evals-guide.md`)

- Covers `saveResultsTo`, `baselineResultsFrom`, `saveBaseline`, `loadBaseline`
- Field table for `regressions` / `improvements` / `deltaPassRate` / `baselinePass`
- Three-step practical workflow

## Server Comparison A/B Testing (`docs/evals-guide.md`)

- Covers `runServerComparison` with all four `ComparisonOutcome` values
- Explains why `BOTH_FAIL` is excluded from win rates
- Three concrete use cases

## Snippet coverage expansion

7 additional code blocks in `authentication.md`, `cli.md`, and `transports.md` wired to linted snippet source files. Notable: `docs:sync` caught that the Custom Login Flow example had two fictitious `PlaywrightOAuthClientProvider` methods and corrected the doc to match the real API.

## Test Plan
- [ ] `npm run docs:check` passes
- [ ] `npm run lint` passes
- [ ] `npm run typecheck` passes
- [ ] `npm run format:check` passes