### PR TITLE
experimental: Add external host eval RFCs

### DIFF
--- a/.markdown-coderc.json
+++ b/.markdown-coderc.json
@@ -1,6 +1,6 @@
 {
   "snippetRoot": "./snippets",
   "markdownGlob": "{docs/**/*.md,README.md}",
-  "excludeGlob": ["node_modules/**", ".git/**", "dist/**"],
+  "excludeGlob": ["node_modules/**", ".git/**", "dist/**", "docs/rfcs/**"],
   "includeExtensions": [".ts", ".js", ".json", ".bash", ".sh"]
 }

--- a/.prettierignore
+++ b/.prettierignore
@@ -12,3 +12,6 @@ package-lock.json
 
 # Generated eval results
 **/.mcp-eval-results/
+
+# Draft RFCs
+docs/rfcs/

--- a/docs/rfcs/README.md
+++ b/docs/rfcs/README.md
@@ -1,0 +1,15 @@
+# RFCs
+
+Design proposals and implementation plans that are not yet stable product
+documentation.
+
+## External Host Evals
+
+- [RFC 00: External Host Evals Overview](./external-host-evals-00-overview.md)
+  captures the support matrix, observability ladder, and overall architecture.
+- [RFC 01: External Host Eval Core Runtime](./external-host-evals-01-core-runtime.md)
+  scopes the first implementation phase: normalized evidence, host driver
+  interfaces, CLI support, and an optional MCP trace proxy.
+- [RFC 02: Browser-Hosted External Host Evals](./external-host-evals-02-browser-hosts-and-cowork.md)
+  scopes the browser-hosted phase, including public proxy constraints and a
+  Claude Cowork MVP.

