### PR TITLE
fix: resolve pre-release gate P0/P1 blockers in examples and docs

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -303,21 +303,14 @@ Run an eval dataset. Expectations are defined per-case in the dataset's `expect`
 - `options: object`
   - `dataset: EvalDataset` - Dataset to run
   - `concurrency?: number` - Max parallel cases (default: 1 = sequential)
-  - `judgeClient?: LLMJudgeClient` - Optional LLM judge client
 - `context: object`
   - `mcp: MCPFixtureApi` - MCP fixture API
-  - `testInfo: TestInfo` - Playwright test info (required for snapshot support)
+  - `testInfo?: TestInfo` - Playwright test info (required for snapshot support)
 
 **Returns:** `Promise<EvalRunnerResult>`
 
 ```typescript
-const result = await runEvalDataset(
-  {
-    dataset,
-    judgeClient,
-  },
-  { mcp, testInfo }
-);
+const result = await runEvalDataset({ dataset }, { mcp, testInfo });
 
 console.log(`Passed: ${result.passed}/${result.total}`);
 ```
@@ -594,15 +587,15 @@ Evaluates a response using an LLM-as-a-judge. Returns a `Promise<ValidationResul
 
 **`JudgeValidatorConfig`:**
 
-| Field       | Type           | Default    | Description                                        |
-| ----------- | -------------- | ---------- | -------------------------------------------------- |
-| `rubric`    | `RubricSpec`   | —          | Evaluation rubric (required unless `judge` is set) |
-| `judge`     | `string`       | —          | Name of a registered custom judge                  |
-| `reference` | `unknown`      | —          | Reference response to compare against              |
-| `threshold` | `number`       | `0.7`      | Minimum score to pass (0–1)                        |
-| `reps`      | `number`       | `1`        | Number of evaluations to run (scores averaged)     |
-| `provider`  | `ProviderKind` | `'claude'` | Judge LLM provider                                 |
-| `model`     | `string`       | —          | Model override                                     |
+| Field       | Type           | Default       | Description                                        |
+| ----------- | -------------- | ------------- | -------------------------------------------------- |
+| `rubric`    | `RubricSpec`   | —             | Evaluation rubric (required unless `judge` is set) |
+| `judge`     | `string`       | —             | Name of a registered custom judge                  |
+| `reference` | `unknown`      | —             | Reference response to compare against              |
+| `threshold` | `number`       | `0.7`         | Minimum score to pass (0–1)                        |
+| `reps`      | `number`       | `1`           | Number of evaluations to run (scores averaged)     |
+| `provider`  | `ProviderKind` | `'anthropic'` | Judge LLM provider                                 |
+| `model`     | `string`       | —             | Model override                                     |
 
 ```typescript
 const result = await validateJudge(response, {
@@ -1150,16 +1143,6 @@ interface EvalDataset {
   metadata?: Record<string, unknown>;
   schemas?: Record<string, ZodSchema>; // Zod schemas for toMatchToolSchema assertions
 }
-```
-
-### `EvalExpectation`
-
-```typescript
-type EvalExpectation = (
-  context: { mcp: MCPFixtureApi },
-  evalCase: EvalCase,
-  response: CallToolResult
-) => Promise<{ pass: boolean; details: string }>;
 ```
 
 ## Next Steps

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -57,7 +57,7 @@ If you prefer to set up your project manually:
 ### 1. Install Dependencies
 
 ```bash
-npm install --save-dev @gleanwork/mcp-server-tester @playwright/test @modelcontextprotocol/sdk zod
+npm install --save-dev @gleanwork/mcp-server-tester @playwright/test
 ```
 
 ### 2. Configure Playwright

--- a/examples/README.md
+++ b/examples/README.md
@@ -65,9 +65,10 @@ test('validates config', async ({ mcp }) => {
       id: 'config-check',
       toolName: 'read_file',
       args: { path: 'config.json' },
-      expectedTextContains: ['version', '1.0.0'],
+      expect: {
+        containsText: ['version', '1.0.0'],
+      },
     },
-    { textContains: createTextContainsExpectation() },
     { mcp }
   );
 
@@ -82,10 +83,7 @@ Load test cases from JSON files for maintainability:
 ```typescript
 const dataset = await loadEvalDataset('./eval-dataset.json');
 
-const result = await runEvalDataset(
-  { dataset, expectations: { textContains: createTextContainsExpectation() } },
-  { mcp, testInfo, expect }
-);
+const result = await runEvalDataset({ dataset }, { mcp, testInfo, expect });
 
 expect(result.passed).toBe(result.total);
 ```
@@ -110,15 +108,15 @@ test('LLM discovers directory contents', async ({ mcp }) => {
 
 ## Example Comparison
 
-| Feature             | basic | filesystem | sqlite | glean |
-| ------------------- | ----- | ---------- | ------ | ----- |
-| Transport           | stdio | stdio      | stdio  | HTTP  |
-| Direct API Tests    | ✓     | ✓          | ✓      | ✓     |
-| Inline Eval Cases   | ✗     | ✓          | ✗      | ✗     |
-| JSON Eval Datasets  | ✗     | ✓          | ✓      | ✓     |
-| LLM Host Simulation | ✗     | ✓          | ✗      | ✗     |
-| LLM Host from JSON  | ✗     | ✓          | ✓      | ✓     |
-| MCP Reporter        | ✗     | ✓          | ✗      | ✓     |
+| Feature             | basic | filesystem | sqlite |
+| ------------------- | ----- | ---------- | ------ |
+| Transport           | stdio | stdio      | stdio  |
+| Direct API Tests    | ✓     | ✓          | ✓      |
+| Inline Eval Cases   | ✗     | ✓          | ✗      |
+| JSON Eval Datasets  | ✗     | ✓          | ✓      |
+| LLM Host Simulation | ✗     | ✓          | ✗      |
+| LLM Host from JSON  | ✗     | ✓          | ✓      |
+| MCP Reporter        | ✗     | ✓          | ✗      |
 
 ## Running LLM Tests
 

--- a/examples/filesystem-server/README.md
+++ b/examples/filesystem-server/README.md
@@ -72,9 +72,10 @@ test('validates config with inline case', async ({ mcp }) => {
       id: 'inline-config-check',
       toolName: 'read_file',
       args: { path: 'config.json' },
-      expectedTextContains: ['version', '1.0.0'],
+      expect: {
+        containsText: ['version', '1.0.0'],
+      },
     },
-    { textContains: createTextContainsExpectation() },
     { mcp }
   );
 
@@ -117,17 +118,17 @@ Define test cases in JSON for maintainability:
   "mode": "direct",
   "toolName": "read_file",
   "args": { "path": "readme.txt" },
-  "expectedTextContains": "Hello World"
+  "expect": {
+    "containsText": "Hello World",
+    "isError": false
+  }
 }
 ```
 
 ```typescript
 const dataset = await loadEvalDataset('./eval-dataset.json');
 
-const result = await runEvalDataset(
-  { dataset, expectations: { textContains: createTextContainsExpectation() } },
-  { mcp, testInfo, expect }
-);
+const result = await runEvalDataset({ dataset }, { mcp, testInfo, expect });
 
 expect(result.passed).toBe(result.total);
 ```

--- a/examples/filesystem-server/eval-dataset.json
+++ b/examples/filesystem-server/eval-dataset.json
@@ -80,18 +80,10 @@
         "maxTokens": 1000
       },
       "expect": {
-        "containsText": ["guide.md", "api.md"]
-      },
-      "metadata": {
-        "expectedToolCalls": [
-          {
-            "name": "list_directory",
-            "arguments": {
-              "path": "docs"
-            },
-            "required": true
-          }
-        ]
+        "containsText": ["guide.md", "api.md"],
+        "toolsTriggered": {
+          "calls": [{ "name": "list_directory", "required": true }]
+        }
       }
     },
     {
@@ -108,18 +100,10 @@
         "maxTokens": 1000
       },
       "expect": {
-        "containsText": "1.0.0"
-      },
-      "metadata": {
-        "expectedToolCalls": [
-          {
-            "name": "read_file",
-            "arguments": {
-              "path": "config.json"
-            },
-            "required": true
-          }
-        ]
+        "containsText": "1.0.0",
+        "toolsTriggered": {
+          "calls": [{ "name": "read_file", "required": true }]
+        }
       }
     },
     {
@@ -135,18 +119,10 @@
         "temperature": 0.0
       },
       "expect": {
-        "containsText": [".md"]
-      },
-      "metadata": {
-        "expectedToolCalls": [
-          {
-            "name": "search_files",
-            "arguments": {
-              "pattern": "**/*.md"
-            },
-            "required": true
-          }
-        ]
+        "containsText": [".md"],
+        "toolsTriggered": {
+          "calls": [{ "name": "search_files", "required": true }]
+        }
       }
     },
     {
@@ -162,18 +138,10 @@
         "temperature": 0.0
       },
       "expect": {
-        "containsText": ["2", "Alice", "Bob"]
-      },
-      "metadata": {
-        "expectedToolCalls": [
-          {
-            "name": "read_file",
-            "arguments": {
-              "path": "data/users.csv"
-            },
-            "required": true
-          }
-        ]
+        "containsText": ["2", "Alice", "Bob"],
+        "toolsTriggered": {
+          "calls": [{ "name": "read_file", "required": true }]
+        }
       }
     },
     {
@@ -188,13 +156,10 @@
         "model": "claude-sonnet-4-20250514",
         "temperature": 0.0
       },
