### PR TITLE
fix: export refreshAccessToken from public API

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -47,6 +47,7 @@ export {
 } from './auth/setupOAuth.js';
 export {
   performClientCredentialsFlow,
+  refreshAccessToken,
   type ClientCredentialsConfig,
 } from './auth/oauthFlow.js';
 


### PR DESCRIPTION
## Summary
- Add `refreshAccessToken` to the re-export block in `src/index.ts`
- The function exists at `src/auth/oauthFlow.ts:291` but was missing from the public API

## P0 release blocker
`docs/authentication.md:672` recommends `refreshAccessToken()` for token refresh. Users following the troubleshooting guide get a runtime import error.

## Test plan
- [x] `npm run typecheck` passes
- [x] `npm run build` passes

Closes CHK-003.

🤖 Generated with [Claude Code](https://claude.com/claude-code)