--- a/docs/rfcs/external-host-evals-00-overview.md
+++ b/docs/rfcs/external-host-evals-00-overview.md
@@ -1,0 +1,187 @@
+# RFC 00: External Host Evals Overview
+
+## Status
+
+Draft.
+
+## Context
+
+`mcp-server-tester` currently supports two useful but incomplete ways to evaluate
+MCP behavior:
+
+- `direct` mode calls MCP tools directly and gives deterministic server-level
+  signal.
+- `mcp_host` mode uses an SDK-driven LLM loop to approximate how a host might
+  discover and call tools.
+
+That is not enough for real-world host behavior. MCP servers are increasingly
+used through concrete hosts: CLI clients, desktop applications, and hosted web
+products. Those hosts differ in prompting, tool selection, tool execution,
+context limits, token accounting, UX, and trace visibility.
+
+The goal of external host evals is to run the same scenario set through real MCP
+hosts and normalize the resulting evidence into the same eval/reporting model
+used by `mcp-server-tester`.
+
+## Design Goal
+
+External host evals should be portable first, host-enriched second, and
+company-specific last.
+
+The open-source library should provide:
+
+- Generic host-driving interfaces.
+- Generic trace and artifact schemas.
+- Optional MCP protocol tracing when a host can be routed through a proxy.
+- Reporter support that makes evidence source and confidence explicit.
+- Host adapter extension points for CLI, browser, and desktop clients.
+
+Company-specific infrastructure, dashboards, credentials, and internal trace
+stores should be adapters or examples, not assumptions in the core design.
+
+## Non-Goals
+
+- Do not assume every host can be transparently intercepted.
+- Do not assume web-hosted clients execute MCP calls from the user's local
+  machine.
+- Do not claim equal trace fidelity across host variants when evidence comes
+  from different sources.
+- Do not make computer-use or DOM scraping the source of truth when protocol
+  traces or structured host traces are available.
+- Do not require Glean infrastructure for the open-source feature to work.
+
+## Host Support Matrix
+
+This matrix is intentionally concrete. It should be updated as adapters mature.
+
+| Host                    | Surface     | MCP calls from     | Endpoint proxy feasible                                   | Driving                            | Final answer                | Tool trace                                                                            | Token usage             | Cloud feasibility                | Confidence  |
+| ----------------------- | ----------- | ------------------ | --------------------------------------------------------- | ---------------------------------- | --------------------------- | ------------------------------------------------------------------------------------- | ----------------------- | -------------------------------- | ----------- |
+| Claude Code             | CLI/TUI     | Local process      | Yes                                                       | Spawn process                      | stdout / stream JSON        | CLI stream plus optional MCP proxy                                                    | CLI output if available | Container or VM                  | High        |
+| Codex CLI               | CLI/TUI     | Local process      | Yes                                                       | Spawn process                      | stdout / logs               | CLI logs plus optional MCP proxy                                                      | Logs if available       | Container or VM                  | High        |
+| Gemini CLI              | CLI/TUI     | Local process      | Likely                                                    | Spawn process                      | stdout / logs               | Logs plus optional MCP proxy                                                          | Logs if available       | Container or VM                  | Medium-high |
+| Claude Desktop          | Desktop app | Local app          | Yes if config is editable                                 | Accessibility / computer use       | UI / transcript             | Local MCP proxy or app logs                                                           | UI / logs if available  | VM only                          | Medium      |
+| Claude Cowork web       | Browser     | Host backend       | Only if host config can point to a public proxy           | Playwright / DOM                   | DOM, export, or browser API | Public MCP proxy for configured MCP servers; host export or DOM for native connectors | Host export or UI       | Browser worker if auth is stable | Medium      |
+| ChatGPT Enterprise      | Browser     | Host backend       | Maybe for custom MCP connectors                           | Playwright / DOM                   | DOM, export, or browser API | Public MCP proxy if configurable; DOM/tool cards otherwise                            | UI/export if available  | Browser worker                   | Medium-low  |
+| Gemini Enterprise       | Browser     | Host backend       | Maybe through admin config                                | Playwright / DOM                   | DOM or browser API          | Public MCP proxy if configurable; DOM otherwise                                       | Unknown                 | Browser worker                   | Medium-low  |
+| Cursor                  | Desktop app | Local/remote mixed | Maybe                                                     | App automation or CLI if available | UI / logs                   | Proxy/logs if local MCP                                                               | Unknown                 | VM                               | Medium-low  |
+| Generic hosted web host | Browser     | Host backend       | Only if server URL can be configured to a public endpoint | Playwright / DOM                   | DOM/API/export              | Public proxy, host export, or DOM                                                     | Host export/UI/none     | Browser worker                   | Varies      |
+| Generic local CLI host  | CLI/TUI     | Local process      | Yes                                                       | Spawn process                      | stdout / logs               | stdout/logs/proxy                                                                     | stdout/logs/none        | Container or VM                  | High        |
+
+## Feasibility Tiers
+
+External host support should be described by tier, not just by host name.
+
+| Tier                         | Meaning                                                                              | Examples                                                                  |
+| ---------------------------- | ------------------------------------------------------------------------------------ | ------------------------------------------------------------------------- |
+| Tier 1: Structured           | Host runs through a process or API and emits structured output or logs.              | Claude Code, Codex CLI                                                    |
+| Tier 2: Protocol-observed    | Host can be pointed at an MCP trace proxy.                                           | Local CLI, editable desktop configs, hosted web with configurable MCP URL |
+| Tier 3: Host-export observed | Host exposes native traces, but collection is host-specific.                         | Claude Cowork trace export, app logs                                      |
+| Tier 4: UI-observed          | Only browser DOM, transcript export, network artifacts, or tool cards are available. | ChatGPT/Cowork native connectors                                          |
+| Tier 5: Visual/computer-use  | Only screenshot/accessibility-driven operation is available.                         | Opaque desktop apps                                                       |
+
+The framework can support all tiers, but reports must surface the tier and
+evidence source. A low-fidelity host run can still be useful; it just must not
+be presented as protocol-level truth.
+
+## Observation Ladder
+
+For each run, evidence should be collected from the strongest available source:
+
+1. MCP protocol trace: proxy or server-side logs.
+2. Host-native trace: exported run trace, local log, or host API.
+3. Browser API trace: web app APIs visible to Playwright/CDP.
+4. DOM trace: visible transcript, tool cards, status indicators.
+5. Visual trace: screenshots, video, accessibility tree, computer-use output.
+
+Each metric should carry source metadata:
+
+```typescript
+type TraceSource =
+  | 'mcp-proxy'
+  | 'mcp-server-logs'
+  | 'host-native-export'
+  | 'browser-api'
+  | 'dom'
+  | 'screenshot'
+  | 'manual-import'
+  | 'none';
+
+type ObservationConfidence = 'high' | 'medium' | 'low';
+
+interface Observed<T> {
+  value: T;
+  source: TraceSource;
+  confidence: ObservationConfidence;
+  limitations?: string[];
+}
+```
+
+## Conceptual Architecture
+
+```text
+Eval dataset
+  |
+  v
+Host eval orchestrator
+  |
+  +-- Host driver        // operates the host
+  +-- Trace collectors   // collect protocol, host, browser, or UI evidence
+  +-- Result normalizer  // converts host evidence into eval results
+  +-- Reporter           // displays evidence source, confidence, artifacts
+```
+
+Driving and observability are separate. A Playwright browser driver may submit
+the prompt, but protocol traces might come from an MCP proxy, host traces might
+come from a downloaded export, and the final answer might come from the DOM.
+
+## Proposed Dataset Shape
+
+The long-term dataset shape should distinguish synthetic SDK hosts from real
+external hosts.
+
+```json
+{
+  "id": "find-planning-docs",
+  "mode": "external_host",
+  "scenario": "Find the latest planning docs for Project Atlas. Use company knowledge.",
+  "host": {
+    "name": "claude-cowork",
+    "variant": "glean-mcp",
+    "driver": "browser",
+    "observers": ["dom", "mcp-proxy"]
+  },
+  "expect": {
+    "containsText": ["Project Atlas"],
+    "toolsTriggered": {
+      "calls": [{ "name": "search", "required": true }]
+    },
+    "passesJudge": "correctness"
+  }
+}
+```
+
+Possible mode naming:
+
+- `direct`: direct MCP tool call.
+- `mcp_host`: current synthetic SDK/CLI host behavior.
+- `external_host`: real host execution through CLI, browser, or desktop.
+
+## Outcomes
+
+This RFC is successful when:
+
+- We agree on the support matrix dimensions.
+- We agree that evidence source and confidence are first-class report fields.
+- We agree that host driving and trace collection are separate interfaces.
+- We agree that Glean-specific trace stores and dashboards are adapters, not
+  core assumptions.
+
+## Open Questions
+
+- Should `external_host` be a new mode, or should `mcp_host.hostType` grow to
+  cover real external hosts?
+- Should host adapters live in the main package, separate packages, or examples?
+- Which trace sources should be mandatory for a run to be considered pass/fail
+  eligible?
+- How much artifact retention should the default reporter provide before a
+  separate dashboard/storage system is needed?

