### PR TITLE
feat: add runtime tool overrides

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -312,6 +312,7 @@ Run an eval dataset. Expectations are defined per-case in the dataset's `expect`
   - `saveResultsTo?: string` - Save run results to file for baseline comparison
   - `omitResponsesFromBaseline?: boolean` - Strip responses from saved baseline (default: `true`)
   - `baselineResultsFrom?: string` - Load baseline file for regression detection
+  - `toolOverrides?: ToolOverrideVariant` - Runtime tool metadata overrides for variant experiments
   - `mcpHostModel?: string` - Model identifier recorded in run metadata
   - `judgeModel?: string` - Judge model identifier recorded in run metadata
 - `context: EvalContext`
@@ -330,9 +331,63 @@ const result = await runEvalDataset(
 console.log(`Passed: ${result.passed}/${result.total}`);
 ```
 
+Runtime tool overrides let you test alternate tool descriptions or input schemas without editing the eval dataset or MCP server source. Tool names are canonical server tool names; v1 does not support renames.
+
+```typescript
+const variant = {
+  id: 'search-description-v2',
+  tools: {
+    search: {
+      description:
+        'Search internal company documents, policies, wiki pages, and announcements.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          query: {
+            type: 'string',
+            description: 'Natural language document or policy query.',
+          },
+        },
+        required: ['query'],
+      },
+    },
+  },
+};
+
+const baseline = await runEvalDataset(
+  { dataset, defaultLlmIterations: 10 },
+  { mcp, testInfo }
+);
+
+const candidate = await runEvalDataset(
+  {
+    dataset,
+    defaultLlmIterations: 10,
+    toolOverrides: variant,
+  },
+  { mcp, testInfo }
+);
+
+console.log(candidate.metadata?.toolOverrideVariantId);
+```
+
+```typescript
+interface ToolOverrideVariant {
+  id: string;
+  description?: string;
+  tools: Record<
+    string,
+    {
+      description?: string;
+      inputSchema?: Record<string, unknown>;
+    }
+  >;
+}
+```
+
 **Result Structure:**
 
-```typescript snippet=src/evals/evalRunner.ts#L66-L143
+```typescript snippet=src/evals/evalRunner.ts#L106-L184
 /**
  * Overall result of running an eval dataset
  */

--- a/docs/mcp-host.md
+++ b/docs/mcp-host.md
@@ -180,9 +180,57 @@ LLM host simulation calls a real LLM API. Approximate costs:
 
 **Recommendation:** Use `mode: "direct"` for regression testing. Use `mode: "mcp_host"` selectively for tool description quality validation.
 
-## A/B Testing Tool Descriptions
+## Runtime Tool Override Experiments
 
-Run two Playwright projects with different MCP server configurations to compare tool description variants:
+Use `toolOverrides` to compare tool metadata variants without changing your eval dataset or MCP server source. The dataset remains the behavioral contract; the override is runtime-only data passed to `runEvalDataset`.
+
+```typescript
+const variant = {
+  id: 'search-description-v2',
+  description: 'Clarify that search is for internal docs and policies.',
+  tools: {
+    search: {
+      description:
+        'Search internal company documents, policies, wiki pages, and announcements. Use this when the user asks to find company information by topic.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          query: {
+            type: 'string',
+            description: 'Natural language document or policy query.',
+          },
+        },
+        required: ['query'],
+      },
+    },
+  },
+};
+
+const baseline = await runEvalDataset(
+  { dataset, defaultLlmIterations: 10 },
+  { mcp, testInfo }
+);
+
+const candidate = await runEvalDataset(
+  {
+    dataset,
+    defaultLlmIterations: 10,
+    toolOverrides: variant,
+  },
+  { mcp, testInfo }
+);
+
+const passRateDelta =
+  candidate.passed / candidate.total - baseline.passed / baseline.total;
+const toolF1Delta =
+  (candidate.datasetToolF1 ?? 0) - (baseline.datasetToolF1 ?? 0);
+```
+
+`toolOverrides.tools` is keyed by canonical MCP tool name. v1 supports `description` and `inputSchema` replacements only; tool renames, mocked responses, and dataset rewriting are intentionally out of scope.
+
+## Project-Based A/B Testing
+
+Run two Playwright projects with different MCP server configurations when the variant is not limited to runtime metadata. This is useful for comparing different server builds, tool behavior, auth scopes, response shapes, transports, or any change that should be exercised through a real MCP server process.
 
 ```typescript
 // playwright.config.ts
