### PR TITLE
docs: clarify runEvalDataset two-argument signature

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -322,7 +322,10 @@ Run an eval dataset. Expectations are defined per-case in the dataset's `expect`
 **Returns:** `Promise<EvalRunnerResult>`
 
 ```typescript
-const result = await runEvalDataset({ dataset }, { mcp, testInfo });
+const result = await runEvalDataset(
+  { dataset }, // options — what to run and how
+  { mcp, testInfo } // context — Playwright fixtures from your test
+);
 
 console.log(`Passed: ${result.passed}/${result.total}`);
 ```


### PR DESCRIPTION
## Summary

- Added inline comments to the `runEvalDataset` example in api-reference.md explaining the two-argument signature (`options` = what to run, `context` = Playwright fixtures)

## Test plan

- [x] Documentation-only change
- [x] Formatting verified with Prettier

🤖 Generated with [Claude Code](https://claude.com/claude-code)