### PR TITLE
feat: add eval run comparison utility

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -371,6 +371,25 @@ const candidate = await runEvalDataset(
 console.log(candidate.metadata?.toolOverrideVariantId);
 ```
 
+Use `compareEvalRuns()` to summarize the completed baseline and candidate runs:
+
+```typescript
+import { compareEvalRuns } from '@gleanwork/mcp-server-tester';
+
+const comparison = compareEvalRuns({
+  baseline,
+  candidate,
+  labels: {
+    baseline: 'baseline',
+    candidate: variant.id,
+  },
+});
+
+console.log(`Pass-rate delta: ${comparison.deltaPassRate}`);
+console.log(`Improved cases: ${comparison.improvedCases.length}`);
+console.log(`Regressed cases: ${comparison.regressedCases.length}`);
+```
+
 ```typescript
 interface ToolOverrideVariant {
   id: string;
@@ -384,6 +403,35 @@ interface ToolOverrideVariant {
   >;
 }
 ```
+
+### `compareEvalRuns(options)`
+
+Compare two completed eval runs. This is a pure utility: it does not run evals, read or write baselines, call LLMs, or mutate datasets.
+
+**Parameters:**
+
+- `options: CompareEvalRunsOptions`
+  - `baseline: EvalRunnerResult` - Baseline run result
+  - `candidate: EvalRunnerResult` - Candidate run result
+  - `labels?: { baseline?: string; candidate?: string }` - Optional display labels
+
+**Returns:** `EvalRunComparisonResult`
+
+```typescript
+const comparison = compareEvalRuns({
+  baseline,
+  candidate,
+});
+```
+
+The result includes pass-rate deltas, optional tool precision/recall/F1 deltas, and case buckets:
+
+- `improvedCases` - failed in baseline, passed in candidate
+- `regressedCases` - passed in baseline, failed in candidate
+- `unchangedPasses` - passed in both runs
+- `unchangedFailures` - failed in both runs
+- `missingFromBaseline` - case exists only in candidate
+- `missingFromCandidate` - case exists only in baseline
 
 **Result Structure:**
 

--- a/docs/mcp-host.md
+++ b/docs/mcp-host.md
@@ -185,6 +185,8 @@ LLM host simulation calls a real LLM API. Approximate costs:
 Use `toolOverrides` to compare tool metadata variants without changing your eval dataset or MCP server source. The dataset remains the behavioral contract; the override is runtime-only data passed to `runEvalDataset`.
 
 ```typescript
+import { compareEvalRuns } from '@gleanwork/mcp-server-tester';
+
 const variant = {
   id: 'search-description-v2',
   description: 'Clarify that search is for internal docs and policies.',
@@ -220,10 +222,18 @@ const candidate = await runEvalDataset(
   { mcp, testInfo }
 );
 
-const passRateDelta =
-  candidate.passed / candidate.total - baseline.passed / baseline.total;
-const toolF1Delta =
-  (candidate.datasetToolF1 ?? 0) - (baseline.datasetToolF1 ?? 0);
+const comparison = compareEvalRuns({
+  baseline,
+  candidate,
+  labels: {
+    baseline: 'baseline',
+    candidate: variant.id,
+  },
+});
+
+console.log(`Pass-rate delta: ${comparison.deltaPassRate}`);
+console.log(`Tool F1 delta: ${comparison.deltaToolF1 ?? 'n/a'}`);
+console.log(`Improved cases: ${comparison.improvedCases.length}`);
 ```
 
 `toolOverrides.tools` is keyed by canonical MCP tool name. v1 supports `description` and `inputSchema` replacements only; tool renames, mocked responses, and dataset rewriting are intentionally out of scope.

--- a/skills/write-mcp-host-eval/SKILL.md
+++ b/skills/write-mcp-host-eval/SKILL.md
@@ -305,6 +305,8 @@ test('tool discovery evals', async ({ mcp }, testInfo) => {
 When comparing tool description or input schema variants, do not mutate the eval dataset. Keep the dataset as the behavioral contract and pass variant data dynamically through `runEvalDataset({ toolOverrides })`.
 
 ```typescript
+import { compareEvalRuns } from '@gleanwork/mcp-server-tester';
+
 const baseline = await runEvalDataset(
   { dataset, defaultLlmIterations: 10 },
   { mcp, testInfo }
@@ -329,13 +331,22 @@ const candidate = await runEvalDataset(
   },
   { mcp, testInfo }
 );
+
+const comparison = compareEvalRuns({
+  baseline,
+  candidate,
+  labels: {
+    baseline: 'baseline',
+    candidate: variant.id,
+  },
+});
 ```
 
 For agent-driven remediation loops:
 
 - Generate variants as runtime data, not eval dataset edits.
-- Compare baseline and candidate results in userland.
-- Report improved cases, regressed cases, pass-rate delta, and tool F1 delta.
+- Compare baseline and candidate results with `compareEvalRuns`.
+- Report pass-rate delta, tool precision/recall/F1 deltas, improved cases, regressed cases, and unchanged failures.
 - Emit a structured override proposal. Do not edit MCP server source unless the user explicitly asks for source remediation.
 
 ## Step 7 — Project-Based A/B Testing

--- a/src/evals/evalRunComparison.test.ts
+++ b/src/evals/evalRunComparison.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, it } from 'vitest';
+import { compareEvalRuns } from './evalRunComparison.js';
+import type { EvalRunnerResult } from './evalRunner.js';
+import type { EvalCaseResult } from '../types/reporter.js';
+
+function createCase(id: string, pass: boolean): EvalCaseResult {
+  return {
+    id,
+    datasetName: 'comparison-test',
+    toolName: 'mcp_host',
+    source: 'eval',
+    pass,
+    expectations: {},
+    durationMs: 1,
+  };
+}
+
+function createRun(
+  cases: EvalCaseResult[],
+  overrides: Partial<EvalRunnerResult> = {}
+): EvalRunnerResult {
+  const passed = cases.filter((c) => c.pass).length;
+  return {
+    total: cases.length,
+    passed,
+    failed: cases.length - passed,
+    caseResults: cases,
+    durationMs: 10,
+    ...overrides,
+  };
+}
+
+describe('compareEvalRuns', () => {
+  it('buckets improved, regressed, unchanged, and missing cases', () => {
+    const baseline = createRun([
+      createCase('improved', false),
+      createCase('regressed', true),
+      createCase('unchanged-pass', true),
+      createCase('unchanged-fail', false),
+      createCase('missing-from-candidate', true),
+    ]);
+    const candidate = createRun([
+      createCase('improved', true),
+      createCase('regressed', false),
+      createCase('unchanged-pass', true),
+      createCase('unchanged-fail', false),
+      createCase('missing-from-baseline', true),
+    ]);
+
+    const result = compareEvalRuns({ baseline, candidate });
+
+    expect(result.cases.map((c) => [c.id, c.outcome])).toEqual([
+      ['improved', 'IMPROVED'],
+      ['regressed', 'REGRESSED'],
+      ['unchanged-pass', 'UNCHANGED_PASS'],
+      ['unchanged-fail', 'UNCHANGED_FAIL'],
+      ['missing-from-candidate', 'MISSING_FROM_CANDIDATE'],
+      ['missing-from-baseline', 'MISSING_FROM_BASELINE'],
+    ]);
+    expect(result.improvedCases.map((c) => c.id)).toEqual(['improved']);
+    expect(result.regressedCases.map((c) => c.id)).toEqual(['regressed']);
+    expect(result.unchangedPasses.map((c) => c.id)).toEqual(['unchanged-pass']);
+    expect(result.unchangedFailures.map((c) => c.id)).toEqual([
+      'unchanged-fail',
+    ]);
+    expect(result.missingFromBaseline.map((c) => c.id)).toEqual([
+      'missing-from-baseline',
+    ]);
+    expect(result.missingFromCandidate.map((c) => c.id)).toEqual([
+      'missing-from-candidate',
+    ]);
+  });
+
+  it('computes pass-rate and tool metric deltas', () => {
+    const baseline = createRun(
+      [createCase('a', true), createCase('b', false), createCase('c', false)],
+      {
+        datasetToolPrecision: 0.5,
+        datasetToolRecall: 0.25,
+        datasetToolF1: 1 / 3,
+      }
+    );
+    const candidate = createRun(
+      [createCase('a', true), createCase('b', true), createCase('c', false)],
+      {
+        datasetToolPrecision: 0.75,
+        datasetToolRecall: 0.5,
+        datasetToolF1: 0.6,
+      }
+    );
+
+    const result = compareEvalRuns({ baseline, candidate });
+
+    expect(result.baselinePassRate).toBeCloseTo(1 / 3);
+    expect(result.candidatePassRate).toBeCloseTo(2 / 3);
+    expect(result.deltaPassRate).toBeCloseTo(1 / 3);
+    expect(result.baselineToolPrecision).toBe(0.5);
+    expect(result.candidateToolPrecision).toBe(0.75);
+    expect(result.deltaToolPrecision).toBe(0.25);
+    expect(result.baselineToolRecall).toBe(0.25);
+    expect(result.candidateToolRecall).toBe(0.5);
+    expect(result.deltaToolRecall).toBe(0.25);
+    expect(result.baselineToolF1).toBeCloseTo(1 / 3);
+    expect(result.candidateToolF1).toBe(0.6);
+    expect(result.deltaToolF1).toBeCloseTo(0.6 - 1 / 3);
+  });
+
+  it('omits metric deltas when only one side has a metric', () => {
+    const baseline = createRun([createCase('a', true)], {
+      datasetToolPrecision: 0.5,
+    });
+    const candidate = createRun([createCase('a', true)]);
+
+    const result = compareEvalRuns({ baseline, candidate });
+
+    expect(result.baselineToolPrecision).toBe(0.5);
+    expect(result.candidateToolPrecision).toBeUndefined();
+    expect(result.deltaToolPrecision).toBeUndefined();
+  });
+
+  it('uses explicit labels and candidate variant id defaults', () => {
+    const baseline = createRun([createCase('a', true)]);
+    const candidate = createRun([createCase('a', true)], {
+      metadata: {
+        timestamp: '2026-05-19T00:00:00.000Z',
+        packageVersion: '1.0.0',
+        toolOverrideVariantId: 'search-description-v2',
+      },
+    });
+
+    expect(compareEvalRuns({ baseline, candidate }).candidateLabel).toBe(
+      'search-description-v2'
+    );
+
+    const labeled = compareEvalRuns({
+      baseline,
+      candidate,
+      labels: {
+        baseline: 'control',
+        candidate: 'candidate-a',
+      },
+    });
+
+    expect(labeled.baselineLabel).toBe('control');
+    expect(labeled.candidateLabel).toBe('candidate-a');
+  });
+
+  it('returns zero pass rates for empty runs', () => {
+    const result = compareEvalRuns({
+      baseline: createRun([]),
+      candidate: createRun([]),
+    });
+
+    expect(result.baselinePassRate).toBe(0);
+    expect(result.candidatePassRate).toBe(0);
+    expect(result.deltaPassRate).toBe(0);
+  });
+});

--- a/src/evals/evalRunComparison.ts
+++ b/src/evals/evalRunComparison.ts
@@ -1,0 +1,205 @@
+import type { EvalCaseResult } from '../types/reporter.js';
+import type { EvalRunnerResult } from './evalRunner.js';
+
+/** Labels used when presenting an eval run comparison. */
+export interface EvalRunComparisonLabels {
+  /** Label for the baseline run. Defaults to "baseline". */
+  baseline?: string;
+  /** Label for the candidate run. Defaults to the candidate variant id or "candidate". */
+  candidate?: string;
+}
+
+/** Outcome of comparing one eval case across two completed eval runs. */
+export type EvalCaseComparisonOutcome =
+  | 'IMPROVED'
+  | 'REGRESSED'
+  | 'UNCHANGED_PASS'
+  | 'UNCHANGED_FAIL'
+  | 'MISSING_FROM_BASELINE'
+  | 'MISSING_FROM_CANDIDATE';
+
+/** Per-case comparison between a baseline run and candidate run. */
+export interface EvalCaseComparison {
+  /** Case ID */
+  id: string;
+  /** Outcome for this case */
+  outcome: EvalCaseComparisonOutcome;
+  /** Baseline case result, absent when the case only exists in the candidate run */
+  baseline?: EvalCaseResult;
+  /** Candidate case result, absent when the case only exists in the baseline run */
+  candidate?: EvalCaseResult;
+}
+
+/** Options for comparing two completed eval runs. */
+export interface CompareEvalRunsOptions {
+  /** Baseline run result */
+  baseline: EvalRunnerResult;
+  /** Candidate run result */
+  candidate: EvalRunnerResult;
+  /** Optional human-readable run labels */
+  labels?: EvalRunComparisonLabels;
+}
+
+/** Aggregated comparison between two completed eval runs. */
+export interface EvalRunComparisonResult {
+  /** Baseline label */
+  baselineLabel: string;
+  /** Candidate label */
+  candidateLabel: string;
+  /** Baseline pass rate (passed / total, or 0 when total is 0) */
+  baselinePassRate: number;
+  /** Candidate pass rate (passed / total, or 0 when total is 0) */
+  candidatePassRate: number;
+  /** Candidate pass rate minus baseline pass rate */
+  deltaPassRate: number;
+  /** Baseline dataset tool precision, when present */
+  baselineToolPrecision?: number;
+  /** Candidate dataset tool precision, when present */
+  candidateToolPrecision?: number;
+  /** Candidate precision minus baseline precision, when both are present */
+  deltaToolPrecision?: number;
+  /** Baseline dataset tool recall, when present */
+  baselineToolRecall?: number;
+  /** Candidate dataset tool recall, when present */
+  candidateToolRecall?: number;
+  /** Candidate recall minus baseline recall, when both are present */
+  deltaToolRecall?: number;
+  /** Baseline dataset tool F1, when present */
+  baselineToolF1?: number;
+  /** Candidate dataset tool F1, when present */
+  candidateToolF1?: number;
+  /** Candidate F1 minus baseline F1, when both are present */
+  deltaToolF1?: number;
+  /** All per-case comparison records in deterministic order */
+  cases: EvalCaseComparison[];
+  /** Cases that failed in baseline and passed in candidate */
+  improvedCases: EvalCaseComparison[];
+  /** Cases that passed in baseline and failed in candidate */
+  regressedCases: EvalCaseComparison[];
+  /** Cases that passed in both runs */
+  unchangedPasses: EvalCaseComparison[];
+  /** Cases that failed in both runs */
+  unchangedFailures: EvalCaseComparison[];
+  /** Cases present only in candidate */
+  missingFromBaseline: EvalCaseComparison[];
+  /** Cases present only in baseline */
+  missingFromCandidate: EvalCaseComparison[];
+}
+
+/**
+ * Compares two completed eval runs without running any evals or reading files.
+ *
+ * Use this after running a baseline and candidate (for example a toolOverrides
+ * variant) to compute pass-rate deltas, tool metric deltas, and per-case
+ * improvement/regression buckets.
+ */
+export function compareEvalRuns(
+  options: CompareEvalRunsOptions
+): EvalRunComparisonResult {
+  const { baseline, candidate, labels } = options;
+  const candidateMap = new Map<string, EvalCaseResult>(
+    candidate.caseResults.map((result) => [result.id, result])
+  );
+
+  const cases: EvalCaseComparison[] = [];
+  const seenIds = new Set<string>();
+
+  for (const baselineCase of baseline.caseResults) {
+    seenIds.add(baselineCase.id);
+    const candidateCase = candidateMap.get(baselineCase.id);
+    if (!candidateCase) {
+      cases.push({
+        id: baselineCase.id,
+        outcome: 'MISSING_FROM_CANDIDATE',
+        baseline: baselineCase,
+      });
+      continue;
+    }
+
+    cases.push({
+      id: baselineCase.id,
+      outcome: compareCaseOutcome(baselineCase.pass, candidateCase.pass),
+      baseline: baselineCase,
+      candidate: candidateCase,
+    });
+  }
+
+  for (const candidateCase of candidate.caseResults) {
+    if (seenIds.has(candidateCase.id)) {
+      continue;
+    }
+
+    cases.push({
+      id: candidateCase.id,
+      outcome: 'MISSING_FROM_BASELINE',
+      candidate: candidateCase,
+    });
+  }
+
+  const baselinePassRate = passRate(baseline);
+  const candidatePassRate = passRate(candidate);
+
+  return {
+    baselineLabel: labels?.baseline ?? 'baseline',
+    candidateLabel:
+      labels?.candidate ??
+      candidate.metadata?.toolOverrideVariantId ??
+      'candidate',
+    baselinePassRate,
+    candidatePassRate,
+    deltaPassRate: candidatePassRate - baselinePassRate,
+    ...metricDelta(
+      'ToolPrecision',
+      baseline.datasetToolPrecision,
+      candidate.datasetToolPrecision
+    ),
+    ...metricDelta(
+      'ToolRecall',
+      baseline.datasetToolRecall,
+      candidate.datasetToolRecall
+    ),
+    ...metricDelta('ToolF1', baseline.datasetToolF1, candidate.datasetToolF1),
+    cases,
+    improvedCases: cases.filter((c) => c.outcome === 'IMPROVED'),
+    regressedCases: cases.filter((c) => c.outcome === 'REGRESSED'),
+    unchangedPasses: cases.filter((c) => c.outcome === 'UNCHANGED_PASS'),
+    unchangedFailures: cases.filter((c) => c.outcome === 'UNCHANGED_FAIL'),
+    missingFromBaseline: cases.filter(
+      (c) => c.outcome === 'MISSING_FROM_BASELINE'
+    ),
+    missingFromCandidate: cases.filter(
+      (c) => c.outcome === 'MISSING_FROM_CANDIDATE'
+    ),
+  };
+}
+
+function compareCaseOutcome(
+  baselinePass: boolean,
+  candidatePass: boolean
+): EvalCaseComparisonOutcome {
+  if (!baselinePass && candidatePass) return 'IMPROVED';
+  if (baselinePass && !candidatePass) return 'REGRESSED';
+  return baselinePass ? 'UNCHANGED_PASS' : 'UNCHANGED_FAIL';
+}
+
+function passRate(result: EvalRunnerResult): number {
+  return result.total > 0 ? result.passed / result.total : 0;
+}
+
+function metricDelta(
+  name: 'ToolPrecision' | 'ToolRecall' | 'ToolF1',
+  baselineValue: number | undefined,
+  candidateValue: number | undefined
+): Record<string, number> {
+  const result: Record<string, number> = {};
+  if (baselineValue !== undefined) {
+    result[`baseline${name}`] = baselineValue;
+  }
+  if (candidateValue !== undefined) {
+    result[`candidate${name}`] = candidateValue;
+  }
+  if (baselineValue !== undefined && candidateValue !== undefined) {
+    result[`delta${name}`] = candidateValue - baselineValue;
+  }
+  return result;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -212,6 +212,16 @@ export type {
 } from './evals/serverComparison.js';
 export { runServerComparison } from './evals/serverComparison.js';
 
+// Completed eval run comparison
+export type {
+  CompareEvalRunsOptions,
+  EvalCaseComparison,
+  EvalCaseComparisonOutcome,
+  EvalRunComparisonLabels,
+  EvalRunComparisonResult,
+} from './evals/evalRunComparison.js';
+export { compareEvalRuns } from './evals/evalRunComparison.js';
+
 // MCP Host Simulation
 export type {
   HostType,


### PR DESCRIPTION
## Motivation

Runtime tool overrides let callers run the same eval dataset against baseline and candidate tool metadata. The next repeated task is comparing those completed runs in a consistent way. Without a helper, agents and users have to hand-roll case matching, pass-rate deltas, and tool precision/recall/F1 deltas every time they test a variant.

This keeps the library aligned with the existing architecture: `runEvalDataset` produces results, and comparison utilities summarize results. It avoids adding an optimizer or another runner API before the comparison primitive proves useful.

## What Changed

- Added `compareEvalRuns(...)`, a pure utility for comparing two completed `EvalRunnerResult`s.
- Added exported comparison types for labels, per-case outcomes, and aggregate results.
- Bucketed cases into improved, regressed, unchanged pass/fail, and missing-from-baseline/candidate groups.
- Computed pass-rate deltas and optional tool precision/recall/F1 deltas.
- Updated API docs, MCP host docs, and `write-mcp-host-eval` skill guidance to use `compareEvalRuns` after baseline/candidate runs.
- Added unit coverage for case bucketing, metric deltas, label defaults/overrides, and empty runs.

## Scope

This utility does not run evals, call LLMs, read/write baselines, mutate datasets, or perform agentic optimization. Multi-candidate matrix comparison can be added later if pairwise comparison proves useful.

## Validation

- `npm run typecheck`
- `npm test`
- `npm run format:check`
- `npm run docs:check`
- `npm run lint`