-      "metadata": {
-        "expectedToolCalls": [
-          {
-            "name": "list_directory",
-            "required": true
-          }
-        ]
+      "expect": {
+        "toolsTriggered": {
+          "calls": [{ "name": "list_directory", "required": true }]
+        }
       }
     },
     {

--- a/examples/sqlite-server/README.md
+++ b/examples/sqlite-server/README.md
@@ -14,7 +14,7 @@ This example demonstrates testing the [SQLite MCP Server](https://github.com/joh
 
 ## Prerequisites
 
-- Node.js 18+
+- Node.js 22+
 - npm or pnpm
 
 ## Installation
@@ -139,7 +139,9 @@ Direct SQL queries to specific tools:
   "args": {
     "sql": "SELECT * FROM users"
   },
-  "expectedSchemaName": "queryResult"
+  "expect": {
+    "schema": "queryResult"
+  }
 }
 ```
 
@@ -156,13 +158,10 @@ Natural language scenarios where the LLM chooses which tool and constructs the q
     "provider": "anthropic",
     "model": "claude-sonnet-4-20250514"
   },
-  "metadata": {
-    "expectedToolCalls": [
-      {
-        "name": "query",
-        "required": true
-      }
-    ]
+  "expect": {
+    "toolsTriggered": {
+      "calls": [{ "name": "query", "required": true }]
+    }
   }
 }
 ```

--- a/src/index.ts
+++ b/src/index.ts
@@ -183,9 +183,11 @@ export {
 
 // Eval Runner
 export type {
+  EvalCaseRequest,
   EvalContext,
   EvalExpectationResult,
   EvalCaseResult,
+  EvalRunMetadata,
   IterationResult,
   EvalRunnerResult,
   EvalRunnerOptions,


### PR DESCRIPTION
## Summary

- Update all example READMEs to current API (2-arg `runEvalCase`, `expect` blocks, simplified `runEvalDataset` signature)
- Move dead `metadata.expectedToolCalls` to `expect.toolsTriggered` in filesystem `eval-dataset.json` (5 mcp_host cases)
- Remove phantom `judgeClient` parameter and `EvalExpectation` type from api-reference.md
- Fix `'claude'` → `'anthropic'` default provider in api-reference.md
- Add `EvalCaseRequest` and `EvalRunMetadata` type exports to `src/index.ts`
- Simplify quickstart.md install command (remove transitive deps)
- Fix Node.js version 18+ → 22+ in sqlite example

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm run build` passes
- [x] `npm run format:check` passes
- [x] All 911 unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)