### PR TITLE
docs: add security warning about http:// for remote servers

### DIFF
--- a/docs/transports.md
+++ b/docs/transports.md
@@ -178,6 +178,8 @@ export default defineConfig({
 }
 ```
 
+> **Security note:** When `serverUrl` uses `http://` with a non-localhost address, the framework emits a console warning: tokens and credentials are transmitted unencrypted over plain HTTP. Always use `https://` for remote servers. The warning is suppressed for `localhost` / `127.0.0.1` since local development traffic stays on the machine.
+
 ### Examples
 
 **Local HTTP Server:**


### PR DESCRIPTION
## Summary
- Add a security note to the HTTP transport section in `docs/transports.md`
- Documents the console.warn emitted when `serverUrl` uses `http://` with a non-localhost address
- Explains that `https://` should be used for remote servers

## Test plan
- [x] Docs only — 2 lines added
- [x] Warning message verified against `src/config/mcpConfig.ts:358`

Closes CHK-012.

🤖 Generated with [Claude Code](https://claude.com/claude-code)