### PR TITLE
fix: add missing BrowserConfig type to resolve lint errors

### DIFF
--- a/src/evals/mcpHost/mcpHostTypes.ts
+++ b/src/evals/mcpHost/mcpHostTypes.ts
@@ -113,6 +113,62 @@ export interface CLIConfig {
 }
 
 /**
+ * A cookie to inject into the browser context before running the script.
+ * Matches the shape expected by Playwright's `BrowserContext.addCookies()`.
+ */
+export interface BrowserCookie {
+  name: string;
+  value: string;
+  url?: string;
+  domain?: string;
+  path?: string;
+  expires?: number;
+  httpOnly?: boolean;
+  secure?: boolean;
+  sameSite?: 'Strict' | 'Lax' | 'None';
+  partitionKey?: string;
+}
+
+/**
+ * Configuration for a browser-based host.
+ *
+ * Uses Playwright to launch a Chromium instance, inject auth state,
+ * and execute a user-provided script that drives a web-based MCP host
+ * (e.g., claude.ai).
+ */
+export interface BrowserConfig {
+  /**
+   * Path to the browser script (resolved relative to cwd).
+   * The script must default-export an async function
+   * `(page: Page, scenario: string) => Promise<MCPHostSimulationResult>`.
+   */
+  script: string;
+
+  /**
+   * Timeout in milliseconds for the browser script.
+   * @default 120000 (2 minutes)
+   */
+  timeout?: number;
+
+  /**
+   * Whether to launch in headless mode.
+   * @default true
+   */
+  headless?: boolean;
+
+  /**
+   * Path to a Playwright storage state JSON file (cookies + localStorage).
+   * Resolved relative to cwd.
+   */
+  storageState?: string;
+
+  /**
+   * Extra cookies to inject into the browser context.
+   */
+  cookies?: BrowserCookie[];
+}
+
+/**
  * Configuration for MCP host simulation
  */
 export interface MCPHostConfig {
@@ -164,6 +220,11 @@ export interface MCPHostConfig {
    * CLI host configuration (required for 'cli' host type).
    */
   cli?: CLIConfig;
+
+  /**
+   * Browser host configuration (required for 'browser' host type).
+   */
+  browser?: BrowserConfig;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Added `BrowserConfig` and `BrowserCookie` type definitions to `src/evals/mcpHost/mcpHostTypes.ts`
- Added `browser?: BrowserConfig` field to `MCPHostConfig`
- Resolves 16 `@typescript-eslint/no-unsafe-*` lint errors in `src/evals/mcpHost/adapters/browser/runner.ts` that were caused by the missing type making `browserConfig` an error-typed value

## Test plan
- [x] `npx eslint src/evals/mcpHost/adapters/browser/runner.ts` passes clean
- [x] `npx tsc --noEmit` passes clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)