### PR TITLE
feat: add Claude Code as a built-in CLI host provider for mcp_host mode

### DIFF
--- a/src/evals/datasetTypes.ts
+++ b/src/evals/datasetTypes.ts
@@ -300,6 +300,7 @@ const MCPHostConfigSchema = z.object({
     'openrouter',
     'xai',
     'vertex-anthropic',
+    'claude-code',
   ]),
   apiKeyEnvVar: z.string().optional(),
   model: z.string().optional(),

--- a/src/evals/evalRunner.ts
+++ b/src/evals/evalRunner.ts
@@ -1,4 +1,5 @@
 import type { MCPFixtureApi } from '../mcp/fixtures/mcpFixture.js';
+import type { MCPConfig } from '../config/mcpConfig.js';
 import type { EvalDataset, EvalCase, EvalExpectBlock } from './datasetTypes.js';
 import type { TestInfo, Expect } from '@playwright/test';
 import type { ZodType } from 'zod';
@@ -50,6 +51,9 @@ export interface EvalContext {
    * Required for snapshot expectations to work properly
    */
   expect?: Expect;
+
+  /** MCP server config — required for CLI host providers (e.g., 'claude-code'). */
+  mcpConfig?: MCPConfig;
 }
 
 export type { EvalExpectationResult } from '../types/index.js';
