### PR TITLE
fix: remove stale glean-server references from example READMEs

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -24,7 +24,6 @@ Complete working examples demonstrating how to use `@gleanwork/mcp-server-tester
 | [basic-playwright-usage](./basic-playwright-usage/) | Minimal starter (~60 lines)           | ⭐         |
 | [filesystem-server](./filesystem-server/)           | **Canonical example** - all patterns  | ⭐⭐⭐     |
 | [sqlite-server](./sqlite-server/)                   | Database testing with custom fixtures | ⭐⭐       |
-| [glean-server](./glean-server/)                     | Production HTTP server testing        | ⭐⭐       |
 
 ## Quick Start
 

--- a/examples/basic-playwright-usage/README.md
+++ b/examples/basic-playwright-usage/README.md
@@ -70,4 +70,3 @@ Once you understand the basics, check out:
 
 - **[filesystem-server](../filesystem-server/)** - Comprehensive example with eval datasets
 - **[sqlite-server](../sqlite-server/)** - Database testing with custom fixtures
-- **[glean-server](../glean-server/)** - HTTP transport and production server testing

--- a/examples/filesystem-server/README.md
+++ b/examples/filesystem-server/README.md
@@ -158,4 +158,3 @@ ANTHROPIC_API_KEY=your-key npm test
 
 - **[basic-playwright-usage](../basic-playwright-usage/)** - Minimal starter example
 - **[sqlite-server](../sqlite-server/)** - Database testing example
-- **[glean-server](../glean-server/)** - HTTP transport example


### PR DESCRIPTION
## Summary
- Remove dangling glean-server cross-references from 3 example READMEs
- The `examples/glean-server/` directory does not exist

## Test plan
- [x] Docs only — 3 line deletions
- [x] Verified `examples/glean-server/` does not exist

Closes CHK-007.

🤖 Generated with [Claude Code](https://claude.com/claude-code)