### PR TITLE
docs: add runtime override experiment harness

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -390,6 +390,8 @@ console.log(`Improved cases: ${comparison.improvedCases.length}`);
 console.log(`Regressed cases: ${comparison.regressedCases.length}`);
 ```
 
+For a complete baseline → candidate → comparison → proposal harness, see [Runtime Tool Override Experiments](./mcp-host.md#runtime-tool-override-experiments).
+
 ```typescript
 interface ToolOverrideVariant {
   id: string;

--- a/docs/mcp-host.md
+++ b/docs/mcp-host.md
@@ -238,6 +238,131 @@ console.log(`Improved cases: ${comparison.improvedCases.length}`);
 
 `toolOverrides.tools` is keyed by canonical MCP tool name. v1 supports `description` and `inputSchema` replacements only; tool renames, mocked responses, and dataset rewriting are intentionally out of scope.
 
+### Experiment harness pattern
+
+Keep the experiment loop outside the runner until the orchestration pattern proves itself. A harness should:
+
+- Run the unchanged dataset once as the baseline.
+- Run the same dataset again with one runtime `toolOverrides` candidate.
+- Compare completed runs with `compareEvalRuns`.
+- Emit structured proposal data when the candidate still has unchanged failures or regressions.
+- Leave dataset edits, server source changes, and multi-candidate optimization to userland.
+
+```typescript snippet=snippets/runtime-tool-override-experiment.ts
+import { test, expect } from '@gleanwork/mcp-server-tester/fixtures/mcp';
+import {
+  compareEvalRuns,
+  loadEvalDataset,
+  runEvalDataset,
+  type EvalRunComparisonResult,
+  type ToolOverrideVariant,
+} from '@gleanwork/mcp-server-tester';
+
+interface ToolOverrideProposal {
+  variantId: string;
+  reason: string;
+  toolOverrides: ToolOverrideVariant;
+  evidence: {
+    unchangedFailures: string[];
+    regressedCases: string[];
+  };
+}
+
+test('compare a runtime tool metadata variant', async ({ mcp }, testInfo) => {
+  const dataset = await loadEvalDataset('./data/host-evals.json');
+
+  const baseline = await runEvalDataset(
+    { dataset, defaultLlmIterations: 10 },
+    { mcp, testInfo }
+  );
+
+  const candidateVariant: ToolOverrideVariant = {
+    id: 'search-description-v2',
+    description: 'Clarify when to use search for internal knowledge.',
+    tools: {
+      search: {
+        description:
+          'Search internal company documents, policies, wiki pages, and announcements. Use this when the user asks to find company information by topic.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            query: {
+              type: 'string',
+              description:
+                'Natural language query describing the document, policy, or topic to find.',
+            },
+          },
+          required: ['query'],
+        },
+      },
+    },
+  };
+
+  const candidate = await runEvalDataset(
+    {
+      dataset,
+      defaultLlmIterations: 10,
+      toolOverrides: candidateVariant,
+    },
+    { mcp, testInfo }
+  );
+
+  const comparison = compareEvalRuns({
+    baseline,
+    candidate,
+    labels: {
+      baseline: 'baseline',
+      candidate: candidateVariant.id,
+    },
+  });
+
+  const proposal = buildNextOverrideProposal(comparison, candidateVariant);
+  if (proposal) {
+    console.log(JSON.stringify(proposal, null, 2));
+  }
+
+  expect(comparison.regressedCases, proposal?.reason).toHaveLength(0);
+  expect(comparison.candidatePassRate).toBeGreaterThanOrEqual(
+    comparison.baselinePassRate
+  );
+});
+
+function buildNextOverrideProposal(
+  comparison: EvalRunComparisonResult,
+  previousVariant: ToolOverrideVariant
+): ToolOverrideProposal | undefined {
+  const unresolved = comparison.unchangedFailures.map((c) => c.id);
+  const regressed = comparison.regressedCases.map((c) => c.id);
+
+  if (unresolved.length === 0 && regressed.length === 0) {
+    return undefined;
+  }
+
+  return {
+    variantId: 'search-description-v3',
+    reason:
+      'The candidate still has failed or regressed cases. Propose a narrower search description before changing server source.',
+    toolOverrides: {
+      ...previousVariant,
+      id: 'search-description-v3',
+      description: 'Further clarify search intent and query construction.',
+      tools: {
+        ...previousVariant.tools,
+        search: {
+          ...previousVariant.tools.search,
+          description:
+            'Use search only to find internal company knowledge such as documents, policies, wiki pages, and announcements. Convert the user request into a concise topic query.',
+        },
+      },
+    },
+    evidence: {
+      unchangedFailures: unresolved,
+      regressedCases: regressed,
+    },
+  };
+}
+```
+
 ## Project-Based A/B Testing
 
 Run two Playwright projects with different MCP server configurations when the variant is not limited to runtime metadata. This is useful for comparing different server builds, tool behavior, auth scopes, response shapes, transports, or any change that should be exercised through a real MCP server process.

--- a/examples/README.md
+++ b/examples/README.md
@@ -106,6 +106,17 @@ test('LLM discovers directory contents', async ({ mcp }) => {
 });
 ```
 
+### Runtime Tool Metadata Experiments
+
+Use runtime `toolOverrides` when you want to test description or input schema variants without changing the eval dataset or MCP server source. The harness pattern is:
+
+1. Run the unchanged dataset as the baseline.
+2. Run the same dataset with one `toolOverrides` candidate.
+3. Compare completed runs with `compareEvalRuns`.
+4. Emit structured proposal data for the next candidate when failures remain.
+
+See [Runtime Tool Override Experiments](../docs/mcp-host.md#runtime-tool-override-experiments) for a complete example.
+
 ## Example Comparison
 
 | Feature             | basic | filesystem | sqlite |

--- a/skills/write-mcp-host-eval/SKILL.md
+++ b/skills/write-mcp-host-eval/SKILL.md
@@ -349,6 +349,14 @@ For agent-driven remediation loops:
 - Report pass-rate delta, tool precision/recall/F1 deltas, improved cases, regressed cases, and unchanged failures.
 - Emit a structured override proposal. Do not edit MCP server source unless the user explicitly asks for source remediation.
 
+Preferred harness shape:
+
+1. Run the unchanged dataset as `baseline`.
+2. Run the same dataset with exactly one `toolOverrides` candidate.
+3. Call `compareEvalRuns({ baseline, candidate, labels })`.
+4. If regressions or unchanged failures remain, emit JSON-like proposal data with `variantId`, `reason`, `toolOverrides`, and evidence case IDs.
+5. Let the caller decide whether to run the next candidate. Do not build a hidden self-edit loop into the generated test.
+
 ## Step 7 — Project-Based A/B Testing
 
 Use project-based A/B testing when the variant is not limited to runtime tool metadata. This is the right path for changed tool behavior, changed auth/config/transport, different server builds, changed response shapes, or any experiment that needs to run against a real MCP server variant.

--- a/snippets/runtime-tool-override-experiment.ts
+++ b/snippets/runtime-tool-override-experiment.ts
@@ -1,0 +1,112 @@
+import { test, expect } from '@gleanwork/mcp-server-tester/fixtures/mcp';
+import {
+  compareEvalRuns,
+  loadEvalDataset,
+  runEvalDataset,
+  type EvalRunComparisonResult,
+  type ToolOverrideVariant,
+} from '@gleanwork/mcp-server-tester';
+
+interface ToolOverrideProposal {
+  variantId: string;
+  reason: string;
+  toolOverrides: ToolOverrideVariant;
+  evidence: {
+    unchangedFailures: string[];
+    regressedCases: string[];
+  };
+}
+
+test('compare a runtime tool metadata variant', async ({ mcp }, testInfo) => {
+  const dataset = await loadEvalDataset('./data/host-evals.json');
+
+  const baseline = await runEvalDataset(
+    { dataset, defaultLlmIterations: 10 },
+    { mcp, testInfo }
+  );
+
+  const candidateVariant: ToolOverrideVariant = {
+    id: 'search-description-v2',
+    description: 'Clarify when to use search for internal knowledge.',
+    tools: {
+      search: {
+        description:
+          'Search internal company documents, policies, wiki pages, and announcements. Use this when the user asks to find company information by topic.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            query: {
+              type: 'string',
+              description:
+                'Natural language query describing the document, policy, or topic to find.',
+            },
+          },
+          required: ['query'],
+        },
+      },
+    },
+  };
+
+  const candidate = await runEvalDataset(
+    {
+      dataset,
+      defaultLlmIterations: 10,
+      toolOverrides: candidateVariant,
+    },
+    { mcp, testInfo }
+  );
+
+  const comparison = compareEvalRuns({
+    baseline,
+    candidate,
+    labels: {
+      baseline: 'baseline',
+      candidate: candidateVariant.id,
+    },
+  });
+
+  const proposal = buildNextOverrideProposal(comparison, candidateVariant);
+  if (proposal) {
+    console.log(JSON.stringify(proposal, null, 2));
+  }
+
+  expect(comparison.regressedCases, proposal?.reason).toHaveLength(0);
+  expect(comparison.candidatePassRate).toBeGreaterThanOrEqual(
+    comparison.baselinePassRate
+  );
+});
+
+function buildNextOverrideProposal(
+  comparison: EvalRunComparisonResult,
+  previousVariant: ToolOverrideVariant
+): ToolOverrideProposal | undefined {
+  const unresolved = comparison.unchangedFailures.map((c) => c.id);
+  const regressed = comparison.regressedCases.map((c) => c.id);
+
+  if (unresolved.length === 0 && regressed.length === 0) {
+    return undefined;
+  }
+
+  return {
+    variantId: 'search-description-v3',
+    reason:
+      'The candidate still has failed or regressed cases. Propose a narrower search description before changing server source.',
+    toolOverrides: {
+      ...previousVariant,
+      id: 'search-description-v3',
+      description: 'Further clarify search intent and query construction.',
+      tools: {
+        ...previousVariant.tools,
+        search: {
+          ...previousVariant.tools.search,
+          description:
+            'Use search only to find internal company knowledge such as documents, policies, wiki pages, and announcements. Convert the user request into a concise topic query.',
+        },
+      },
+    },
+    evidence: {
+      unchangedFailures: unresolved,
+      regressedCases: regressed,
+    },
+  };
+}


### PR DESCRIPTION
## Motivation

The comparison utility gives callers a consistent way to summarize baseline and candidate eval runs. The next thing agents need is a concrete, repeatable harness shape for using that primitive with runtime tool metadata overrides.

This documents the experiment loop without adding another orchestration API too early. The intent is to make the recommended mechanics obvious: keep eval datasets stable, pass variants dynamically through `toolOverrides`, compare the completed runs, and emit a structured proposal for the next candidate instead of silently editing server source or datasets.

## What Changed

- Added `snippets/runtime-tool-override-experiment.ts` with a baseline → candidate → comparison → proposal example.
- Documented the experiment harness pattern in the MCP host guide.
- Added cross-references from the API docs and examples index.
- Updated the `write-mcp-host-eval` skill so generated host evals follow the same loop.

## Scope

This remains a userland pattern. It does not add new public APIs, run multiple candidates automatically, mutate datasets, edit MCP server source, or introduce hidden self-remediation behavior.

## Validation

- `npm run format:check`
- `npm run docs:check`
- `npm run typecheck`
- `npm run lint`
- `npm test`