@@ -273,7 +277,8 @@ export interface EvalCaseOptions {
 
 async function executeToolCall(
   evalCase: EvalCase,
-  mcp: MCPFixtureApi
+  mcp: MCPFixtureApi,
+  mcpConfig?: MCPConfig
 ): Promise<{ response: unknown; error?: string }> {
   const mode = evalCase.mode || 'direct';
 
@@ -295,7 +300,8 @@ async function executeToolCall(
       const simulationResult = await simulateMCPHost(
         mcp,
         evalCase.scenario,
-        evalCase.mcpHostConfig
+        evalCase.mcpHostConfig,
+        mcpConfig
       );
 
       if (!simulationResult.success) {
@@ -564,8 +570,18 @@ async function runSingleIteration(
 ): Promise<EvalCaseResult> {
   const startTime = Date.now();
 
+  // Resolve mcpConfig: explicit context > testInfo fallback
+  const mcpConfig =
+    context.mcpConfig ??
+    (context.testInfo?.project?.use as { mcpConfig?: MCPConfig } | undefined)
+      ?.mcpConfig;
+
   // Execute tool call
-  const { response, error } = await executeToolCall(evalCase, context.mcp);
+  const { response, error } = await executeToolCall(
+    evalCase,
+    context.mcp,
+    mcpConfig
+  );
 
   // Collect expectation results from expect block
   let expectationResults: EvalCaseResult['expectations'] = {};

--- a/src/evals/mcpHost/adapters/cli/claudeCode.test.ts
+++ b/src/evals/mcpHost/adapters/cli/claudeCode.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect } from 'vitest';
+import { claudeCodeAdapter } from './claudeCode.js';
+import type {
+  StdioMCPConfig,
+  HttpMCPConfig,
+} from '../../../../config/mcpConfig.js';
+
+describe('claudeCodeAdapter', () => {
+  describe('buildCommand', () => {
+    it('builds command for stdio transport', () => {
+      const mcpConfig: StdioMCPConfig = {
+        transport: 'stdio',
+        command: 'node',
+        args: ['server.js'],
+        env: { DEBUG: '1' },
+      };
+
+      const invocation = claudeCodeAdapter.buildCommand(
+        'Find docs about testing',
+        mcpConfig
+      );
+
+      expect(invocation.command).toBe('claude');
+      expect(invocation.args).toContain('-p');
+      expect(invocation.args).toContain('Find docs about testing');
+      expect(invocation.args).toContain('--output-format');
+      expect(invocation.args).toContain('stream-json');
+      expect(invocation.args).toContain('--verbose');
+      expect(invocation.args).toContain('--allowedTools');
+      expect(invocation.args).toContain('mcp__test-server__*');
+
+      // Check MCP config JSON
+      const mcpConfigIdx = invocation.args.indexOf('--mcp-config');
+      const mcpConfigJson = JSON.parse(
+        invocation.args[mcpConfigIdx + 1]!
+      ) as Record<string, unknown>;
+      expect(mcpConfigJson).toEqual({
+        mcpServers: {
+          'test-server': {
+            command: 'node',
+            args: ['server.js'],
+            env: { DEBUG: '1' },
+          },
+        },
+      });
+    });
+
+    it('builds command for HTTP transport', () => {
+      const mcpConfig: HttpMCPConfig = {
+        transport: 'http',
+        serverUrl: 'http://localhost:3000/mcp',
+      };
+
+      const invocation = claudeCodeAdapter.buildCommand('scenario', mcpConfig);
+
+      const mcpConfigIdx = invocation.args.indexOf('--mcp-config');
+      const mcpConfigJson = JSON.parse(
+        invocation.args[mcpConfigIdx + 1]!
+      ) as Record<string, unknown>;
+      expect(mcpConfigJson).toEqual({
+        mcpServers: {
+          'test-server': {
+            type: 'http',
+            url: 'http://localhost:3000/mcp',
+          },
+        },
+      });
+    });
+
+    it('includes model when specified', () => {
+      const mcpConfig: StdioMCPConfig = {
+        transport: 'stdio',
+        command: 'node',
+        args: [],
+      };
+      const invocation = claudeCodeAdapter.buildCommand('scenario', mcpConfig, {
+        model: 'sonnet',
+      });
+
+      expect(invocation.args).toContain('--model');
+      expect(invocation.args).toContain('sonnet');
+    });
+
+    it('uses custom binary when specified', () => {
+      const mcpConfig: StdioMCPConfig = {
+        transport: 'stdio',
+        command: 'node',
+        args: [],
+      };
+      const invocation = claudeCodeAdapter.buildCommand('scenario', mcpConfig, {
+        binary: '/usr/local/bin/claude',
+      });
+
+      expect(invocation.command).toBe('/usr/local/bin/claude');
+    });
+  });
+
+  describe('parseOutput', () => {
+    it('delegates to parseStreamJson', () => {
+      const stdout = JSON.stringify({
+        type: 'assistant',
+        message: {
+          content: [{ type: 'text', text: 'Hello' }],
+        },
+      });
+
+      const result = claudeCodeAdapter.parseOutput(stdout);
+      expect(result.success).toBe(true);
+      expect(result.response).toBe('Hello');
+    });
+  });
+});

--- a/src/evals/mcpHost/adapters/cli/claudeCode.ts
+++ b/src/evals/mcpHost/adapters/cli/claudeCode.ts
@@ -1,0 +1,69 @@
+import { isStdioConfig, type MCPConfig } from '../../../../config/mcpConfig.js';
+import type { CLIHostAdapter, CLIInvocation, CLIHostOptions } from './types.js';
+import { parseStreamJson } from './parsers.js';
+
+const DEFAULT_BINARY = 'claude';
+const DEFAULT_TIMEOUT = 120_000; // 2 minutes — LLM calls can be slow
+
+function toClaudeCodeMCPConfig(mcpConfig: MCPConfig): Record<string, unknown> {
+  if (isStdioConfig(mcpConfig)) {
+    const server: Record<string, unknown> = {
+      command: mcpConfig.command,
+    };
+    if (mcpConfig.args) server.args = mcpConfig.args;
+    if (mcpConfig.env) server.env = mcpConfig.env;
+
+    return {
+      mcpServers: {
+        'test-server': server,
+      },
+    };
+  }
+
+  const server: Record<string, unknown> = {
+    type: 'http',
+    url: mcpConfig.serverUrl,
+  };
+  if (mcpConfig.headers) server.headers = mcpConfig.headers;
+
+  return {
+    mcpServers: {
+      'test-server': server,
+    },
+  };
+}
+
+export const claudeCodeAdapter: CLIHostAdapter = {
+  buildCommand(
+    scenario: string,
+    mcpConfig: MCPConfig,
+    options?: CLIHostOptions
+  ): CLIInvocation {
+    const binary = options?.binary ?? DEFAULT_BINARY;
+    const mcpConfigJson = JSON.stringify(toClaudeCodeMCPConfig(mcpConfig));
+
+    const args = [
+      '-p',
+      scenario,
+      '--output-format',
+      'stream-json',
+      '--verbose',
+      '--mcp-config',
+      mcpConfigJson,
+      '--allowedTools',
+      'mcp__test-server__*',
+    ];
+
+    if (options?.model) {
+      args.push('--model', options.model);
+    }
+
+    return {
+      command: binary,
+      args,
+      timeout: DEFAULT_TIMEOUT,
+    };
+  },
+
+  parseOutput: parseStreamJson,
+};

--- a/src/evals/mcpHost/adapters/cli/index.ts
+++ b/src/evals/mcpHost/adapters/cli/index.ts
@@ -1,0 +1,8 @@
+/**
+ * CLI Host Adapters — Claude Code
+ *
+ * Built-in Claude Code CLI adapter for mcp_host mode.
+ */
+
+export { claudeCodeAdapter } from './claudeCode.js';
+export { runCLIHost } from './runner.js';

--- a/src/evals/mcpHost/adapters/cli/parsers.test.ts
+++ b/src/evals/mcpHost/adapters/cli/parsers.test.ts
@@ -1,0 +1,249 @@
+import { describe, it, expect } from 'vitest';
+import { parseStreamJson, createJsonParser } from './parsers.js';
+
+describe('parseStreamJson', () => {
+  it('extracts tool calls from assistant messages', () => {
+    const stdout = [
+      JSON.stringify({
+        type: 'assistant',
+        message: {
+          role: 'assistant',
+          content: [
+            {
+              type: 'tool_use',
+              id: 'toolu_123',
+              name: 'mcp__test-server__search',
+              input: { query: 'test' },
+            },
+          ],
+        },
+      }),
+      JSON.stringify({
+        type: 'assistant',
+        message: {
+          role: 'assistant',
+          content: [{ type: 'text', text: 'Here are the results' }],
+        },
+      }),
+    ].join('\n');
+
+    const result = parseStreamJson(stdout);
+    expect(result.success).toBe(true);
+    expect(result.toolCalls).toHaveLength(1);
+    expect(result.toolCalls[0]).toEqual({
+      name: 'search',
+      arguments: { query: 'test' },
+      id: 'toolu_123',
+    });
+    expect(result.response).toBe('Here are the results');
+  });
+
+  it('strips mcp__ prefix from tool names', () => {
+    const stdout = JSON.stringify({
+      type: 'assistant',
+      message: {
+        content: [
+          {
+            type: 'tool_use',
+            name: 'mcp__test-server__get_weather',
+            input: { city: 'London' },
+          },
+        ],
+      },
+    });
+
+    const result = parseStreamJson(stdout);
+    expect(result.toolCalls[0]!.name).toBe('get_weather');
+  });
+
+  it('keeps non-MCP tool names as-is', () => {
+    const stdout = JSON.stringify({
+      type: 'assistant',
+      message: {
+        content: [
+          {
+            type: 'tool_use',
+            name: 'Bash',
+            input: { command: 'ls' },
+          },
+        ],
+      },
+    });
+
+    const result = parseStreamJson(stdout);
+    expect(result.toolCalls[0]!.name).toBe('Bash');
+  });
+
+  it('handles empty output', () => {
+    const result = parseStreamJson('');
+    expect(result.success).toBe(true);
+    expect(result.toolCalls).toHaveLength(0);
+    expect(result.response).toBeUndefined();
+  });
+
+  it('skips non-JSON lines', () => {
+    const stdout = [
+      'debug: starting up',
+      JSON.stringify({
+        type: 'assistant',
+        message: {
+          content: [{ type: 'text', text: 'Hello' }],
+        },
+      }),
+      'another debug line',
+    ].join('\n');
+
+    const result = parseStreamJson(stdout);
+    expect(result.response).toBe('Hello');
+  });
+
+  it('extracts tool results into conversation history', () => {
+    const stdout = JSON.stringify({
+      type: 'user',
+      message: {
+        content: [
+          {
+            type: 'tool_result',
+            tool_use_id: 'toolu_123',
+            content: '{"echo":"hello"}',
+          },
+        ],
+      },
+    });
+
+    const result = parseStreamJson(stdout);
+    expect(result.conversationHistory).toHaveLength(1);
+    expect(result.conversationHistory![0]).toEqual({
+      role: 'tool',
+      content: '{"echo":"hello"}',
+    });
+  });
+
+  it('handles final result event when no text was captured', () => {
+    const stdout = JSON.stringify({
+      type: 'result',
+      result: 'Final answer',
+    });
+
+    const result = parseStreamJson(stdout);
+    expect(result.response).toBe('Final answer');
+  });
+
+  it('prefers text from assistant messages over result event', () => {
+    const stdout = [
+      JSON.stringify({
+        type: 'assistant',
+        message: {
+          content: [{ type: 'text', text: 'From assistant' }],
+        },
+      }),
+      JSON.stringify({
+        type: 'result',
+        result: 'From result',
+      }),
+    ].join('\n');
+
+    const result = parseStreamJson(stdout);
+    expect(result.response).toBe('From assistant');
+  });
+
+  it('accumulates text from multiple assistant messages', () => {
+    const stdout = [
+      JSON.stringify({
+        type: 'assistant',
+        message: {
+          content: [{ type: 'text', text: 'Hello ' }],
+        },
+      }),
+      JSON.stringify({
+        type: 'assistant',
+        message: {
+          content: [{ type: 'text', text: 'world' }],
+        },
+      }),
+    ].join('\n');
+
+    const result = parseStreamJson(stdout);
+    expect(result.response).toBe('Hello world');
+  });
+
+  it('returns error when result event has is_error=true', () => {
+    const stdout = JSON.stringify({
+      type: 'result',
+      is_error: true,
+      result: 'Model not found',
+    });
+
+    const result = parseStreamJson(stdout);
+    expect(result.success).toBe(false);
+    expect(result.error).toBe('Model not found');
+  });
+
+  it('skips system events', () => {
+    const stdout = [
+      JSON.stringify({ type: 'system', subtype: 'init', tools: ['Bash'] }),
+      JSON.stringify({
+        type: 'assistant',
+        message: {
+          content: [{ type: 'text', text: 'Hi' }],
+        },
+      }),
+    ].join('\n');
+
+    const result = parseStreamJson(stdout);
+    expect(result.toolCalls).toHaveLength(0);
+    expect(result.response).toBe('Hi');
+  });
+});
+
+describe('createJsonParser', () => {
+  it('extracts fields using dot paths', () => {
+    const parser = createJsonParser({
+      toolCalls: 'result.tools',
+      response: 'result.text',
+    });
+
+    const stdout = JSON.stringify({
+      result: {
+        tools: [{ name: 'search', arguments: { q: 'test' } }],
+        text: 'Found results',
+      },
+    });
+
+    const result = parser(stdout);
+    expect(result.success).toBe(true);
+    expect(result.toolCalls).toHaveLength(1);
+    expect(result.toolCalls[0]!.name).toBe('search');
+    expect(result.response).toBe('Found results');
+  });
+
+  it('handles missing tool calls array', () => {
+    const parser = createJsonParser({
+      toolCalls: 'result.tools',
+      response: 'result.text',
+    });
+
+    const stdout = JSON.stringify({
+      result: { text: 'No tools used' },
+    });
+
+    const result = parser(stdout);
+    expect(result.toolCalls).toHaveLength(0);
+    expect(result.response).toBe('No tools used');
+  });
+
+  it('supports custom success path', () => {
+    const parser = createJsonParser({
+      toolCalls: 'data.calls',
+      response: 'data.answer',
+      success: 'data.ok',
+    });
+
+    const stdout = JSON.stringify({
+      data: { calls: [], answer: 'done', ok: false },
+    });
+
+    const result = parser(stdout);
+    expect(result.success).toBe(false);
+  });
+});

--- a/src/evals/mcpHost/adapters/cli/parsers.ts
+++ b/src/evals/mcpHost/adapters/cli/parsers.ts
@@ -1,0 +1,142 @@
+import type {
+  MCPHostSimulationResult,
+  LLMToolCall,
+} from '../../mcpHostTypes.js';
+
+/** Parses Claude Code `--output-format stream-json` NDJSON output. */
+export function parseStreamJson(stdout: string): MCPHostSimulationResult {
+  const lines = stdout.split('\n').filter((line) => line.trim().length > 0);
+  const toolCalls: LLMToolCall[] = [];
+  const textParts: string[] = [];
+  const conversationHistory: Array<{
+    role: 'user' | 'assistant' | 'tool';
+    content: string;
+  }> = [];
+
+  for (const line of lines) {
+    let event: StreamJsonEvent;
+    try {
+      event = JSON.parse(line) as StreamJsonEvent;
+    } catch {
+      // Skip non-JSON lines (e.g., debug output)
+      continue;
+    }
+
+    if (event.type === 'assistant' && event.message?.content) {
+      for (const block of event.message.content) {
+        if (block.type === 'tool_use' && block.name) {
+          const rawName = block.name;
+          const mcpMatch = /^mcp__[^_]+__(.+)$/.exec(rawName);
+          toolCalls.push({
+            name: mcpMatch ? mcpMatch[1]! : rawName,
+            arguments: block.input ?? {},
+            id: block.id,
+          });
+        }
+
+        if (block.type === 'text' && block.text) {
+          textParts.push(block.text);
+        }
+      }
+    }
+
+    if (event.type === 'user' && event.message?.content) {
+      for (const block of event.message.content) {
+        if (block.type === 'tool_result') {
+          const content =
+            typeof block.content === 'string'
+              ? block.content
+              : JSON.stringify(block.content);
+          conversationHistory.push({ role: 'tool', content });
+        }
+      }
+    }
+
+    if (event.type === 'result' && typeof event.result === 'string') {
+      if (textParts.length === 0) {
+        textParts.push(event.result);
+      }
+    }
+
+    if (event.type === 'result' && event.is_error === true) {
+      return {
+        success: false,
+        toolCalls,
+        error:
+          typeof event.result === 'string'
+            ? event.result
+            : 'CLI host reported an error',
+      };
+    }
+  }
+
+  const response = textParts.join('');
+
+  if (response) {
+    conversationHistory.push({ role: 'assistant', content: response });
+  }
+
+  return {
+    success: true,
+    toolCalls,
+    response: response || undefined,
+    conversationHistory:
+      conversationHistory.length > 0 ? conversationHistory : undefined,
+  };
+}
+
+/** Creates a parser for CLIs that output a single JSON object with configurable paths. */
+export function createJsonParser(paths: {
+  toolCalls: string;
+  response: string;
+  success?: string;
+}): (stdout: string) => MCPHostSimulationResult {
+  return (stdout: string): MCPHostSimulationResult => {
+    const data = JSON.parse(stdout) as Record<string, unknown>;
+
+    const rawToolCalls = getNestedValue(data, paths.toolCalls);
+    const toolCalls: LLMToolCall[] = Array.isArray(rawToolCalls)
+      ? rawToolCalls.map((tc: Record<string, unknown>) => ({
+          name: typeof tc.name === 'string' ? tc.name : '',
+          arguments: (tc.arguments ?? tc.args ?? {}) as Record<string, unknown>,
+        }))
+      : [];
+
+    const response = getNestedValue(data, paths.response);
+    const success = paths.success
+      ? Boolean(getNestedValue(data, paths.success))
+      : true;
+
+    return {
+      success,
+      toolCalls,
+      response: typeof response === 'string' ? response : undefined,
+    };
+  };
+}
+
+interface ContentBlock {
+  type: string;
+  id?: string;
+  name?: string;
+  input?: Record<string, unknown>;
+  text?: string;
+  content?: unknown;
+  tool_use_id?: string;
+}
+
+interface StreamJsonEvent {
+  type: string;
+  message?: { role?: string; content?: ContentBlock[] };
+  result?: string;
+  is_error?: boolean;
+}
+
+function getNestedValue(obj: Record<string, unknown>, path: string): unknown {
+  return path.split('.').reduce<unknown>((current, key) => {
+    if (current !== null && typeof current === 'object') {
+      return (current as Record<string, unknown>)[key];
+    }
+    return undefined;
+  }, obj);
+}

--- a/src/evals/mcpHost/adapters/cli/runner.ts
+++ b/src/evals/mcpHost/adapters/cli/runner.ts
@@ -1,0 +1,168 @@
+import { spawn } from 'node:child_process';
+import type { MCPConfig } from '../../../../config/mcpConfig.js';
+import type {
+  MCPHostSimulationResult,
+  LLMToolCall,
+} from '../../mcpHostTypes.js';
+import type { CLIHostAdapter, CLIHostOptions } from './types.js';
+
+const DEFAULT_TIMEOUT = 60_000;
+
+/** Runs a CLI host adapter: builds the command, spawns the process, parses output. */
+export async function runCLIHost(
+  adapter: CLIHostAdapter,
+  scenario: string,
+  mcpConfig: MCPConfig,
+  options?: CLIHostOptions
+): Promise<MCPHostSimulationResult> {
+  const invocation = adapter.buildCommand(scenario, mcpConfig, options);
+  const timeout = invocation.timeout ?? DEFAULT_TIMEOUT;
+
+  const startTime = Date.now();
+
+  let stdout: string;
+  let stderr = '';
+  try {
+    const result = await spawnProcess(invocation.command, invocation.args, {
+      env: { ...process.env, ...invocation.env },
+      timeout,
+    });
+    stdout = result.stdout;
+    stderr = result.stderr;
+  } catch (err) {
+    const elapsed = Date.now() - startTime;
+    const message = err instanceof Error ? err.message : String(err);
+
+    if (message.includes('TIMEOUT') || message.includes('timed out')) {
+      return {
+        success: false,
+        toolCalls: [],
+        error:
+          `CLI host timed out after ${elapsed}ms (limit: ${timeout}ms). ` +
+          `Increase timeout via mcpHostConfig.timeout or CLIInvocation.timeout.`,
+      };
+    }
+
+    return {
+      success: false,
+      toolCalls: [],
+      error: `CLI host process failed: ${message}${stderr ? `\nstderr: ${stderr}` : ''}`,
+    };
+  }
+
+  let result: MCPHostSimulationResult;
+  try {
+    result = adapter.parseOutput(stdout);
+  } catch (err) {
+    return {
+      success: false,
+      toolCalls: [],
+      error:
+        `Failed to parse CLI host output: ${err instanceof Error ? err.message : String(err)}` +
+        `\nstdout (first 500 chars): ${stdout.slice(0, 500)}`,
+    };
+  }
+
+  const validationError = validateSimulationResult(result);
+  if (validationError) {
+    return {
+      success: false,
+      toolCalls: [],
+      error: `CLI host adapter returned invalid result: ${validationError}`,
+    };
+  }
+
+  return result;
+}
+
+function validateSimulationResult(result: unknown): string | null {
+  if (result === null || typeof result !== 'object') {
+    return `Expected object, got ${typeof result}`;
+  }
+
+  const obj = result as Record<string, unknown>;
+
+  if (typeof obj.success !== 'boolean') {
+    return `"success" must be a boolean, got ${typeof obj.success}`;
+  }
+
+  if (!Array.isArray(obj.toolCalls)) {
+    return `"toolCalls" must be an array, got ${typeof obj.toolCalls}`;
+  }
+
+  for (let i = 0; i < obj.toolCalls.length; i++) {
+    const tc = obj.toolCalls[i] as LLMToolCall;
+    if (typeof tc.name !== 'string') {
+      return `toolCalls[${i}].name must be a string, got ${typeof tc.name}`;
+    }
+    if (typeof tc.arguments !== 'object' || tc.arguments === null) {
+      return `toolCalls[${i}].arguments must be an object, got ${typeof tc.arguments}`;
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Uses `spawn` (not `execFile`) so we can close stdin immediately —
+ * Claude Code waits for stdin input if it's left open.
+ */
+function spawnProcess(
+  command: string,
+  args: string[],
+  options: { env?: NodeJS.ProcessEnv; timeout: number }
+): Promise<{ stdout: string; stderr: string }> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, {
+      env: options.env,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+
+    child.stdin.end();
+
+    const stdoutChunks: Buffer[] = [];
+    const stderrChunks: Buffer[] = [];
+    let totalBytes = 0;
+    const MAX_BUFFER = 10 * 1024 * 1024; // 10MB
+
+    child.stdout.on('data', (chunk: Buffer) => {
+      totalBytes += chunk.length;
+      if (totalBytes <= MAX_BUFFER) {
+        stdoutChunks.push(chunk);
+      }
+    });
+
+    child.stderr.on('data', (chunk: Buffer) => {
+      totalBytes += chunk.length;
+      if (totalBytes <= MAX_BUFFER) {
+        stderrChunks.push(chunk);
+      }
+    });
+
+    const timer = setTimeout(() => {
+      child.kill('SIGTERM');
+      reject(new Error(`Process timed out after ${options.timeout}ms`));
+    }, options.timeout);
+
+    child.on('error', (err) => {
+      clearTimeout(timer);
+      reject(err);
+    });
+
+    child.on('close', (code) => {
+      clearTimeout(timer);
+      const stdout = Buffer.concat(stdoutChunks).toString('utf-8');
+      const stderr = Buffer.concat(stderrChunks).toString('utf-8');
+
+      if (code !== 0) {
+        const err = new Error(
+          `Command failed with exit code ${code ?? 'null'}${stderr ? `\nstderr: ${stderr}` : ''}`
+        );
+        reject(err);
+        return;
+      }
+
+      resolve({ stdout, stderr });
+    });
+  });
+}

--- a/src/evals/mcpHost/adapters/cli/types.ts
+++ b/src/evals/mcpHost/adapters/cli/types.ts
@@ -1,0 +1,26 @@
+import type { MCPConfig } from '../../../../config/mcpConfig.js';
+import type { MCPHostSimulationResult } from '../../mcpHostTypes.js';
+
+export interface CLIInvocation {
+  command: string;
+  args: string[];
+  env?: Record<string, string>;
+  timeout?: number;
+}
+
+export interface CLIHostAdapter {
+  buildCommand(
+    scenario: string,
+    mcpConfig: MCPConfig,
+    options?: CLIHostOptions
+  ): CLIInvocation;
+
+  parseOutput(stdout: string): MCPHostSimulationResult;
+}
+
+export interface CLIHostOptions {
+  model?: string;
+  maxToolCalls?: number;
+  temperature?: number;
+  binary?: string;
+}

--- a/src/evals/mcpHost/index.ts
+++ b/src/evals/mcpHost/index.ts
@@ -7,3 +7,6 @@
 
 export * from './mcpHostTypes.js';
 export * from './mcpHostSimulation.js';
+
+// Built-in Claude Code CLI adapter
+export { claudeCodeAdapter } from './adapters/cli/index.js';

--- a/src/evals/mcpHost/mcpHostSimulation.test.ts
+++ b/src/evals/mcpHost/mcpHostSimulation.test.ts
@@ -92,8 +92,11 @@ describe('isProviderAvailable', () => {
     });
   }
 
+  it('returns true for claude-code', () => {
+    expect(isProviderAvailable('claude-code')).toBe(true);
+  });
+
   it('returns false for unknown provider', () => {
-    // @ts-expect-error - testing invalid provider
     expect(isProviderAvailable('unknown')).toBe(false);
   });
 });
@@ -128,9 +131,22 @@ describe('getMissingDependencyMessage', () => {
     }
   });
 
+  it('returns CLI-specific message for claude-code', () => {
+    const msg = getMissingDependencyMessage('claude-code');
+    expect(msg).toContain('Claude Code CLI');
+  });
+
   it('returns generic message for unknown provider', () => {
-    // @ts-expect-error - testing invalid provider
     const msg = getMissingDependencyMessage('unknown');
     expect(msg).toContain('Unknown provider');
+  });
+});
+
+describe('claude-code CLI routing', () => {
+  it('throws when claude-code is used without mcpConfig', async () => {
+    const mcp = createMockMCP();
+    await expect(
+      simulateMCPHost(mcp, 'scenario', { provider: 'claude-code' })
+    ).rejects.toThrow('requires mcpConfig');
   });
 });

