### PR TITLE
fix: include response preview in matcher failure messages

### DIFF
--- a/src/assertions/matchers/toContainToolText.ts
+++ b/src/assertions/matchers/toContainToolText.ts
@@ -18,6 +18,8 @@ export function toContainToolText(
 ) {
   const result = validateText(received, expected, options);
 
+  const preview = result.details?.textPreview as string | undefined;
+
   return {
     pass: result.pass,
     message: () => {
@@ -28,6 +30,9 @@ export function toContainToolText(
         return result.pass
           ? `Expected response NOT to contain ${expectedStr}, but it did`
           : result.message;
+      }
+      if (!result.pass && preview) {
+        return `${result.message}\n\nActual response (truncated):\n${preview}`;
       }
       return result.message;
     },

--- a/src/assertions/matchers/toMatchToolPattern.ts
+++ b/src/assertions/matchers/toMatchToolPattern.ts
@@ -18,6 +18,8 @@ export function toMatchToolPattern(
 ) {
   const result = validatePattern(received, patterns, options);
 
+  const preview = result.details?.textPreview as string | undefined;
+
   return {
     pass: result.pass,
     message: () => {
@@ -25,6 +27,9 @@ export function toMatchToolPattern(
         return result.pass
           ? 'Expected response NOT to match pattern(s), but it did'
           : result.message;
+      }
+      if (!result.pass && preview) {
+        return `${result.message}\n\nActual response (truncated):\n${preview}`;
       }
       return result.message;
     },

--- a/src/assertions/matchers/toMatchToolSchema.ts
+++ b/src/assertions/matchers/toMatchToolSchema.ts
@@ -19,6 +19,8 @@ export function toMatchToolSchema(
 ) {
   const result = validateSchema(received, schema, options);
 
+  const preview = result.details?.textPreview as string | undefined;
+
   return {
     pass: result.pass,
     message: () => {
@@ -26,6 +28,9 @@ export function toMatchToolSchema(
         return result.pass
           ? 'Expected response NOT to match schema, but it did'
           : result.message;
+      }
+      if (!result.pass && preview) {
+        return `${result.message}\n\nActual response (truncated):\n${preview}`;
       }
       return result.message;
     },

--- a/src/assertions/validators/schema.ts
+++ b/src/assertions/validators/schema.ts
@@ -6,7 +6,7 @@
 
 import type { ZodType, ZodError } from 'zod';
 import type { ValidationResult, SchemaValidatorOptions } from './types.js';
-import { extractText } from './utils.js';
+import { extractText, stringifyResponse } from './utils.js';
 
 /**
  * Validates that a response matches a Zod schema
@@ -61,11 +61,13 @@ export function validateSchema(
     const zodError = error as ZodError;
     const issues = formatZodIssues(zodError);
 
+    const text = stringifyResponse(response);
     return {
       pass: false,
       message: `Response does not match schema: ${issues}`,
       details: {
         issues: zodError.issues,
+        textPreview: truncateForDisplay(text),
       },
     };
   }
@@ -159,4 +161,11 @@ function formatZodIssues(error: ZodError): string {
   });
 
   return issues.join('; ');
+}
+
+function truncateForDisplay(str: string, maxLength = 200): string {
+  if (str.length <= maxLength) {
+    return str;
+  }
+  return str.slice(0, maxLength) + '... (truncated)';
 }


### PR DESCRIPTION
## Summary
- `toContainToolText`, `toMatchToolPattern`, and `toMatchToolSchema` now append a truncated preview of the actual response to failure messages
- Added `textPreview` to the schema validator's `details` on failure, matching the existing behavior in text and pattern validators

## Test plan
- [x] `npm run typecheck` passes
- [x] 104 matcher + validator tests pass
- [x] No existing test behavior changed (preview is additive to failure messages)

Closes CHK-006.

🤖 Generated with [Claude Code](https://claude.com/claude-code)