### PR TITLE
fix: pre-release cleanup for documentation accuracy and validator diagnostics

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -300,24 +300,29 @@ Run an eval dataset. Expectations are defined per-case in the dataset's `expect`
 
 **Parameters:**
 
-- `options: object`
+- `options: EvalRunnerOptions`
   - `dataset: EvalDataset` - Dataset to run
-  - `concurrency?: number` - Max parallel cases (default: 1 = sequential)
-  - `judgeClient?: LLMJudgeClient` - Optional LLM judge client
-- `context: object`
+  - `schemas?: Record<string, ZodType>` - Schema registry for `expect.schema` validation by name
+  - `stopOnFailure?: boolean` - Stop on first failure (default: `false`)
+  - `onCaseComplete?: (result: EvalCaseResult) => void` - Callback after each case completes
+  - `concurrency?: number` - Max parallel cases (default: `1` = sequential)
+  - `defaultLlmIterations?: number` - Default iteration count for `mcp_host` cases (default: `1`)
+  - `defaultJudgeReps?: number` - Default judge evaluation count per case (default: `1`)
+  - `filterTags?: string[]` - Only run cases whose `tags` contain at least one match
+  - `saveResultsTo?: string` - Save run results to file for baseline comparison
+  - `omitResponsesFromBaseline?: boolean` - Strip responses from saved baseline (default: `true`)
+  - `baselineResultsFrom?: string` - Load baseline file for regression detection
+  - `mcpHostModel?: string` - Model identifier recorded in run metadata
+  - `judgeModel?: string` - Judge model identifier recorded in run metadata
+- `context: EvalContext`
   - `mcp: MCPFixtureApi` - MCP fixture API
-  - `testInfo: TestInfo` - Playwright test info (required for snapshot support)
+  - `testInfo?: TestInfo` - Playwright test info (required for snapshot support)
+  - `expect?: ExpectType` - Playwright expect function (required for snapshot support)
 
 **Returns:** `Promise<EvalRunnerResult>`
 
 ```typescript
-const result = await runEvalDataset(
-  {
-    dataset,
-    judgeClient,
-  },
-  { mcp, testInfo }
-);
+const result = await runEvalDataset({ dataset }, { mcp, testInfo });
 
 console.log(`Passed: ${result.passed}/${result.total}`);
 ```
@@ -899,7 +904,7 @@ Run MCP protocol conformance checks.
   - `requiredTools?: string[]` - Tools that must be present
   - `validateSchemas?: boolean` - Validate tool input schemas (default: `false`)
 
-**Returns:** `Promise<ConformanceResult>`
+**Returns:** `Promise<MCPConformanceResult>`
 
 ```typescript
 const result = await runConformanceChecks(mcp, {
@@ -913,7 +918,7 @@ expect(result.pass).toBe(true);
 **Result Structure:**
 
 ```typescript