--- a/src/evals/mcpHost/mcpHostSimulation.ts
+++ b/src/evals/mcpHost/mcpHostSimulation.ts
@@ -1,12 +1,15 @@
 /**
  * MCP Host Simulation - Main entry point
  *
- * All providers (openai, anthropic, google, azure, mistral, deepseek,
+ * SDK providers (openai, anthropic, google, azure, mistral, deepseek,
  * openrouter, xai) run through the Vercel AI SDK orchestrator, which uses
- * generateText + stopWhen for a uniform multi-turn tool-calling loop with
- * built-in latency decomposition.
+ * generateText with maxSteps for a uniform multi-turn tool-calling loop
+ * with built-in latency decomposition.
  *
- * Required packages per provider:
+ * The 'claude-code' provider spawns the Claude Code CLI process instead,
+ * passing the MCP server config via `--mcp-config`.
+ *
+ * Required packages per SDK provider:
  *   openai      → npm install ai @ai-sdk/openai
  *   anthropic   → npm install ai @ai-sdk/anthropic
  *   google      → npm install ai @ai-sdk/google
@@ -18,19 +21,19 @@
  */
 
 import type { MCPFixtureApi } from '../../mcp/fixtures/mcpFixture.js';
+import type { MCPConfig } from '../../config/mcpConfig.js';
 import type {
   MCPHostConfig,
   MCPHostSimulationResult,
   MCPHostSimulator,
-  LLMProvider,
+  SDKProvider,
 } from './mcpHostTypes.js';
 import { createVercelOrchestrator } from './adapters/vercel.js';
