### PR TITLE
fix: extract usage metrics from CLI host result events

### DIFF
--- a/src/evals/mcpHost/adapters/cli/parsers.test.ts
+++ b/src/evals/mcpHost/adapters/cli/parsers.test.ts
@@ -162,6 +162,76 @@ describe('parseStreamJson', () => {
     expect(result.response).toBeUndefined();
   });
 
+  it('extracts usage metrics from result event', () => {
+    const stdout = [
+      JSON.stringify({
+        type: 'assistant',
+        message: {
+          content: [{ type: 'text', text: 'Hello' }],
+        },
+      }),
+      JSON.stringify({
+        type: 'result',
+        result: 'Hello',
+        usage: {
+          input_tokens: 150,
+          output_tokens: 42,
+          cache_read_input_tokens: 100,
+          cache_creation_input_tokens: 50,
+        },
+        total_cost_usd: 0.0035,
+        duration_ms: 2500,
+        duration_api_ms: 1800,
+      }),
+    ].join('\n');
+
+    const result = parseStreamJson(stdout);
+    expect(result.success).toBe(true);
+    expect(result.usage).toEqual({
+      inputTokens: 150,
+      outputTokens: 42,
+      totalCostUsd: 0.0035,
+      durationMs: 2500,
+      durationApiMs: 1800,
+      cacheReadInputTokens: 100,
+      cacheCreationInputTokens: 50,
+    });
+  });
+
+  it('extracts usage metrics from error result event', () => {
+    const stdout = JSON.stringify({
+      type: 'result',
+      is_error: true,
+      result: 'Something went wrong',
+      usage: { input_tokens: 50, output_tokens: 0 },
+      total_cost_usd: 0.001,
+      duration_ms: 500,
+    });
+
+    const result = parseStreamJson(stdout);
+    expect(result.success).toBe(false);
+    expect(result.usage).toEqual({
+      inputTokens: 50,
+      outputTokens: 0,
+      totalCostUsd: 0.001,
+      durationMs: 500,
+      durationApiMs: undefined,
+      cacheReadInputTokens: undefined,
+      cacheCreationInputTokens: undefined,
+    });
+  });
+
+  it('returns undefined usage when result event has no usage field', () => {
+    const stdout = JSON.stringify({
+      type: 'result',
+      result: 'No usage info',
+    });
+
+    const result = parseStreamJson(stdout);
+    expect(result.success).toBe(true);
+    expect(result.usage).toBeUndefined();
+  });
+
   it('collects tool_result blocks into conversationHistory', () => {
     const stdout = JSON.stringify({
       type: 'user',

--- a/src/evals/mcpHost/adapters/cli/parsers.ts
+++ b/src/evals/mcpHost/adapters/cli/parsers.ts
@@ -2,12 +2,14 @@ import type {
   MCPHostSimulationResult,
   LLMToolCall,
 } from '../../mcpHostTypes.js';
+import type { UsageMetrics } from '../../../../types/index.js';
 
 /** Parses NDJSON (stream-json) output from CLI hosts. */
 export function parseStreamJson(stdout: string): MCPHostSimulationResult {
   const lines = stdout.split('\n').filter((line) => line.trim().length > 0);
   const toolCalls: LLMToolCall[] = [];
   const textParts: string[] = [];
+  let usage: UsageMetrics | undefined;
   const conversationHistory: Array<{
     role: 'user' | 'assistant' | 'tool';
     content: string;
@@ -52,9 +54,21 @@ export function parseStreamJson(stdout: string): MCPHostSimulationResult {
       }
     }
 
-    if (event.type === 'result' && typeof event.result === 'string') {
-      if (textParts.length === 0) {
+    if (event.type === 'result') {
+      if (typeof event.result === 'string' && textParts.length === 0) {
         textParts.push(event.result);
+      }
+
+      if (event.usage) {
+        usage = {
+          inputTokens: event.usage.input_tokens ?? 0,
+          outputTokens: event.usage.output_tokens ?? 0,
+          totalCostUsd: event.total_cost_usd ?? 0,
+          durationMs: event.duration_ms ?? 0,
+          durationApiMs: event.duration_api_ms,
+          cacheReadInputTokens: event.usage.cache_read_input_tokens,
+          cacheCreationInputTokens: event.usage.cache_creation_input_tokens,
+        };
       }
     }
 
@@ -66,6 +80,7 @@ export function parseStreamJson(stdout: string): MCPHostSimulationResult {
           typeof event.result === 'string'
             ? event.result
             : 'CLI host reported an error',
+        usage,
       };
     }
   }
@@ -82,6 +97,7 @@ export function parseStreamJson(stdout: string): MCPHostSimulationResult {
     response: response || undefined,
     conversationHistory:
       conversationHistory.length > 0 ? conversationHistory : undefined,
+    usage,
   };
 }
 
@@ -130,6 +146,15 @@ interface StreamJsonEvent {
   message?: { role?: string; content?: ContentBlock[] };
   result?: string;
   is_error?: boolean;
+  usage?: {
+    input_tokens?: number;
+    output_tokens?: number;
+    cache_read_input_tokens?: number;
+    cache_creation_input_tokens?: number;
+  };
+  total_cost_usd?: number;
+  duration_ms?: number;
+  duration_api_ms?: number;
 }
 
 function getNestedValue(obj: Record<string, unknown>, path: string): unknown {


### PR DESCRIPTION
## Summary
- `parseStreamJson` now captures `usage`, `total_cost_usd`, `duration_ms`, and `duration_api_ms` from `result` events in Claude CLI's stream-json output
- Maps snake_case CLI fields to the existing `UsageMetrics` interface and includes them in both success and error return paths
- `MCPHostSimulationResult.usage` was always `undefined` for CLI-based hosts — this populates it

## Test plan
- [x] Added test: extracts full usage metrics (tokens, cost, durations, cache fields)
- [x] Added test: extracts usage from error result events
- [x] Added test: returns `undefined` usage when result event has no usage field
- [x] All 933 existing tests pass
- [x] typecheck, lint, format, docs:check, build all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)