@@ -191,20 +239,23 @@ projects: [
     name: 'baseline',
     use: {
       mcpConfig: {
-        /* ... */
+        transport: 'stdio',
+        command: 'node',
+        args: ['./dist/server-v1.js'],
       },
     },
   },
   {
-    name: 'with-skill',
+    name: 'server-v2',
     use: {
       mcpConfig: {
-        /* ... */
+        transport: 'stdio',
+        command: 'node',
+        args: ['./dist/server-v2.js'],
       },
-      mcpHostConfig: { provider: 'anthropic' },
     },
   },
 ];
 ```
 
-The MCP reporter groups results by project, letting you compare pass rates side-by-side.
+The MCP reporter groups results by project, letting you compare pass rates side-by-side. Prefer `toolOverrides` for description and input schema experiments; use project-based A/B testing when the real server surface or implementation changes.

--- a/skills/write-mcp-host-eval/SKILL.md
+++ b/skills/write-mcp-host-eval/SKILL.md
@@ -300,9 +300,47 @@ test('tool discovery evals', async ({ mcp }, testInfo) => {
 1. **Options object** — `{ dataset, concurrency?, ... }` — what to run and how
 2. **Context object** — `{ mcp, testInfo }` — Playwright fixtures from your test
 
-## Step 6 — A/B Testing Tool Descriptions
+## Step 6 — Runtime Tool Override Experiments
 
-Compare tool description variants by running two Playwright projects with different MCP server configs:
+When comparing tool description or input schema variants, do not mutate the eval dataset. Keep the dataset as the behavioral contract and pass variant data dynamically through `runEvalDataset({ toolOverrides })`.
+
+```typescript
+const baseline = await runEvalDataset(
+  { dataset, defaultLlmIterations: 10 },
+  { mcp, testInfo }
+);
+
+const variant = {
+  id: 'search-description-v2',
+  description: 'Clarify that search is for internal docs and policies.',
+  tools: {
+    search: {
+      description:
+        'Search internal company documents, policies, wiki pages, and announcements. Use this when the user asks to find company information by topic.',
+    },
+  },
+};
+
+const candidate = await runEvalDataset(
+  {
+    dataset,
+    defaultLlmIterations: 10,
+    toolOverrides: variant,
+  },
+  { mcp, testInfo }
+);
+```
+
+For agent-driven remediation loops:
+
+- Generate variants as runtime data, not eval dataset edits.
+- Compare baseline and candidate results in userland.
+- Report improved cases, regressed cases, pass-rate delta, and tool F1 delta.
+- Emit a structured override proposal. Do not edit MCP server source unless the user explicitly asks for source remediation.
+
+## Step 7 — Project-Based A/B Testing
+
+Use project-based A/B testing when the variant is not limited to runtime tool metadata. This is the right path for changed tool behavior, changed auth/config/transport, different server builds, changed response shapes, or any experiment that needs to run against a real MCP server variant.
 
 ```typescript
 // playwright.config.ts