--- a/docs/rfcs/external-host-evals-01-core-runtime.md
+++ b/docs/rfcs/external-host-evals-01-core-runtime.md
@@ -1,0 +1,274 @@
+# RFC 01: External Host Eval Core Runtime
+
+## Status
+
+Draft.
+
+## Scope
+
+This RFC defines the first implementation phase for external host evals. It is
+limited to reusable open-source primitives:
+
+- Normalized external host result types.
+- Evidence source and confidence metadata.
+- Host driver and trace collector interfaces.
+- A CLI-backed driver path using the existing generic CLI host support.
+- An optional MCP trace proxy for hosts that can be pointed at a proxy endpoint.
+- Reporter fields that make evidence quality visible.
+
+This phase should not depend on Claude Cowork, Glean dashboards, internal trace
+stores, or browser automation.
+
+## Why Start Here
+
+CLI hosts and proxy-observed hosts give the cleanest signal with the lowest
+operational complexity. They exercise the same abstractions needed by browser
+and desktop hosts without starting from the flakiest surface.
+
+This phase also lets open-source users get value immediately:
+
+- Drive a local CLI host.
+- Capture stdout/log artifacts.
+- Optionally trace MCP JSON-RPC traffic through a proxy.
+- Reuse existing eval expectations and reporter views.
+
+## Core Types
+
+```typescript
+export type ExternalHostDriverKind = 'cli' | 'browser' | 'desktop' | 'custom';
+
+export type TraceSource =
+  | 'mcp-proxy'
+  | 'mcp-server-logs'
+  | 'host-native-export'
+  | 'browser-api'
+  | 'dom'
+  | 'screenshot'
+  | 'manual-import'
+  | 'none';
+
+export type ObservationConfidence = 'high' | 'medium' | 'low';
+
+export interface Observed<T> {
+  value: T;
+  source: TraceSource;
+  confidence: ObservationConfidence;
+  limitations?: string[];
+}
+
+export interface HostArtifact {
+  kind: 'stdout' | 'stderr' | 'log' | 'screenshot' | 'video' | 'har' | 'trace';
+  name: string;
+  path?: string;
+  contentType?: string;
+  summary?: string;
+}
+
+export interface ExternalHostRunResult {
+  success: boolean;
+  hostName: string;
+  hostVariant?: string;
+  scenario: string;
+  finalAnswer?: Observed<string>;
+  toolCalls?: Observed<Array<LLMToolCall>>;
+  usage?: Observed<UsageMetrics>;
+  conversationHistory?: Observed<
+    Array<{ role: 'user' | 'assistant' | 'tool'; content: string }>
+  >;
+  artifacts: HostArtifact[];
+  error?: string;
+  durationMs?: number;
+}
+```
+
+`MCPHostSimulationResult` can either be extended or wrapped. The key requirement
+is that existing expectations (`containsText`, `toolsTriggered`, `passesJudge`,
+`toolCallCount`) can validate an `ExternalHostRunResult` without losing
+evidence metadata.
+
+## Interfaces
+
+```typescript
+export interface HostRunContext {
+  runId: string;
+  caseId: string;
+  scenario: string;
+  workingDirectory?: string;
+  timeoutMs?: number;
+}
+
+export interface ExternalHostDriver<Config = unknown> {
+  kind: ExternalHostDriverKind;
+  setup(config: Config, context: HostRunContext): Promise<HostSession>;
+  execute(session: HostSession, scenario: string): Promise<HostExecution>;
+  teardown(session: HostSession): Promise<void>;
+}
+
+export interface TraceCollector<Config = unknown> {
+  source: TraceSource;
+  start(config: Config, context: HostRunContext): Promise<void>;
+  stop(context: HostRunContext): Promise<Partial<ExternalHostRunResult>>;
+}
+```
+
+The orchestrator composes one driver with zero or more collectors. A CLI driver
+may itself produce stdout, stderr, final answer, and tool calls. A protocol
+collector may independently produce MCP tool traces.
+
+## CLI Driver
+
+The existing `hostType: 'cli'` support is the right starting point. Phase one
+should reshape it into the external host runtime while preserving current user
+behavior.
+
+Example host config:
+
+```yaml
+hosts:
+  claude-code:
+    type: cli
+    command: claude
+    args:
+      - -p
+      - '{{scenario}}'
+      - --output-format
+      - stream-json
+      - --verbose
+    outputFormat: stream-json
+    timeout: 120000
+```
+
+The CLI driver should:
+
+- Spawn without a shell.
+- Replace `{{scenario}}` in args.
+- Capture stdout and stderr as artifacts.
+- Parse structured output when configured.
+- Return `finalAnswer`, `toolCalls`, and `usage` with source metadata.
+
+## MCP Trace Proxy
+
+The trace proxy is a generic MCP protocol recorder. It is not a Glean service.
+
+For local/CLI/desktop hosts:
+
+```text
+host process -> local trace proxy -> target MCP server
+```
+
+For hosted web clients that execute MCP calls from the host backend:
+
+```text
+host backend -> public trace proxy -> target MCP server
+```
+
+Phase one should implement the local form first and design the public form as a
+deployment option, not as a requirement.
+
+The proxy should record:
+
+- Run id and case id.
+- JSON-RPC request id.
+- Method.
+- Params.
+- Result or error.
+- Start/end timestamps.
+- Duration.
+- Transport metadata that is safe to store.
+
+The proxy should avoid:
+
+- Tool-specific parsing.
+- Glean-specific auth assumptions.
+- Storing secrets in traces.
+
+Trace output:
+
+```typescript
+interface MCPProtocolTraceEvent {
+  runId: string;
+  caseId: string;
+  requestId?: string | number;
+  method: string;
+  params?: unknown;
+  result?: unknown;
+  error?: unknown;
+  startedAt: string;
+  endedAt: string;
+  durationMs: number;
+}
+```
+
+## Dataset and Config
+
+Minimal phase-one dataset example:
+
+```json
+{
+  "id": "cli-search-trigger",
+  "mode": "external_host",
+  "scenario": "Find recent documents about quarterly planning.",
+  "host": {
+    "name": "claude-code",
+    "driver": "cli",
+    "observers": ["mcp-proxy"]
+  },
+  "expect": {
+    "toolsTriggered": {
+      "calls": [{ "name": "search", "required": true }]
+    }
+  }
+}
+```
+
+The implementation can initially support this through `mcpHostConfig` for
+backward compatibility, then add `host` as a clearer schema once the runtime
+settles.
+
+## Reporter Requirements
+
+The reporter should show:
+
+- Host name and variant.
+- Driver kind.
+- Evidence sources for final answer, tool calls, usage, and conversation.
+- Confidence levels.
+- Artifacts.
+- Existing pass/fail expectations.
+
+Example display:
+
+```text
+Tool calls: 3 calls, source=mcp-proxy, confidence=high
+Final answer: source=stdout, confidence=high
+Usage: unavailable
+```
+
+## Phase-One Outcomes
+
+This phase is complete when:
+
+- A CLI external host can run scenarios through the new runtime.
+- Existing CLI host behavior remains compatible.
+- The result schema can represent observed values with source/confidence.
+- A local MCP trace proxy can capture tool calls for a configurable target MCP
+  server.
+- Reports distinguish assertion failures from infrastructure failures.
+- Reports display evidence source and confidence.
+
+## Explicit Non-Outcomes
+
+- No browser automation yet.
+- No Claude Cowork adapter yet.
+- No public hosted trace proxy deployment yet.
+- No desktop VM orchestration yet.
+- No internal Glean dashboard export.
+
+## Risks
+
+- The new schema could duplicate `MCPHostSimulationResult` too much. Prefer a
+  small compatibility layer rather than parallel result models.
+- The trace proxy could become a second MCP implementation. Keep it as a
+  transport-level recorder and forwarder.
+- CLI host output formats differ. Start with explicit parsers and artifact
+  capture rather than trying to infer every CLI's behavior.

