### PR TITLE
fix: terminate MCP session before closing client

### DIFF
--- a/src/mcp/clientFactory.ts
+++ b/src/mcp/clientFactory.ts
@@ -409,7 +409,9 @@ export async function closeMCPClient(client: Client): Promise<void> {
       } catch (sessionError) {
         debugClient(
           'Error terminating session: %s',
-          sessionError instanceof Error ? sessionError.message : String(sessionError)
+          sessionError instanceof Error
+            ? sessionError.message
+            : String(sessionError)
         );
       }
     }

--- a/src/mcp/clientFactory.ts
+++ b/src/mcp/clientFactory.ts
@@ -400,6 +400,20 @@ export async function closeMCPClient(client: Client): Promise<void> {
   // outstanding request IDs as a public API, so we close directly and let the
   // transport teardown signal disconnection to the server.
   try {
+    // Terminate the MCP session before closing so stateful servers can clean up.
+    // TODO: Remove once MCP moves to stateless protocol (see roadmap: https://blog.modelcontextprotocol.io/posts/2026-mcp-roadmap/)
+    const transport = client.transport;
+    if (transport instanceof StreamableHTTPClientTransport) {
+      try {
+        await transport.terminateSession();
+      } catch (sessionError) {
+        debugClient(
+          'Error terminating session: %s',
+          sessionError instanceof Error ? sessionError.message : String(sessionError)
+        );
+      }
+    }
+
     await client.close();
   } catch (error) {
     debugClient(


### PR DESCRIPTION
## Summary

- `closeMCPClient()` now calls `terminateSession()` on `StreamableHTTPClientTransport` before calling `client.close()`
- This ensures stateful MCP servers that track sessions via `Mcp-Session-Id` can clean up properly between test runs
- Session termination errors are caught and logged (non-fatal) so they don't mask the actual close operation

Without this fix, stateful servers see stale sessions and may reject subsequent connections — forcing users to manually call `terminateSession()` in `afterEach` hooks.

**Note:** MCP is [moving toward a stateless protocol](https://blog.modelcontextprotocol.io/posts/2026-mcp-roadmap/). This session termination code is marked with a TODO to remove once the SDK drops session-based state management.

Closes #184

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm test` — all 911 tests pass
- [x] `npm run format:check` passes
- [x] Verified `terminateSession()` is called before `client.close()` (required because they share the same `AbortController` signal)

🤖 Generated with [Claude Code](https://claude.com/claude-code)