@@ -319,7 +357,7 @@ export default defineConfig({
       },
     },
     {
-      name: 'improved-descriptions',
+      name: 'server-v2',
       use: {
         mcpConfig: {
           transport: 'stdio',
@@ -332,7 +370,12 @@ export default defineConfig({
 });
 ```
 
-The MCP reporter groups results by project, letting you compare pass rates side-by-side.
+The MCP reporter groups results by project, letting users compare pass rates side-by-side.
+
+Choose the comparison mode deliberately:
+
+- Use `toolOverrides` for descriptions and input schemas only.
+- Use project-based A/B testing for real server, config, behavior, or response changes.
 
 ## Complete Example
 

--- a/src/evals/evalRunner.toolOverrides.test.ts
+++ b/src/evals/evalRunner.toolOverrides.test.ts
@@ -1,0 +1,254 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { runEvalDataset, type EvalContext } from './evalRunner.js';
+import type { EvalDataset } from './datasetTypes.js';
+import type { MCPFixtureApi } from '../mcp/fixtures/mcpFixture.js';
+import type { Tool } from '@modelcontextprotocol/sdk/types.js';
+
+const mocks = vi.hoisted(() => ({
+  simulateMCPHost: vi.fn(),
+}));
+
+vi.mock('./mcpHost/mcpHostSimulation.js', () => ({
+  simulateMCPHost: mocks.simulateMCPHost,
+}));
+
+function createMockMCP(tools: Tool[]): MCPFixtureApi {
+  return {
+    client: {} as MCPFixtureApi['client'],
+    authType: 'none',
+    project: 'test-project',
+    getServerInfo: vi.fn().mockReturnValue({ name: 'test', version: '1.0.0' }),
+    listTools: vi.fn().mockResolvedValue(tools),
+    callTool: vi.fn().mockResolvedValue({
+      content: [{ type: 'text', text: 'ok' }],
+      isError: false,
+    }),
+  };
+}
+
+function createContext(mcp: MCPFixtureApi): EvalContext {
+  return {
+    mcp,
+    testInfo: {
+      attach: vi.fn().mockResolvedValue(undefined),
+    } as unknown as EvalContext['testInfo'],
+  };
+}
+
+function createHostDataset(): EvalDataset {
+  return {
+    name: 'tool-override-test',
+    cases: [
+      {
+        id: 'search-discovery',
+        mode: 'mcp_host',
+        scenario: 'Find the expense policy',
+        mcpHostConfig: { provider: 'openai', model: 'gpt-4o' },
+        expect: {
+          toolsTriggered: {
+            calls: [{ name: 'search', required: true }],
+          },
+        },
+      },
+    ],
+  };
+}
+
+describe('runEvalDataset toolOverrides', () => {
+  beforeEach(() => {
+    mocks.simulateMCPHost.mockReset();
+  });
+
+  it('exposes overridden tool metadata to mcp_host runs and preserves untouched tools', async () => {
+    const mcp = createMockMCP([
+      {
+        name: 'search',
+        description: 'Old search description',
+        inputSchema: {
+          type: 'object',
+          properties: { query: { type: 'string' } },
+        },
+      },
+      {
+        name: 'read_document',
+        description: 'Read a document',
+        inputSchema: { type: 'object' },
+      },
+    ]);
+
+    let observedTools: Tool[] = [];
+    mocks.simulateMCPHost.mockImplementation(async (hostMcp: MCPFixtureApi) => {
+      observedTools = await hostMcp.listTools();
+      return {
+        success: true,
+        toolCalls: [{ name: 'search', arguments: { query: 'expense' } }],
+        response: 'Done',
+      };
+    });
+
+    const dataset = createHostDataset();
+    const result = await runEvalDataset(
+      {
+        dataset,
+        toolOverrides: {
+          id: 'search-description-v2',
+          tools: {
+            search: {
+              description: 'Search internal company documents and policies.',
+              inputSchema: {
+                type: 'object',
+                properties: {
+                  query: {
+                    type: 'string',
+                    description: 'Natural language document query.',
+                  },
+                },
+                required: ['query'],
+              },
+            },
+          },
+        },
+      },
+      createContext(mcp)
+    );
+
+    expect(result.failed).toBe(0);
+    expect(result.metadata?.toolOverrideVariantId).toBe(
+      'search-description-v2'
+    );
+    expect(result.caseResults[0]?.request?.toolOverrideVariantId).toBe(
+      'search-description-v2'
+    );
+    expect(observedTools).toMatchObject([
+      {
+        name: 'search',
+        description: 'Search internal company documents and policies.',
+        inputSchema: {
+          properties: {
+            query: {
+              description: 'Natural language document query.',
+            },
+          },
+        },
+      },
+      {
+        name: 'read_document',
+        description: 'Read a document',
+      },
+    ]);
+    expect(dataset.cases[0]?.expect?.toolsTriggered?.calls[0]?.name).toBe(
+      'search'
+    );
+  });
+
+  it('forwards canonical tool calls to the underlying MCP fixture', async () => {
+    const mcp = createMockMCP([
+      {
+        name: 'search',
+        description: 'Search',
+        inputSchema: { type: 'object' },
+      },
+    ]);
+
+    mocks.simulateMCPHost.mockImplementation(async (hostMcp: MCPFixtureApi) => {
+      await hostMcp.callTool('search', { query: 'expense policy' });
+      return {
+        success: true,
+        toolCalls: [{ name: 'search', arguments: { query: 'expense policy' } }],
+        response: 'Done',
+      };
+    });
+
+    await runEvalDataset(
+      {
+        dataset: createHostDataset(),
+        toolOverrides: {
+          id: 'search-schema-v2',
+          tools: {
+            search: {
+              description: 'Search internal documents.',
+            },
+          },
+        },
+      },
+      createContext(mcp)
+    );
+
+    expect(mcp.callTool).toHaveBeenCalledWith('search', {
+      query: 'expense policy',
+    });
+  });
+
+  it('fails clearly when an override references an unknown tool', async () => {
+    const mcp = createMockMCP([
+      {
+        name: 'search',
+        description: 'Search',
+        inputSchema: { type: 'object' },
+      },
+    ]);
+
+    mocks.simulateMCPHost.mockImplementation(async (hostMcp: MCPFixtureApi) => {
+      await hostMcp.listTools();
+      return { success: true, toolCalls: [], response: 'Done' };
+    });
+
+    const result = await runEvalDataset(
+      {
+        dataset: createHostDataset(),
+        toolOverrides: {
+          id: 'bad-variant',
+          tools: {
+            missing_tool: {
+              description: 'This tool does not exist.',
+            },
+          },
+        },
+      },
+      createContext(mcp)
+    );
+
+    expect(result.failed).toBe(1);
+    expect(result.caseResults[0]?.error).toContain(
+      'toolOverrides variant "bad-variant" references unknown tool(s): missing_tool'
+    );
+  });
+
+  it('keeps direct mode calls working when toolOverrides are present', async () => {
+    const mcp = createMockMCP([
+      {
+        name: 'search',
+        description: 'Search',
+        inputSchema: { type: 'object' },
+      },
+    ]);
+    const dataset: EvalDataset = {
+      name: 'direct-override-test',
+      cases: [
+        { id: 'direct-search', toolName: 'search', args: { query: 'x' } },
+      ],
+    };
+
+    const result = await runEvalDataset(
+      {
+        dataset,
+        toolOverrides: {
+          id: 'search-description-v2',
+          tools: {
+            search: {
+              description: 'Search internal documents.',
+            },
+          },
+        },
+      },
+      createContext(mcp)
+    );
+
+    expect(result.failed).toBe(0);
+    expect(mcp.callTool).toHaveBeenCalledWith('search', { query: 'x' });
+    expect(mcp.listTools).not.toHaveBeenCalled();
+    expect(result.caseResults[0]?.request?.toolOverrideVariantId).toBe(
+      'search-description-v2'
+    );
+  });
+});

--- a/src/evals/evalRunner.ts
+++ b/src/evals/evalRunner.ts
@@ -1,6 +1,7 @@
 import type { MCPFixtureApi } from '../mcp/fixtures/mcpFixture.js';
 import type { EvalDataset, EvalCase, EvalExpectBlock } from './datasetTypes.js';
 import type { TestInfo, Expect } from '@playwright/test';
+import type { Tool } from '@modelcontextprotocol/sdk/types.js';
 import type { ZodType } from 'zod';
 import { simulateMCPHost } from './mcpHost/mcpHostSimulation.js';
 import type { MCPHostSimulationResult } from './mcpHost/mcpHostTypes.js';
@@ -62,6 +63,45 @@ export type {
   IterationResult,
   EvalRunMetadata,
 } from '../types/reporter.js';
+
+/**
+ * Metadata overrides for a single existing MCP tool.
+ */
+export interface ToolMetadataOverride {
+  /**
+   * Replacement tool description shown to MCP hosts.
+   */
+  description?: string;
+
+  /**
+   * Replacement input schema shown to MCP hosts.
+   */
+  inputSchema?: Record<string, unknown>;
+}
+
+/**
+ * Runtime metadata variant for experimenting with MCP tool discoverability.
+ *
+ * Tool keys are canonical MCP server tool names. Overrides affect only the
+ * metadata returned from listTools(); callTool() still forwards canonical tool
+ * names and arguments to the original MCP server.
+ */
+export interface ToolOverrideVariant {
+  /**
+   * Stable identifier for this runtime variant.
+   */
+  id: string;
+
+  /**
+   * Optional human-readable explanation of what this variant is testing.
+   */
+  description?: string;
+
+  /**
+   * Per-tool metadata overrides keyed by canonical tool name.
+   */
+  tools: Record<string, ToolMetadataOverride>;
+}
 
 /**
  * Overall result of running an eval dataset
@@ -247,6 +287,15 @@ export interface EvalRunnerOptions {
   baselineResultsFrom?: string;
 
   /**
+   * Runtime MCP tool metadata overrides used for variant experiments.
+   *
+   * Overrides are applied to the tool list shown to MCP hosts without changing
+   * the eval dataset or mutating the underlying MCP server. Tool keys must be
+   * canonical tool names exposed by the server.
+   */
+  toolOverrides?: ToolOverrideVariant;
+
+  /**
    * MCP host model identifier to record in run metadata.
    * Use this to identify which model was used when running mcp_host cases.
    *
@@ -276,6 +325,59 @@ export interface EvalCaseOptions {
    * Schema registry for schema validation by name
    */
   schemas?: Record<string, ZodType>;
+
+  /**
+   * Runtime tool override variant id for reporter/debug metadata.
+   */
+  toolOverrideVariantId?: string;
+}
+
+function createToolOverrideMCP(
+  mcp: MCPFixtureApi,
+  variant: ToolOverrideVariant
+): MCPFixtureApi {
+  return {
+    ...mcp,
+
+    async listTools(): Promise<Array<Tool>> {
+      const tools = await mcp.listTools();
+      const knownToolNames = new Set(tools.map((tool) => tool.name));
+      const unknownToolNames = Object.keys(variant.tools).filter(
+        (name) => !knownToolNames.has(name)
+      );
+
+      if (unknownToolNames.length > 0) {
+        throw new Error(
+          `[mcp-server-tester] toolOverrides variant "${variant.id}" references unknown tool(s): ` +
+            unknownToolNames.join(', ')
+        );
+      }
+
+      return tools.map((tool) => {
+        const override = variant.tools[tool.name];
+        if (!override) {
+          return tool;
+        }
+
+        return {
+          ...tool,
+          ...(override.description !== undefined && {
+            description: override.description,
+          }),
+          ...(override.inputSchema !== undefined && {
+            inputSchema: override.inputSchema as Tool['inputSchema'],
+          }),
+        };
+      });
+    },
+
+    async callTool<TArgs extends Record<string, unknown>>(
+      name: string,
+      args: TArgs
+    ) {
+      return mcp.callTool(name, args);
+    },
+  };
 }
 
 async function executeToolCall(
@@ -564,9 +666,15 @@ async function runExpectBlockValidations(
 /**
  * Builds the request metadata from an eval case for inclusion in results.
  */
-function buildRequest(evalCase: EvalCase): EvalCaseRequest {
+function buildRequest(
+  evalCase: EvalCase,
+  toolOverrideVariantId?: string
+): EvalCaseRequest {
   const request: EvalCaseRequest = {};
   if (evalCase.description) request.description = evalCase.description;
+  if (toolOverrideVariantId !== undefined) {
+    request.toolOverrideVariantId = toolOverrideVariantId;
+  }
 
   if (evalCase.mode === 'mcp_host') {
     if (evalCase.scenario) request.scenario = evalCase.scenario;
@@ -675,7 +783,7 @@ async function runSingleIteration(
       evalCase.scenario != null ? 'mcp_host' : (evalCase.toolName ?? 'unknown'),
     source: 'eval',
     pass: didCasePass(error, expectationResults),
-    request: buildRequest(evalCase),
+    request: buildRequest(evalCase, options.toolOverrideVariantId),
     response,
     error,
     expectations: expectationResults,
@@ -821,6 +929,7 @@ export async function runEvalCase(
     project: context.mcp.project,
     durationMs: 0,
     tags: evalCase.tags,
+    request: buildRequest(evalCase, options.toolOverrideVariantId),
   };
 
   const totalHostUsage = iterationResults.reduce(
@@ -946,11 +1055,15 @@ export async function runEvalDataset(
     saveResultsTo,
     omitResponsesFromBaseline = true,
     baselineResultsFrom,
+    toolOverrides,
     mcpHostModel,
     judgeModel,
   } = options;
 
   const startTime = Date.now();
+  const effectiveContext: EvalContext = toolOverrides
+    ? { ...context, mcp: createToolOverrideMCP(context.mcp, toolOverrides) }
+    : context;
 
   // Merge schemas from dataset and options
   const allSchemas = {
@@ -1019,9 +1132,10 @@ export async function runEvalDataset(
         ? { ...withIterations, judgeReps: defaultJudgeReps }
         : withIterations;
 
-    const result = await runEvalCase(effectiveCase, context, {
+    const result = await runEvalCase(effectiveCase, effectiveContext, {
       datasetName: dataset.name,
       schemas: allSchemas,
+      toolOverrideVariantId: toolOverrides?.id,
     });
 
     if (onCaseComplete) {
@@ -1054,6 +1168,9 @@ export async function runEvalDataset(
     gitHash,
     timestamp: new Date().toISOString(),
     packageVersion: packageJson.version,
+    ...(toolOverrides !== undefined && {
+      toolOverrideVariantId: toolOverrides.id,
+    }),
     ...(mcpHostModel !== undefined && { mcpHostModel }),
     ...(judgeModel !== undefined && { judgeModel }),
   };

--- a/src/index.ts
+++ b/src/index.ts
@@ -191,6 +191,8 @@ export type {
   IterationResult,
   EvalRunnerResult,
   EvalRunnerOptions,
+  ToolMetadataOverride,
+  ToolOverrideVariant,
 } from './evals/evalRunner.js';
 export { runEvalDataset, runEvalCase } from './evals/evalRunner.js';
 

--- a/src/types/reporter.ts
+++ b/src/types/reporter.ts
@@ -25,6 +25,8 @@ export interface EvalRunMetadata {
   timestamp: string;
   /** Package version from package.json */
   packageVersion: string;
+  /** Runtime tool override variant identifier, when one was used */
+  toolOverrideVariantId?: string;
   /** MCP host model identifier (if mcp_host mode) */
   mcpHostModel?: string;
   /** Judge model identifier (if judge was used) */
@@ -163,6 +165,8 @@ export interface IterationResult {
 export interface EvalCaseRequest {
   /** Human-readable description of the case */
   description?: string;
+  /** Runtime tool override variant identifier, when one was used */
+  toolOverrideVariantId?: string;
 
   // Direct mode fields
   /** Tool arguments (direct mode) */


### PR DESCRIPTION
## Motivation

`mcp-server-tester` already has `mcp_host` evals for measuring whether an agent can discover the right MCP tool and call it with usable arguments. The next useful loop is experimentation: when those evals fail, an agent should be able to try clearer tool descriptions or input schemas, rerun the same evals, and report whether the variant improved tool selection.

Before this change, that kind of experiment required either editing the MCP server source or standing up a second Playwright project/server config. That works for true implementation A/B tests, but it is too heavy for metadata-only experiments and makes agent-driven iteration awkward. It also risks conflating the eval dataset, which should remain the behavioral contract, with the variant being tested.

This PR adds runtime tool metadata overrides so callers can keep the dataset stable and pass variant data into `runEvalDataset` for a specific run.

## What changed

- Added `toolOverrides?: ToolOverrideVariant` to `runEvalDataset` options.
- Added exported `ToolOverrideVariant` and `ToolMetadataOverride` types.
- Internally wraps the MCP fixture for override runs:
  - `listTools()` applies description and input schema overrides by canonical tool name.
  - `callTool()` still forwards canonical tool names and arguments to the real MCP server.
  - unknown override tool names fail clearly during tool listing.
- Records the override variant id in run metadata and per-case request metadata so saved/reporter output can identify candidate runs.
- Added focused coverage for override metadata, canonical call forwarding, unknown tool validation, and direct-mode behavior.
- Updated docs and the `write-mcp-host-eval` skill to describe both runtime metadata experiments and project-based A/B testing.

## Usage

```ts
const baseline = await runEvalDataset(
  { dataset, defaultLlmIterations: 10 },
  { mcp, testInfo }
);

const candidate = await runEvalDataset(
  {
    dataset,
    defaultLlmIterations: 10,
    toolOverrides: {
      id: "search-description-v2",
      tools: {
        search: {
          description:
            "Search internal company documents, policies, wiki pages, and announcements.",
        },
      },
    },
  },
  { mcp, testInfo }
);
```

## Scope

This intentionally does not support tool renames, mocked responses, source remediation, or dataset mutation. Runtime overrides are for metadata-only experiments. Project-based A/B testing remains documented for real server/config/behavior changes.

## Validation

- `npm run typecheck`
- `npm test`
- `npm run format:check`
- `npm run docs:check`
- `npm run lint`