### PR TITLE
fix: case-insensitive AbortError check in eval runner

### DIFF
--- a/src/evals/evalRunner.ts
+++ b/src/evals/evalRunner.ts
@@ -701,7 +701,7 @@ function isInfrastructureError(err: unknown): boolean {
   }
 
   return (
-    name === 'AbortError' ||
+    name?.toLowerCase() === 'aborterror' ||
     msg.includes('econnreset') ||
     msg.includes('etimedout') ||
     msg.includes('econnrefused') ||


### PR DESCRIPTION
## Summary
- Fix case-sensitive `AbortError` name check in `evalRunner.ts:704`
- Changes `name === 'AbortError'` to `name?.toLowerCase() === 'aborterror'` to match the pattern used by all other error checks in the same block

## P0 release blocker
Windows Node.js can throw uppercase error names, causing infrastructure errors to be misclassified as assertion failures and breaking multi-iteration accuracy.

## Test plan
- [x] `npm run typecheck` passes
- [x] `npm test` passes (911 tests)

Closes CHK-001.

🤖 Generated with [Claude Code](https://claude.com/claude-code)