### PR TITLE
fix: remove phantom systemPromptAdditions from docs

### DIFF
--- a/docs/evals-guide.md
+++ b/docs/evals-guide.md
@@ -384,9 +384,7 @@ projects: [
         // After adding a Glean skill to the LLM host config
       },
       mcpHostConfig: {
-        systemPromptAdditions: [
-          'You have access to Glean enterprise search. Use the search tool to find internal documents, and employee_search to find people.',
-        ],
+        provider: 'anthropic',
       },
     },
   },

--- a/docs/mcp-host.md
+++ b/docs/mcp-host.md
@@ -166,7 +166,7 @@ LLM host simulation calls a real LLM API. Approximate costs:
 
 ## A/B Testing Tool Descriptions
 
-Run two Playwright projects with different `systemPromptAdditions` to compare tool description variants:
+Run two Playwright projects with different MCP server configurations to compare tool description variants:
 
 ```typescript
 // playwright.config.ts
@@ -185,7 +185,7 @@ projects: [
       mcpConfig: {
         /* ... */
       },
-      // If your fixture supports systemPromptAdditions, add them here
+      mcpHostConfig: { provider: 'anthropic' },
     },
   },
 ];


### PR DESCRIPTION
## Summary
- Remove `systemPromptAdditions` array from A/B testing example in `docs/evals-guide.md`
- Update heading and comment in `docs/mcp-host.md` that referenced the phantom field

## P0 release blocker
`systemPromptAdditions` does not exist in source types. Users copying the documented examples get TypeScript compilation errors.

## Test plan
- [x] No code changes — docs only
- [x] Verified field does not exist in `src/evals/mcpHost/mcpHostTypes.ts`

Closes CHK-008.

🤖 Generated with [Claude Code](https://claude.com/claude-code)