### PR TITLE
feat: omit tool responses from saved baseline files by default

### DIFF
--- a/src/evals/baseline.ts
+++ b/src/evals/baseline.ts
@@ -3,17 +3,46 @@ import { dirname } from 'path';
 import type { EvalRunnerResult } from './evalRunner.js';
 
 /**
+ * Options for saveBaseline
+ */
+export interface SaveBaselineOptions {
+  /**
+   * When true (default), strips the `response` field from each case result
+   * before saving. Keeps baseline files small and git-friendly — the baseline
+   * is a pass/fail record and the full response is not needed for comparison.
+   *
+   * Set to false to preserve the complete response in the saved file.
+   *
+   * @default true
+   */
+  omitResponses?: boolean;
+}
+
+/**
  * Saves eval results to a JSON file for use as a baseline in future runs.
  *
  * @param result - The eval run result to save
  * @param filePath - Path to write the JSON file (parent dirs created automatically)
+ * @param options - Save options
  */
 export async function saveBaseline(
   result: EvalRunnerResult,
-  filePath: string
+  filePath: string,
+  options: SaveBaselineOptions = {}
 ): Promise<void> {
+  const { omitResponses = true } = options;
+
+  const toSave = omitResponses
+    ? {
+        ...result,
+        caseResults: result.caseResults.map(
+          ({ response: _response, ...rest }) => rest
+        ),
+      }
+    : result;
+
   await mkdir(dirname(filePath), { recursive: true });
-  await writeFile(filePath, JSON.stringify(result, null, 2), 'utf8');
+  await writeFile(filePath, JSON.stringify(toSave, null, 2), 'utf8');
 }
 
 /**

--- a/src/evals/evalRunner.test.ts
+++ b/src/evals/evalRunner.test.ts
@@ -1013,6 +1013,44 @@ describe('saveResultsTo and baselineResultsFrom', () => {
     expect(saved.passed).toBe(1);
   });
 
+  it('omits response by default when saving baseline', async () => {
+    const mcp = createMockMCP({ content: [{ type: 'text', text: 'hello' }] });
+    const dataset = createDataset([
+      createEvalCase({ id: 'case-1', expect: { containsText: 'hello' } }),
+    ]);
+    const filePath = join(tmpDir, 'baseline-no-response.json');
+
+    await runEvalDataset(
+      { dataset, saveResultsTo: filePath },
+      createContext(mcp)
+    );
+
+    const raw = await readFile(filePath, 'utf8');
+    const saved = JSON.parse(raw) as {
+      caseResults: Array<{ response?: unknown }>;
+    };
+    expect(saved.caseResults[0]).not.toHaveProperty('response');
+  });
+
+  it('preserves response when omitResponsesFromBaseline is false', async () => {
+    const mcp = createMockMCP({ content: [{ type: 'text', text: 'hello' }] });
+    const dataset = createDataset([
+      createEvalCase({ id: 'case-1', expect: { containsText: 'hello' } }),
+    ]);
+    const filePath = join(tmpDir, 'baseline-with-response.json');
+
+    await runEvalDataset(
+      { dataset, saveResultsTo: filePath, omitResponsesFromBaseline: false },
+      createContext(mcp)
+    );
+
+    const raw = await readFile(filePath, 'utf8');
+    const saved = JSON.parse(raw) as {
+      caseResults: Array<{ response?: unknown }>;
+    };
+    expect(saved.caseResults[0]).toHaveProperty('response');
+  });
+
   it('computes deltaPassRate when baselineResultsFrom is set', async () => {
     const mcp = createMockMCP({ content: [{ type: 'text', text: 'hello' }] });
     const dataset = createDataset([

--- a/src/evals/evalRunner.ts
+++ b/src/evals/evalRunner.ts
@@ -220,6 +220,17 @@ export interface EvalRunnerOptions {
   saveResultsTo?: string;
 
   /**
+   * When true (default), strips the `response` field from each case result
+   * before saving the baseline file. Keeps baseline files small and git-friendly —
+   * the full tool response is not needed for pass/fail regression detection.
+   *
+   * Set to false to preserve complete responses in the saved file.
+   *
+   * @default true
+   */
+  omitResponsesFromBaseline?: boolean;
+
+  /**
    * If set, loads this file as the baseline and computes delta metrics vs the current run.
    * Populates `EvalRunnerResult.deltaPassRate`, `.regressions`, `.improvements`,
    * and tags each `EvalCaseResult.baselinePass`.
@@ -841,6 +852,7 @@ export async function runEvalDataset(
     onCaseComplete,
     filterTags,
     saveResultsTo,
+    omitResponsesFromBaseline = true,
     baselineResultsFrom,
     mcpHostModel,
     judgeModel,
@@ -1025,7 +1037,9 @@ export async function runEvalDataset(
 
   // Save results to file if requested
   if (saveResultsTo) {
-    await saveBaseline(result, saveResultsTo);
+    await saveBaseline(result, saveResultsTo, {
+      omitResponses: omitResponsesFromBaseline,
+    });
   }
 
   // Attach results for MCP reporter if testInfo is provided

--- a/src/index.ts
+++ b/src/index.ts
@@ -191,7 +191,11 @@ export type {
 export { runEvalDataset, runEvalCase } from './evals/evalRunner.js';
 
 // Baseline eval comparison
-export { saveBaseline, loadBaseline } from './evals/baseline.js';
+export {
+  saveBaseline,
+  loadBaseline,
+  type SaveBaselineOptions,
+} from './evals/baseline.js';
 
 // Multi-server A/B comparison
 export type {


### PR DESCRIPTION
## Summary

`saveBaseline()` now accepts `{ omitResponses: true }` (the default) which strips `response` from each `EvalCaseResult` before writing to disk. Baseline files are pass/fail records — the full tool response is never read back during regression comparison, so storing it just bloats the file.

**Before:** baseline.json contained full tool responses for every case, making them impractical to commit.

**After:** baseline.json contains only the fields needed for regression detection (`id`, `pass`, `assertionPassRate`, etc.). Much smaller, git-friendly.

**API:**
```typescript
// Default — responses omitted (new behavior)
saveBaseline(result, path)
saveBaseline(result, path, { omitResponses: true })

// Opt in to full responses
saveBaseline(result, path, { omitResponses: false })

// Via runEvalDataset
runEvalDataset({ dataset, saveResultsTo: path })                           // omits responses (default)
runEvalDataset({ dataset, saveResultsTo: path, omitResponsesFromBaseline: false }) // full responses
```

## Test Plan
- [x] New test: `omits response by default when saving baseline`
- [x] New test: `preserves response when omitResponsesFromBaseline is false`
- [x] `npm run test:all` — 815 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)