-interface ConformanceResult {
+interface MCPConformanceResult {
   pass: boolean;
   checks: Array<{
     name: string;

--- a/docs/expectations.md
+++ b/docs/expectations.md
@@ -615,6 +615,19 @@ The predicate may be synchronous or `async`. Errors thrown inside the predicate 
 - Prefer a built-in matcher when one fits — predicates are harder to read at a glance
 - The `response` argument is the raw `CallToolResult`; use `text` (second argument) for extracted string content
 
+## Matcher Naming Convention
+
+The custom Playwright matchers follow standard Playwright/Jest prefix conventions. All matchers include `Tool` in the name to distinguish them from built-in matchers.
+
+| Prefix       | Meaning                  | Matchers                                                                                |
+| ------------ | ------------------------ | --------------------------------------------------------------------------------------- |
+| `toMatch*`   | Structural/content match | `toMatchToolResponse`, `toMatchToolSchema`, `toMatchToolPattern`, `toMatchToolSnapshot` |
+| `toContain*` | Substring presence       | `toContainToolText`                                                                     |
+| `toBe*`      | Identity/boolean check   | `toBeToolError`                                                                         |
+| `toHave*`    | Property/count assertion | `toHaveToolResponseSize`, `toHaveToolCalls`, `toHaveToolCallCount`                      |
+| `toPass*`    | External evaluation      | `toPassToolJudge`                                                                       |
+| `toSatisfy*` | Custom predicate         | `toSatisfyToolPredicate`                                                                |
+
 ## Combining Multiple Expectations
 
 A single eval case can declare multiple expectation types at once. The runner evaluates each defined field independently and reports results per expectation:

--- a/docs/mcp-host.md
+++ b/docs/mcp-host.md
@@ -121,23 +121,39 @@ The case passes if `search` was triggered in at least 4 of 5 runs (80% accuracy)
 
 ```typescript
 interface MCPHostConfig {
-  provider:
-    | 'openai'
-    | 'anthropic'
-    | 'google'
-    | 'vertex-anthropic'
-    | 'mistral'
-    | 'azure'
-    | 'deepseek'
-    | 'openrouter'
-    | 'xai';
+  hostType?: 'sdk' | 'cli' | 'browser' | 'desktop'; // Host type (default: 'sdk')
+  provider?: LLMProvider; // Required for 'sdk', ignored for 'cli'
   model?: string; // Model name (provider-specific default if omitted)
   maxToolCalls?: number; // Max tool call steps (default: 10)
   temperature?: number; // LLM temperature (default: 0)
   maxTokens?: number; // Max response tokens
   apiKeyEnvVar?: string; // Override default env var name
+  cli?: CLIConfig; // Required for 'cli' host type
+}
+
+type LLMProvider =
+  | 'openai'
+  | 'anthropic'
+  | 'google'
+  | 'vertex-anthropic'
+  | 'mistral'
+  | 'azure'
+  | 'deepseek'
+  | 'openrouter'
+  | 'xai';
+
+interface CLIConfig {
+  command: string; // CLI command (e.g., 'claude', 'codex')
+  args: string[]; // Arguments — use '{{scenario}}' as prompt placeholder
+  outputFormat?: 'text' | 'json' | 'stream-json'; // How to parse stdout (default: 'stream-json')
+  timeout?: number; // Command timeout in ms (default: 120000)
 }
 ```
+
+**Host types:**
+
+- **`sdk`** (default) — Programmatic via Vercel AI SDK. Reuses the framework's MCP connection. Requires `provider`.
+- **`cli`** — CLI-based hosts (e.g., Claude Code, Codex). Spawns a process with its own MCP connection. Requires `cli`.
 
 ## MCPHostSimulationResult
 

--- a/src/assertions/validators/toolCalls.test.ts
+++ b/src/assertions/validators/toolCalls.test.ts
@@ -29,6 +29,7 @@ describe('validateToolCalls', () => {
     });
     expect(v.pass).toBe(false);
     expect(v.message).toContain('search');
+    expect(v.details).toEqual({ actual: ['other'], expected: 'search' });
   });
 
   it('passes optional tool even when missing', () => {
@@ -147,6 +148,10 @@ describe('validateToolCalls', () => {
       order: 'strict',
     });
     expect(v.pass).toBe(false);
+    expect(v.details).toEqual({
+      actual: ['search', 'fetch'],
+      expected: 'search',
+    });
   });
 
   it('passes strict order when sequence matches', () => {
@@ -166,6 +171,10 @@ describe('validateToolCalls', () => {
     });
     expect(v.pass).toBe(false);
     expect(v.message).toContain('unexpected');
+    expect(v.details).toEqual({
+      actual: ['search', 'unexpected'],
+      unexpected: ['unexpected'],
+    });
   });
 
   it('returns error when response is not an MCPHostSimulationResult', () => {
@@ -258,6 +267,7 @@ describe('validateToolCallCount', () => {
     const v = validateToolCallCount(result, { exact: 2 });
     expect(v.pass).toBe(false);
     expect(v.message).toContain('1');
+    expect(v.details).toEqual({ actual: 1, expected: 2 });
   });
 
   it('passes min/max range', () => {
@@ -267,12 +277,16 @@ describe('validateToolCallCount', () => {
 
   it('fails when below min', () => {
     const result = makeResult([]);
-    expect(validateToolCallCount(result, { min: 1 }).pass).toBe(false);
+    const v = validateToolCallCount(result, { min: 1 });
+    expect(v.pass).toBe(false);
+    expect(v.details).toEqual({ actual: 0, min: 1 });
   });
 
   it('fails when above max', () => {
     const result = makeResult([{ name: 'a' }, { name: 'b' }, { name: 'c' }]);
-    expect(validateToolCallCount(result, { max: 2 }).pass).toBe(false);
+    const v = validateToolCallCount(result, { max: 2 });
+    expect(v.pass).toBe(false);
+    expect(v.details).toEqual({ actual: 3, max: 2 });
   });
 
   it('returns error when response is not an MCPHostSimulationResult', () => {

--- a/src/assertions/validators/toolCalls.ts
+++ b/src/assertions/validators/toolCalls.ts
@@ -152,6 +152,10 @@ export function validateToolCalls(
           return {
             pass: false,
             message: `Expected tool '${expected.name}' to be called in sequence (starting from position ${searchFrom}), but it was not found`,
+            details: {
+              actual: actual.map((c) => c.name),
+              expected: expected.name,
+            },
             metrics,
           };
         }
@@ -172,6 +176,10 @@ export function validateToolCalls(
         return {
           pass: false,
           message: `Expected tool '${expected.name}'${argsNote} to be called, but it was not`,
+          details: {
+            actual: actual.map((c) => c.name),
+            expected: expected.name,
+          },
           metrics,
         };
       }
@@ -185,6 +193,10 @@ export function validateToolCalls(
       return {
         pass: false,
         message: `Unexpected tool calls: ${names}. Only ${[...allowedNames].map((n) => `'${n}'`).join(', ')} are allowed`,
+        details: {
+          actual: actual.map((c) => c.name),
+          unexpected: unexpected.map((c) => c.name),
+        },
         metrics,
       };
     }
@@ -218,6 +230,7 @@ export function validateToolCallCount(
     return {
       pass: false,
       message: `Expected exactly ${exact} tool call(s), but got ${count}`,
+      details: { actual: count, expected: exact },
     };
   }
 
@@ -225,6 +238,7 @@ export function validateToolCallCount(
     return {
       pass: false,
       message: `Expected at least ${min} tool call(s), but got ${count}`,
+      details: { actual: count, min },
     };
   }
 
@@ -232,6 +246,7 @@ export function validateToolCallCount(
     return {
       pass: false,
       message: `Expected at most ${max} tool call(s), but got ${count}`,
+      details: { actual: count, max },
     };
   }
 

--- a/src/judge/judgeClient.ts
+++ b/src/judge/judgeClient.ts
@@ -57,6 +57,8 @@ export function createJudge(config: JudgeConfig = {}): Judge {
       return createGoogleJudge(config);
 
     default:
-      throw new Error(`Unsupported LLM provider: ${String(provider)}`);
+      throw new Error(
+        `Unsupported LLM provider: ${String(provider)}. Valid providers: 'anthropic', 'vertex-anthropic', 'anthropic-agent-sdk', 'openai', 'google'`
+      );
   }
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -97,7 +97,7 @@ export type ExpectationResultMap = Partial<
 /**
  * Breakdown of expectation types used in a run
  */
-export type ExpectationBreakdown = Record<ExpectationType, number>;
+export type ExpectationBreakdown = Partial<Record<ExpectationType, number>>;
 
 // Reporter types are exported from ./reporter.js
 // Import them from there to avoid circular dependencies:


### PR DESCRIPTION
## Summary

- **Improved error messages**: Unsupported LLM provider error now lists valid providers
- **Better validator diagnostics**: All `validateToolCalls` and `validateToolCallCount` failure paths now return structured `details` (actual vs expected values)
- **Safer type evolution**: `ExpectationBreakdown` is now `Partial<Record<...>>` so adding new `ExpectationType` variants doesn't force a major version bump
- **Documentation accuracy**: Fixed `ConformanceResult` → `MCPConformanceResult`, documented all 13 `EvalRunnerOptions` fields, added `hostType`/`CLIConfig` to MCP host docs, added matcher naming convention section

## Changes

### Code (3 files)
- `src/judge/judgeClient.ts` — Error message includes valid provider names
- `src/assertions/validators/toolCalls.ts` — Added `details` to all 6 failure return paths
- `src/types/index.ts` — `ExpectationBreakdown` changed from `Record` to `Partial<Record>`

### Tests (1 file)
- `src/assertions/validators/toolCalls.test.ts` — Added `details` assertions to 6 existing failure tests

### Docs (3 files)
- `docs/api-reference.md` — Fixed type name, documented all `EvalRunnerOptions` fields
- `docs/mcp-host.md` — Added `hostType`, `CLIConfig`, and host type explanations
- `docs/expectations.md` — Added matcher naming convention table

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm run build` passes
- [x] All 911 tests pass
- [x] `npm run format:check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)