--- a/docs/rfcs/external-host-evals-02-browser-hosts-and-cowork.md
+++ b/docs/rfcs/external-host-evals-02-browser-hosts-and-cowork.md
@@ -1,0 +1,267 @@
+# RFC 02: Browser-Hosted External Host Evals
+
+## Status
+
+Draft.
+
+## Scope
+
+This RFC defines the second implementation phase for external host evals:
+
+- Browser-driven hosts.
+- Hosted-backend MCP execution.
+- Public trace proxy as an optional high-fidelity collector.
+- DOM/browser artifact capture as a lower-fidelity collector.
+- Claude Cowork as the first concrete browser-hosted target.
+
+This phase builds on the core runtime from RFC 01.
+
+## Important Constraint
+
+For many web-based hosts, the browser does not execute MCP calls. The browser is
+only the interaction plane. MCP calls are made by the host's backend.
+
+```text
+browser -> host web app -> host backend -> remote MCP server
+```
+
+That means local machine interception usually does not work. A local proxy only
+helps if the host can be configured to call a publicly reachable proxy URL.
+
+## Observation Strategies for Hosted Web Clients
+
+Evidence sources should be attempted in this order:
+
+1. Public MCP trace proxy.
+2. MCP server-side logs, if the server owner exposes them.
+3. Host-native trace export.
+4. Browser API/HAR artifacts.
+5. DOM transcript and visible tool cards.
+6. Screenshots/video/computer-use output.
+
+The framework must allow browser-hosted runs with low-fidelity evidence, but it
+must report that fidelity honestly.
+
+## Browser Driver
+
+The browser driver should be a generic Playwright-based driver, not a
+Claude-specific implementation.
+
+Generic capabilities:
+
+- Launch or connect to a browser.
+- Load a saved authenticated storage state.
+- Open a host URL.
+- Start or reset a conversation.
+- Submit a scenario.
+- Detect completion.
+- Extract final answer.
+- Capture screenshots, video, and optional HAR.
+
+Initial config shape:
+
+```yaml
+hosts:
+  claude-cowork:
+    type: browser
+    url: https://claude.ai
+    auth:
+      storageState: ./.auth/claude-cowork.json
+    driver:
+      selectors:
+        promptBox: '[contenteditable="true"]'
+        submitButton: '[aria-label="Send"]'
+        assistantMessage: '[data-testid="assistant-message"]'
+      completion:
+        strategy: stable-dom
+        timeoutMs: 180000
+    observers:
+      - kind: dom
+      - kind: browser-artifacts
+```
+
+Host-specific adapters may provide code instead of selectors when the host's UI
+requires more logic.
+
+## Public MCP Trace Proxy
+
+Hosted web clients can only be observed at the MCP protocol layer if their MCP
+server configuration can point at a public proxy.
+
+```text
+host backend -> public trace proxy -> real MCP server
+```
+
+Requirements:
+
+- Public HTTPS URL.
+- Stable target MCP server configuration.
+- Auth passthrough or configured upstream auth.
+- Run/case correlation.
+- Tenant isolation if shared across runs.
+- Secret redaction.
+
+This should be generic in OSS. A user can run it wherever they want:
+
+```bash
+mcp-server-tester trace-proxy \
+  --listen https://eval.example.com/mcp \
+  --target https://real-server.example.com/mcp \
+  --run-id run_123
+```
+
+For local development, a tunnel such as ngrok or Cloudflare Tunnel may be used.
+For production-scale runs, users can deploy the proxy in their own cloud.
+
+## Claude Cowork MVP
+
+Claude Cowork is a good first browser-hosted target because it is strategically
+important and exercises the hardest class of host: browser interaction plus
+backend-executed MCP.
+
+The MVP should support two variants:
+
+- `claude-cowork-glean-mcp`
+- `claude-cowork-native-connectors`
+
+The open-source adapter should not assume Glean. A Glean-specific config can be
+an internal example layered on top.
+
+### Variant: Cowork + Configured MCP Server
+
+If Cowork can be configured to use a custom MCP endpoint, use:
+
+```text
+Cowork backend -> public trace proxy -> target MCP server
+```
+
+Expected evidence:
+
+- Final answer: DOM or browser API.
+- Tool calls to configured MCP server: public MCP proxy, high confidence.
+- Token usage: host export/UI if available, otherwise unavailable.
+- Artifacts: screenshot, video, HAR, raw proxy trace.
+
+### Variant: Cowork + Native Connectors
+
+Native connector calls cannot be proxied by `mcp-server-tester`.
+
+Expected evidence:
+
+- Final answer: DOM or browser API.
+- Tool calls: host-native trace export if available; otherwise DOM/tool cards
+  with low confidence.
+- Token usage: host export/UI if available, otherwise unavailable.
+- Artifacts: screenshot, video, HAR, raw host export when available.
+
+Reports must make the asymmetry explicit. A Cowork + Glean MCP run with proxy
+traces is not observationally equivalent to a Cowork + native connectors run
+where only DOM evidence is available.
+
+## Host-Native Trace Exports
+
+If a host exports traces, the framework should collect them through a
+host-specific `TraceCollector`.
+
+The collector should answer:
+
+- Where is the trace produced?
+- How is it correlated to a scenario/run?
+- Does it include tool calls?
+- Does it include token usage?
+- Does it include latency?
+- Does it include hidden prompt/context information that should be redacted?
+
+The collector should normalize to `Observed<T>` and preserve the raw artifact.
+The storage location is not part of the core design. A trace could come from a
+local file, host API, downloaded archive, object store, or manual import.
+
+## Example Dataset
+
+```json
+{
+  "id": "cowork-planning-docs",
+  "mode": "external_host",
+  "scenario": "Find the latest planning docs for Project Atlas. Use company knowledge.",
+  "host": {
+    "name": "claude-cowork",
+    "variant": "glean-mcp",
+    "driver": "browser",
+    "observers": ["dom", "mcp-proxy"]
+  },
+  "iterations": 3,
+  "accuracyThreshold": 0.67,
+  "expect": {
+    "containsText": ["Project Atlas"],
+    "toolsTriggered": {
+      "calls": [{ "name": "search", "required": true }]
+    },
+    "passesJudge": "correctness"
+  }
+}
+```
+
+## Matrix Runner
+
+Browser-hosted evals become most useful when run as a matrix:
+
+```text
+scenario set:
+  planning-docs
+  code-search
+  policy-lookup
+
+hosts:
+  claude-cowork / glean-mcp
+  claude-cowork / native-connectors
+  claude-code / glean-mcp
+  codex-cli / glean-mcp
+```
+
+The runner should expand:
+
+```text
+scenario x host variant x iteration
+```
+
+Results should be sliceable by:
+
+- Host.
+- Variant.
+- Scenario.
+- Tool.
+- Evidence source.
+- Confidence.
+- Iteration.
+
+## Phase-Two Outcomes
+
+This phase is complete when:
+
+- A generic Playwright browser driver can run a simple hosted web flow.
+- Browser runs produce screenshots/video and final answer evidence.
+- Browser runs can be combined with a public MCP trace proxy when the host is
+  configured to use a proxy URL.
+- Claude Cowork has an initial adapter or documented example.
+- Reports clearly show evidence asymmetry between Glean MCP/configured-MCP and
+  native connector variants.
+- Matrix runs work for at least one browser host and one CLI host.
+
+## Explicit Non-Outcomes
+
+- No guarantee that every hosted web client exposes tool traces.
+- No universal interception of host-backend MCP calls.
+- No automatic bypass of host login, MFA, admin setup, or connector approval.
+- No desktop app automation in this phase.
+- No claims-grade token comparison unless token evidence source is high enough
+  confidence for both compared variants.
+
+## Risks
+
+- DOM selectors may be brittle. Prefer host APIs or transcript exports where
+  available.
+- Auth/session state may make cloud execution hard. Treat credential lifecycle
+  as part of host adapter readiness.
+- Hosted clients may change UI or endpoint configuration flows without notice.
+- Some comparisons may have asymmetric observability. The framework should
+  surface this rather than blocking useful lower-confidence runs.


### PR DESCRIPTION
## Summary

- Add an RFC index plus three draft RFCs for external host evals.
- Capture the host support matrix, feasibility tiers, observability ladder, and generic OSS-first architecture.
- Scope phase-one core runtime work and phase-two browser-hosted/Claude Cowork work.
- Exclude `docs/rfcs/` from Prettier and markdown-code snippet sync so draft RFCs are not forced through normal docs formatting gates.

## Validation

- `npm run docs:check`
- `npm exec -- prettier --check "**/*.{ts,tsx,json,md}"`

## Notes

This is intentionally a draft PR for design review. The RFCs avoid assuming Glean-specific infrastructure in the OSS core and call out company-specific trace stores or dashboards as adapters/examples.