### PR TITLE
fix: remove zod from install command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ LLM host mode makes real API calls and produces non-deterministic results. Use `
 Requires Node.js 22+.
 
 ```bash
-npm install --save-dev @gleanwork/mcp-server-tester @playwright/test zod
+npm install --save-dev @gleanwork/mcp-server-tester @playwright/test
 ```
 
 The Anthropic SDK is only needed for LLM-as-judge assertions or LLM host mode with the Anthropic provider:


### PR DESCRIPTION
## Summary
- Remove `zod` from the user-facing install command in `README.md`
- `zod` is a direct dependency of the package and is installed transitively

## Test plan
- [x] Docs only — 1 line changed
- [x] Verified `zod` is in `dependencies` in `package.json`

Closes CHK-009.

🤖 Generated with [Claude Code](https://claude.com/claude-code)