### PR TITLE
feat: include judge metadata in eval results

### DIFF
--- a/src/assertions/validators/judge.test.ts
+++ b/src/assertions/validators/judge.test.ts
@@ -239,8 +239,10 @@ describe('validateJudge', () => {
       consoleSpy.mockRestore();
     });
 
-    it('does not include details for single rep', async () => {
-      const mockJudge = makeMockJudge([{ score: 0.8, pass: true }]);
+    it('includes judge metadata but not rep-specific fields for single rep', async () => {
+      const mockJudge = makeMockJudge([
+        { score: 0.8, pass: true, reasoning: 'Looks good' },
+      ]);
       mockCreateJudge.mockReturnValue(mockJudge);
 
       const result = await validateJudge('response', {
@@ -248,7 +250,13 @@ describe('validateJudge', () => {
         reps: 1,
       });
 
-      expect(result.details).toBeUndefined();
+      expect(result.details).toBeDefined();
+      expect(result.details?.score).toBe(0.8);
+      expect(result.details?.reasoning).toBe('Looks good');
+      expect(result.details?.judgeProvider).toBe('anthropic');
+      // No rep-specific fields for single rep
+      expect(result.details?.scores).toBeUndefined();
+      expect(result.details?.scoreStdDev).toBeUndefined();
     });
   });
 

--- a/src/assertions/validators/judge.ts
+++ b/src/assertions/validators/judge.ts
@@ -158,14 +158,17 @@ export async function validateJudge(
       message: passed
         ? `Judge passed with score ${meanScore.toFixed(2)}${repNote}`
         : `Judge failed with score ${meanScore.toFixed(2)} (threshold: ${threshold})${repNote}. ${lastReasoning ?? ''}`,
-      details:
-        reps > 1
-          ? {
-              scores,
-              scoreStdDev: stdDev,
-              highVariance,
-            }
-          : undefined,
+      details: {
+        score: meanScore,
+        reasoning: lastReasoning,
+        judgeProvider: provider ?? 'anthropic',
+        judgeModel: model,
+        ...(reps > 1 && {
+          scores,
+          scoreStdDev: stdDev,
+          highVariance,
+        }),
+      },
     };
   } catch (err) {
     return {

--- a/src/evals/evalRunner.ts
+++ b/src/evals/evalRunner.ts
@@ -479,6 +479,10 @@ async function runExpectBlockValidations(
     results.judge = {
       pass: validation.pass,
       details: validation.message,
+      score: validation.details?.score as number | undefined,
+      reasoning: validation.details?.reasoning as string | undefined,
+      judgeProvider: validation.details?.judgeProvider as string | undefined,
+      judgeModel: validation.details?.judgeModel as string | undefined,
     };
   }
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -52,6 +52,26 @@ export interface EvalExpectationResult {
    * Optional details about the result
    */
   details?: string;
+
+  /**
+   * Judge score (0-1). Populated for passesJudge expectations.
+   */
+  score?: number;
+
+  /**
+   * Judge reasoning. Populated for passesJudge expectations.
+   */
+  reasoning?: string;
+
+  /**
+   * Judge provider used. Populated for passesJudge expectations.
+   */
+  judgeProvider?: string;
+
+  /**
+   * Judge model used. Populated for passesJudge expectations.
+   */
+  judgeModel?: string;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Add `score`, `reasoning`, `judgeProvider`, and `judgeModel` fields to `EvalExpectationResult`
- `validateJudge` now always populates `details` with judge metadata (previously only populated for multi-rep runs)
- `evalRunner` threads the metadata from validation results into expectation results

Before:
```json
{ "pass": true, "details": "Judge passed with score 1.00" }
```

After:
```json
{
  "pass": true,
  "details": "Judge passed with score 1.00",
  "score": 1.0,
  "reasoning": "The response fully addresses...",
  "judgeProvider": "anthropic",
  "judgeModel": "claude-sonnet-4-20250514"
}
```

## Test plan
- [x] Updated existing test for single-rep details behavior
- [x] All 821 tests pass
- [x] Typecheck, lint, format, build all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)