+import { claudeCodeAdapter, runCLIHost } from './adapters/cli/index.js';
 
-// Single orchestrator instance shared across all providers.
-// Each provider is dynamically imported inside the orchestrator on first use.
 const vercelOrchestrator: MCPHostSimulator = createVercelOrchestrator();
 
-const allProviders: LLMProvider[] = [
+const sdkProviders: SDKProvider[] = [
   'openai',
   'anthropic',
   'azure',
@@ -42,8 +45,8 @@ const allProviders: LLMProvider[] = [
   'vertex-anthropic',
 ];
 
-const simulatorRegistry = new Map<LLMProvider, MCPHostSimulator>(
-  allProviders.map((p) => [p, vercelOrchestrator])
+const simulatorRegistry = new Map<string, MCPHostSimulator>(
+  sdkProviders.map((p) => [p, vercelOrchestrator])
 );
 
 /**
@@ -53,13 +56,10 @@ const simulatorRegistry = new Map<LLMProvider, MCPHostSimulator>(
  * schemas, testing discoverability and parameter clarity at the level a real
  * user (via Claude Desktop, ChatGPT, etc.) would experience.
  *
- * All providers run through the Vercel AI SDK's generateText with maxSteps,
- * which handles multi-turn tool calling natively and provides per-step latency
- * decomposition (llmDurationMs vs. mcpDurationMs).
- *
  * @param mcp - MCP fixture API
  * @param scenario - Natural language prompt describing what the LLM should do
  * @param config - MCP host configuration (provider, model, temperature, etc.)
+ * @param mcpConfig - MCP server connection details (required for 'claude-code' provider)
  * @returns Simulation result with tool calls, final response, and latency data
  *
  * @example
@@ -76,13 +76,29 @@ const simulatorRegistry = new Map<LLMProvider, MCPHostSimulator>(
 export async function simulateMCPHost(
   mcp: MCPFixtureApi,
   scenario: string,
-  config: MCPHostConfig
+  config: MCPHostConfig,
+  mcpConfig?: MCPConfig
 ): Promise<MCPHostSimulationResult> {
+  if (config.provider === 'claude-code') {
+    if (!mcpConfig) {
+      throw new Error(
+        `CLI host "claude-code" requires mcpConfig (the MCP server connection details) ` +
+          `to be available. Ensure mcpConfig is set in your Playwright project configuration ` +
+          `(project.use.mcpConfig in playwright.config.ts).`
+      );
+    }
+    return runCLIHost(claudeCodeAdapter, scenario, mcpConfig, {
+      model: config.model,
+      maxToolCalls: config.maxToolCalls,
+      temperature: config.temperature,
+    });
+  }
+
   const simulator = simulatorRegistry.get(config.provider);
   if (!simulator) {
     throw new Error(
-      `Unsupported provider: ${String(config.provider)}. ` +
-        `Supported: ${allProviders.join(', ')}`
+      `Unsupported provider: "${config.provider}". ` +
+        `Supported: ${[...sdkProviders, 'claude-code'].join(', ')}`
     );
   }
   return simulator.simulate(mcp, scenario, config);
@@ -94,8 +110,8 @@ export async function simulateMCPHost(
  * Note: this does not check whether the required @ai-sdk/* package is
  * installed — that is validated at simulation time with a helpful error.
  */
-export function isProviderAvailable(provider: LLMProvider): boolean {
-  return simulatorRegistry.has(provider);
+export function isProviderAvailable(provider: string): boolean {
+  return provider === 'claude-code' || simulatorRegistry.has(provider);
 }
 
 /**
@@ -104,8 +120,12 @@ export function isProviderAvailable(provider: LLMProvider): boolean {
  * @remarks This is a diagnostic utility for checking whether optional
  * @ai-sdk/* packages are installed. Not part of the primary usage path.
  */
-export function getMissingDependencyMessage(provider: LLMProvider): string {
-  const packageMap: Partial<Record<LLMProvider, string>> = {
+export function getMissingDependencyMessage(provider: string): string {
+  if (provider === 'claude-code') {
+    return 'claude-code requires the Claude Code CLI to be installed. See https://docs.anthropic.com/en/docs/claude-code';
+  }
+
+  const packageMap: Record<string, string> = {
     openai: 'npm install ai @ai-sdk/openai',
     anthropic: 'npm install ai @ai-sdk/anthropic',
     google: 'npm install ai @ai-sdk/google',

--- a/src/evals/mcpHost/mcpHostTypes.ts
+++ b/src/evals/mcpHost/mcpHostTypes.ts
@@ -8,9 +8,8 @@
 import type { MCPFixtureApi } from '../../mcp/fixtures/mcpFixture.js';
 
 /**
- * LLM provider for host simulation.
+ * SDK-based LLM providers that run through the Vercel AI SDK.
  *
- * All providers run through the Vercel AI SDK (`ai` package).
  * Each provider requires its corresponding @ai-sdk/* package:
  *
  *   openai      → npm install ai @ai-sdk/openai
@@ -22,7 +21,7 @@ import type { MCPFixtureApi } from '../../mcp/fixtures/mcpFixture.js';
  *   openrouter  → npm install ai @openrouter/ai-sdk-provider
  *   xai         → npm install ai @ai-sdk/xai
  */
-export type LLMProvider =
+export type SDKProvider =
   | 'openai'
   | 'anthropic'
   | 'azure'
@@ -39,6 +38,13 @@ export type LLMProvider =
    * @example model: 'claude-3-5-haiku@20241022'
    */
   | 'vertex-anthropic';
+
+/**
+ * LLM provider for host simulation.
+ *
+ * Includes SDK providers (Vercel AI SDK) and the built-in 'claude-code' CLI adapter.
+ */
+export type LLMProvider = SDKProvider | 'claude-code';
 
 /**
  * Configuration for MCP host simulation

--- a/src/index.ts
+++ b/src/index.ts
@@ -209,6 +209,7 @@ export { runServerComparison } from './evals/serverComparison.js';
 // MCP Host Simulation
 export type {
   LLMProvider,
+  SDKProvider,
   MCPHostConfig,
   LLMToolCall,
   MCPHostSimulationResult,
@@ -218,6 +219,7 @@ export {
   simulateMCPHost,
   isProviderAvailable,
   getMissingDependencyMessage,
+  claudeCodeAdapter,
 } from './evals/mcpHost/index.js';
 
 // Judge

--- a/tests/cli-host-smoke.spec.ts
+++ b/tests/cli-host-smoke.spec.ts
@@ -1,0 +1,42 @@
+/**
+ * Smoke test: CLI host (claude-code) with the mock MCP server.
+ *
+ * Verifies that the framework correctly:
+ * 1. Extracts mcpConfig from the Playwright project
+ * 2. Passes it to the Claude Code CLI adapter
+ * 3. The CLI connects to the MCP server and calls tools
+ */
+import { test, expect } from '../src/fixtures/mcp.js';
+import { simulateMCPHost } from '../src/evals/mcpHost/mcpHostSimulation.js';
+import type { MCPConfig } from '../src/config/mcpConfig.js';
+// Side-effect import: registers the built-in 'claude-code' adapter
+import '../src/evals/mcpHost/adapters/cli/index.js';
+
+test('claude-code CLI host calls echo tool via MCP', async ({
+  mcp,
+}, testInfo) => {
+  test.setTimeout(120_000);
+
+  const mcpConfig = (testInfo.project.use as { mcpConfig?: unknown }).mcpConfig;
+
+  const result = await simulateMCPHost(
+    mcp,
+    'Use the echo tool to echo the message "hello from cli host test"',
+    {
+      provider: 'claude-code',
+      model: 'sonnet',
+      maxToolCalls: 3,
+    },
+    mcpConfig as MCPConfig
+  );
+
+  console.log('=== CLI Host Result ===');
+  console.log('Success:', result.success);
+  console.log('Tool calls:', JSON.stringify(result.toolCalls, null, 2));
+  console.log('Response:', result.response?.slice(0, 200));
+  if (result.error) console.log('Error:', result.error);
+
+  expect(result.success).toBe(true);
+  expect(result.toolCalls.length).toBeGreaterThan(0);
+  expect(result.toolCalls.some((tc) => tc.name === 'echo')).toBe(true);
+});


### PR DESCRIPTION
Adds `provider: 'claude-code'` support for MCP host eval tests. Unlike SDK providers (Vercel AI SDK), the Claude Code CLI spawns a process that establishes its own MCP connection. The adapter translates the framework's MCPConfig into Claude Code's `--mcp-config` JSON format and parses NDJSON stream-json output.

Key changes:
- New `src/evals/mcpHost/adapters/cli/` module with types, runner, parsers, and the Claude Code adapter
- `simulateMCPHost()` now accepts optional `mcpConfig` parameter and routes 'claude-code' to the CLI adapter
- `evalRunner` resolves mcpConfig from EvalContext or testInfo fallback
- `LLMProvider` type expanded with `SDKProvider` base + 'claude-code'
- Zod schema updated to accept 'claude-code' provider