### PR TITLE
internal: centralize public type exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,11 @@
       "import": "./dist/index.js",
       "require": "./dist/index.cjs"
     },
+    "./types": {
+      "types": "./dist/types/index.d.ts",
+      "import": "./dist/types/index.js",
+      "require": "./dist/types/index.cjs"
+    },
     "./fixtures/mcp": {
       "types": "./dist/fixtures/mcp.d.ts",
       "import": "./dist/fixtures/mcp.js"

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,8 +6,9 @@
  * @packageDocumentation
  */
 
-// Config
+// Types
 export type {
+  // Config
   MCPConfig,
   StdioMCPConfig,
   HttpMCPConfig,
@@ -15,7 +16,119 @@ export type {
   MCPAuthConfig,
   MCPOAuthConfig,
   MCPClientCredentialsConfig,
-} from './config/mcpConfig.js';
+
+  // Auth
+  StoredTokens,
+  StoredClientInfo,
+  StoredOAuthState,
+  OAuthSetupConfig,
+  TokenResult,
+  PlaywrightOAuthClientProviderConfig,
+  ClientCredentialsConfig,
+  ProtectedResourceMetadata,
+  ProtectedResourceDiscoveryResult,
+  StoredServerMetadata,
+  CLIOAuthClientConfig,
+  CLIOAuthResult,
+
+  // MCP
+  CreateMCPClientOptions,
+  ContentBlock,
+  NormalizedToolResponse,
+  MCPFixtureApi,
+  MCPFixtureOptions,
+  MCPAuthFixtures,
+
+  // Assertions
+  ValidationResult,
+  TextValidatorOptions,
+  SizeValidatorOptions,
+  SchemaValidatorOptions,
+  PatternValidatorOptions,
+  SnapshotSanitizer,
+  BuiltInSanitizer,
+  RegexSanitizer,
+  FieldRemovalSanitizer,
+  SchemaRegistry,
+  ToolCallExpectation,
+  ToolCallCountOptions,
+  JudgeValidatorConfig,
+  JudgeMatcherOptions,
+  ToolPredicate,
+  PredicateResult,
+
+  // Core
+  AuthType,
+  ResultSource,
+  ExpectationType,
+  EvalExpectationResult,
+  ExpectationBreakdown,
+  ExpectationResultMap,
+
+  // Evals
+  EvalCase,
+  EvalDataset,
+  EvalExpectBlock,
+  JudgeExpectConfig,
+  SerializedEvalDataset,
+  EvalMode,
+  LoadDatasetOptions,
+  EvalCaseRequest,
+  EvalContext,
+  EvalCaseResult,
+  EvalRunMetadata,
+  IterationResult,
+  EvalRunnerResult,
+  EvalRunnerOptions,
+  ToolMetadataOverride,
+  ToolOverrideVariant,
+  SaveBaselineOptions,
+  ComparisonOutcome,
+  CaseComparisonResult,
+  ServerComparisonResult,
+  ServerComparisonOptions,
+  CompareEvalRunsOptions,
+  EvalCaseComparison,
+  EvalCaseComparisonOutcome,
+  EvalRunComparisonLabels,
+  EvalRunComparisonResult,
+  HostType,
+  CLIOutputFormat,
+  CLIConfig,
+  LLMProvider,
+  MCPHostConfig,
+  LLMToolCall,
+  MCPHostSimulationResult,
+  MCPHostSimulator,
+
+  // Judge
+  JudgeConfig,
+  Judge,
+  JudgeResult,
+  UsageMetrics,
+  ProviderKind,
+  BuiltInRubric,
+  RubricSpec,
+  CustomJudgeExecutor,
+  CustomJudgeResult,
+
+  // Conformance
+  MCPConformanceOptions,
+  MCPConformanceResult,
+  MCPConformanceCheck,
+  MCPConformanceRaw,
+
+  // Reporter
+  MCPEvalReporterConfig,
+  MCPEvalRunData,
+  MCPEvalHistoricalSummary,
+  MCPConformanceResultData,
+  MCPServerCapabilitiesData,
+  MCPEvalData,
+} from './types/index.js';
+export { SnapshotSanitizers } from './types/index.js';
+
+// Config
 export {
   MCPConfigSchema,
   validateMCPConfig,
@@ -24,17 +137,7 @@ export {
 } from './config/mcpConfig.js';
 
 // Auth
-export type {
-  StoredTokens,
-  StoredClientInfo,
-  StoredOAuthState,
-  OAuthSetupConfig,
-  TokenResult,
-} from './auth/types.js';
-export {
-  PlaywrightOAuthClientProvider,
-  type PlaywrightOAuthClientProviderConfig,
-} from './auth/oauthClientProvider.js';
+export { PlaywrightOAuthClientProvider } from './auth/oauthClientProvider.js';
 export {
   createTokenAuthHeaders,
   validateAccessToken,
@@ -48,7 +151,6 @@ export {
 export {
   performClientCredentialsFlow,
   refreshAccessToken,
-  type ClientCredentialsConfig,
 } from './auth/oauthFlow.js';
 
 // Discovery (RFC 9728)
@@ -57,8 +159,6 @@ export {
   discoverAuthorizationServer,
   DiscoveryError,
   MCP_PROTOCOL_VERSION,
-  type ProtectedResourceMetadata,
-  type ProtectedResourceDiscoveryResult,
 } from './auth/discovery.js';
 
 // Token Storage
@@ -68,25 +168,18 @@ export {
   injectTokens,
   loadTokensFromEnv,
   ENV_VAR_NAMES,
-  type StoredServerMetadata,
 } from './auth/storage.js';
 
 // CLI OAuth
-export {
-  CLIOAuthClient,
-  type CLIOAuthClientConfig,
-  type CLIOAuthResult,
-} from './auth/cli.js';
+export { CLIOAuthClient } from './auth/cli.js';
 
 // MCP Client
 export {
   createMCPClientForConfig,
   closeMCPClient,
-  type CreateMCPClientOptions,
 } from './mcp/clientFactory.js';
 
 // Response Normalization
-export type { ContentBlock, NormalizedToolResponse } from './mcp/response.js';
 export { normalizeToolResponse, extractText } from './mcp/response.js';
 
 // Assertions - Matchers (primary API)
@@ -108,65 +201,16 @@ export {
   normalizeWhitespace,
 } from './assertions/validators/index.js';
 
-export { SnapshotSanitizers } from './assertions/validators/types.js';
-export type {
-  ValidationResult,
-  TextValidatorOptions,
-  SizeValidatorOptions,
-  SchemaValidatorOptions,
-  PatternValidatorOptions,
-  SnapshotSanitizer,
-  BuiltInSanitizer,
-  RegexSanitizer,
-  FieldRemovalSanitizer,
-  SchemaRegistry,
-} from './assertions/validators/types.js';
-
-export type {
-  ToolCallExpectation,
-  ToolCallCountOptions,
-} from './assertions/validators/toolCalls.js';
-
-export type { JudgeValidatorConfig } from './assertions/validators/judge.js';
-
-export type {
-  JudgeMatcherOptions,
-  ToolPredicate,
-  PredicateResult,
-} from './assertions/matchers/types.js';
-
 // Fixtures
-export type {
-  MCPFixtureApi,
-  MCPFixtureOptions,
-  AuthType,
-} from './mcp/fixtures/mcpFixture.js';
 export { createMCPFixture } from './mcp/fixtures/mcpFixture.js';
 export { test, expect } from './fixtures/mcp.js';
 
 // Auth fixtures — re-exported from main path for convenience.
 // The auth `test` is aliased to avoid a name collision with the MCP `test` above.
 // Use `mcpAuthTest` when you need to extend auth fixtures (e.g., base.extend<MCPAuthFixtures>).
-export type { MCPAuthFixtures } from './fixtures/mcpAuth.js';
 export { test as mcpAuthTest } from './fixtures/mcpAuth.js';
 
-// Canonical Types (single source of truth)
-export type {
-  ResultSource,
-  ExpectationType,
-  ExpectationBreakdown,
-  ExpectationResultMap,
-} from './types/index.js';
-
 // Eval Dataset
-export type {
-  EvalCase,
-  EvalDataset,
-  EvalExpectBlock,
-  JudgeExpectConfig,
-  SerializedEvalDataset,
-  EvalMode,
-} from './evals/datasetTypes.js';
 export {
   EvalCaseSchema,
   EvalDatasetSchema,
@@ -175,64 +219,24 @@ export {
 } from './evals/datasetTypes.js';
 
 // Eval Loader
-export type { LoadDatasetOptions } from './evals/datasetLoader.js';
 export {
   loadEvalDataset,
   loadEvalDatasetFromObject,
 } from './evals/datasetLoader.js';
 
 // Eval Runner
-export type {
-  EvalCaseRequest,
-  EvalContext,
-  EvalExpectationResult,
-  EvalCaseResult,
-  EvalRunMetadata,
-  IterationResult,
-  EvalRunnerResult,
-  EvalRunnerOptions,
-  ToolMetadataOverride,
-  ToolOverrideVariant,
-} from './evals/evalRunner.js';
 export { runEvalDataset, runEvalCase } from './evals/evalRunner.js';
 
 // Baseline eval comparison
-export {
-  saveBaseline,
-  loadBaseline,
-  type SaveBaselineOptions,
-} from './evals/baseline.js';
+export { saveBaseline, loadBaseline } from './evals/baseline.js';
 
 // Multi-server A/B comparison
-export type {
-  ComparisonOutcome,
-  CaseComparisonResult,
-  ServerComparisonResult,
-  ServerComparisonOptions,
-} from './evals/serverComparison.js';
 export { runServerComparison } from './evals/serverComparison.js';
 
 // Completed eval run comparison
-export type {
-  CompareEvalRunsOptions,
-  EvalCaseComparison,
-  EvalCaseComparisonOutcome,
-  EvalRunComparisonLabels,
-  EvalRunComparisonResult,
-} from './evals/evalRunComparison.js';
 export { compareEvalRuns } from './evals/evalRunComparison.js';
 
 // MCP Host Simulation
-export type {
-  HostType,
-  CLIOutputFormat,
-  CLIConfig,
-  LLMProvider,
-  MCPHostConfig,
-  LLMToolCall,
-  MCPHostSimulationResult,
-  MCPHostSimulator,
-} from './evals/mcpHost/index.js';
 export {
   simulateMCPHost,
   isProviderAvailable,
@@ -240,15 +244,6 @@ export {
 } from './evals/mcpHost/index.js';
 
 // Judge
-export type {
-  JudgeConfig,
-  Judge,
-  JudgeResult,
-  UsageMetrics,
-  ProviderKind,
-  BuiltInRubric,
-  RubricSpec,
-} from './judge/judgeTypes.js';
 export { createJudge } from './judge/judgeClient.js';
 export {
   BUILT_IN_RUBRICS,
@@ -257,10 +252,6 @@ export {
 } from './judge/judgeTypes.js';
 
 // Custom Judge Registry
-export type {
-  CustomJudgeExecutor,
-  CustomJudgeResult,
-} from './judge/judgeRegistry.js';
 export {
   registerJudge,
   getRegisteredJudge,
@@ -268,23 +259,4 @@ export {
 } from './judge/judgeRegistry.js';
 
 // Conformance
-export type {
-  MCPConformanceOptions,
-  MCPConformanceResult,
-  MCPConformanceCheck,
-  MCPConformanceRaw,
-} from './spec/conformanceChecks.js';
 export { runConformanceChecks } from './spec/conformanceChecks.js';
-
-// Reporter types — primarily used by the mcpReporter plugin.
-// These types are available for custom reporter implementations or
-// when consuming reporter output programmatically.
-// Import the reporter itself from '@gleanwork/mcp-server-tester/reporters/mcpReporter'
-export type {
-  MCPEvalReporterConfig,
-  MCPEvalRunData,
-  MCPEvalHistoricalSummary,
-  MCPConformanceResultData,
-  MCPServerCapabilitiesData,
-  MCPEvalData,
-} from './reporters/types.js';

--- a/src/reporters/types.ts
+++ b/src/reporters/types.ts
@@ -9,6 +9,7 @@
 
 // Re-export reporter types from canonical source
 export type {
+  MCPEvalReporterConfig,
   MCPConformanceResultData,
   MCPServerCapabilitiesData,
   EvalCaseRequest,
@@ -28,41 +29,3 @@ export type {
 
 // Re-export conformance check type
 export type { MCPConformanceCheck } from '../types/reporter.js';
-
-/**
- * Configuration options for MCP Eval Reporter
- */
-export interface MCPEvalReporterConfig {
-  /**
-   * Output directory for reports and historical data
-   * @default '.mcp-test-results'
-   */
-  outputDir?: string;
-
-  /**
-   * Auto-open report in browser after test run
-   * @default false
-   */
-  autoOpen?: boolean;
-
-  /**
-   * Number of historical runs to keep
-   * @default 10
-   */
-  historyLimit?: number;
-
-  /**
-   * Suppress console output (report still generated)
-   * @default false
-   */
-  quiet?: boolean;
-
-  /**
-   * Include auto-tracked MCP tool calls from tests without explicit eval results.
-   * When true, any test using the MCP fixture will have its tool calls
-   * included in the report, even without using runEvalCase/runEvalDataset.
-   * When false, only tests with explicit eval results are included.
-   * @default true
-   */
-  includeAutoTracking?: boolean;
-}

--- a/src/types/assertions.ts
+++ b/src/types/assertions.ts
@@ -1,0 +1,26 @@
+export {
+  SnapshotSanitizers,
+  type ValidationResult,
+  type TextValidatorOptions,
+  type SizeValidatorOptions,
+  type SchemaValidatorOptions,
+  type PatternValidatorOptions,
+  type SnapshotSanitizer,
+  type BuiltInSanitizer,
+  type RegexSanitizer,
+  type FieldRemovalSanitizer,
+  type SchemaRegistry,
+} from '../assertions/validators/types.js';
+
+export type {
+  ToolCallExpectation,
+  ToolCallCountOptions,
+} from '../assertions/validators/toolCalls.js';
+
+export type { JudgeValidatorConfig } from '../assertions/validators/judge.js';
+
+export type {
+  JudgeMatcherOptions,
+  ToolPredicate,
+  PredicateResult,
+} from '../assertions/matchers/types.js';

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -1,0 +1,32 @@
+export type {
+  StoredTokens,
+  StoredClientInfo,
+  StoredOAuthState,
+  OAuthSetupConfig,
+  TokenResult,
+} from '../auth/types.js';
+
+export type { PlaywrightOAuthClientProviderConfig } from '../auth/oauthClientProvider.js';
+
+export type {
+  AuthServerMetadata,
+  PKCEPair,
+  AuthorizationUrlConfig,
+  TokenExchangeConfig,
+  TokenRefreshConfig,
+  ClientCredentialsConfig,
+} from '../auth/oauthFlow.js';
+
+export type {
+  ProtectedResourceMetadata,
+  ProtectedResourceDiscoveryResult,
+} from '../auth/discovery.js';
+
+export type {
+  StoredServerMetadata,
+  OAuthStorage,
+  FileOAuthStorageConfig,
+  KnownServer,
+} from '../auth/storage.js';
+
+export type { CLIOAuthClientConfig, CLIOAuthResult } from '../auth/cli.js';

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -1,0 +1,9 @@
+export type {
+  MCPConfig,
+  StdioMCPConfig,
+  HttpMCPConfig,
+  MCPHostCapabilities,
+  MCPAuthConfig,
+  MCPOAuthConfig,
+  MCPClientCredentialsConfig,
+} from '../config/mcpConfig.js';

--- a/src/types/conformance.ts
+++ b/src/types/conformance.ts
@@ -1,0 +1,6 @@
+export type {
+  MCPConformanceOptions,
+  MCPConformanceResult,
+  MCPConformanceCheck,
+  MCPConformanceRaw,
+} from '../spec/conformanceChecks.js';

--- a/src/types/evals.ts
+++ b/src/types/evals.ts
@@ -1,0 +1,49 @@
+export type {
+  EvalCase,
+  EvalDataset,
+  EvalExpectBlock,
+  JudgeExpectConfig,
+  SerializedEvalDataset,
+  EvalMode,
+} from '../evals/datasetTypes.js';
+
+export type { LoadDatasetOptions } from '../evals/datasetLoader.js';
+
+export type {
+  EvalContext,
+  EvalRunnerResult,
+  EvalRunnerOptions,
+  EvalCaseOptions,
+  ToolMetadataOverride,
+  ToolOverrideVariant,
+} from '../evals/evalRunner.js';
+
+export type {
+  ComparisonOutcome,
+  CaseComparisonResult,
+  ServerComparisonResult,
+  ServerComparisonOptions,
+} from '../evals/serverComparison.js';
+
+export type {
+  CompareEvalRunsOptions,
+  EvalCaseComparison,
+  EvalCaseComparisonOutcome,
+  EvalRunComparisonLabels,
+  EvalRunComparisonResult,
+} from '../evals/evalRunComparison.js';
+
+export type { SaveBaselineOptions } from '../evals/baseline.js';
+
+export type {
+  HostType,
+  CLIOutputFormat,
+  CLIConfig,
+  LLMProvider,
+  BrowserCookie,
+  BrowserConfig,
+  MCPHostConfig,
+  LLMToolCall,
+  MCPHostSimulationResult,
+  MCPHostSimulator,
+} from '../evals/mcpHost/index.js';

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -99,12 +99,121 @@ export type ExpectationResultMap = Partial<
  */
 export type ExpectationBreakdown = Partial<Record<ExpectationType, number>>;
 
-// Usage metrics re-exported from judge module for centralised access.
-// Prefer importing UsageMetrics from this module rather than judge/judgeTypes.
-export type { UsageMetrics } from '../judge/judgeTypes.js';
+export {
+  SnapshotSanitizers,
+  type BuiltInSanitizer,
+  type FieldRemovalSanitizer,
+  type JudgeMatcherOptions,
+  type JudgeValidatorConfig,
+  type PatternValidatorOptions,
+  type PredicateResult,
+  type RegexSanitizer,
+  type SchemaRegistry,
+  type SchemaValidatorOptions,
+  type SizeValidatorOptions,
+  type SnapshotSanitizer,
+  type TextValidatorOptions,
+  type ToolCallCountOptions,
+  type ToolCallExpectation,
+  type ToolPredicate,
+  type ValidationResult,
+} from './assertions.js';
 
-// Reporter types are exported from ./reporter.js
-// Import them from there to avoid circular dependencies:
-//   import type { EvalCaseResult } from '../types/reporter.js';
-//
-// Or import everything via the package's main index.ts
+export type {
+  MCPConfig,
+  StdioMCPConfig,
+  HttpMCPConfig,
+  MCPHostCapabilities,
+  MCPAuthConfig,
+  MCPOAuthConfig,
+  MCPClientCredentialsConfig,
+} from './config.js';
+
+export type {
+  StoredTokens,
+  StoredClientInfo,
+  StoredOAuthState,
+  OAuthSetupConfig,
+  TokenResult,
+  PlaywrightOAuthClientProviderConfig,
+  ClientCredentialsConfig,
+  ProtectedResourceMetadata,
+  ProtectedResourceDiscoveryResult,
+  StoredServerMetadata,
+  CLIOAuthClientConfig,
+  CLIOAuthResult,
+} from './auth.js';
+
+export type {
+  CreateMCPClientOptions,
+  ContentBlock,
+  NormalizedToolResponse,
+  MCPFixtureApi,
+  MCPFixtureOptions,
+  MCPAuthFixtures,
+} from './mcp.js';
+
+export type {
+  EvalCase,
+  EvalDataset,
+  EvalExpectBlock,
+  JudgeExpectConfig,
+  SerializedEvalDataset,
+  EvalMode,
+  LoadDatasetOptions,
+  EvalContext,
+  EvalRunnerResult,
+  EvalRunnerOptions,
+  ToolMetadataOverride,
+  ToolOverrideVariant,
+  SaveBaselineOptions,
+  ComparisonOutcome,
+  CaseComparisonResult,
+  ServerComparisonResult,
+  ServerComparisonOptions,
+  CompareEvalRunsOptions,
+  EvalCaseComparison,
+  EvalCaseComparisonOutcome,
+  EvalRunComparisonLabels,
+  EvalRunComparisonResult,
+  HostType,
+  CLIOutputFormat,
+  CLIConfig,
+  LLMProvider,
+  MCPHostConfig,
+  LLMToolCall,
+  MCPHostSimulationResult,
+  MCPHostSimulator,
+} from './evals.js';
+
+export type {
+  JudgeConfig,
+  Judge,
+  JudgeResult,
+  UsageMetrics,
+  ProviderKind,
+  BuiltInRubric,
+  RubricSpec,
+  CustomJudgeExecutor,
+  CustomJudgeResult,
+} from './judge.js';
+
+export type {
+  MCPConformanceOptions,
+  MCPConformanceResult,
+  MCPConformanceCheck,
+  MCPConformanceRaw,
+} from './conformance.js';
+
+export type {
+  MCPEvalReporterConfig,
+  EvalCaseRequest,
+  EvalCaseResult,
+  EvalRunMetadata,
+  IterationResult,
+  MCPEvalRunData,
+  MCPEvalHistoricalSummary,
+  MCPConformanceResultData,
+  MCPServerCapabilitiesData,
+  MCPEvalData,
+} from './reporter.js';

--- a/src/types/judge.ts
+++ b/src/types/judge.ts
@@ -1,0 +1,15 @@
+export type {
+  JudgeResponse,
+  UsageMetrics,
+  ProviderKind,
+  JudgeConfig,
+  JudgeResult,
+  BuiltInRubric,
+  RubricSpec,
+  Judge,
+} from '../judge/judgeTypes.js';
+
+export type {
+  CustomJudgeExecutor,
+  CustomJudgeResult,
+} from '../judge/judgeRegistry.js';

--- a/src/types/mcp.ts
+++ b/src/types/mcp.ts
@@ -1,0 +1,10 @@
+export type {
+  MCPFixtureApi,
+  MCPFixtureOptions,
+} from '../mcp/fixtures/mcpFixture.js';
+
+export type { MCPAuthFixtures } from '../fixtures/mcpAuth.js';
+
+export type { CreateMCPClientOptions } from '../mcp/clientFactory.js';
+
+export type { ContentBlock, NormalizedToolResponse } from '../mcp/response.js';

--- a/src/types/reporter.ts
+++ b/src/types/reporter.ts
@@ -16,6 +16,44 @@ import type {
 } from './index.js';
 
 /**
+ * Configuration options for MCP Eval Reporter
+ */
+export interface MCPEvalReporterConfig {
+  /**
+   * Output directory for reports and historical data
+   * @default '.mcp-test-results'
+   */
+  outputDir?: string;
+
+  /**
+   * Auto-open report in browser after test run
+   * @default false
+   */
+  autoOpen?: boolean;
+
+  /**
+   * Number of historical runs to keep
+   * @default 10
+   */
+  historyLimit?: number;
+
+  /**
+   * Suppress console output (report still generated)
+   * @default false
+   */
+  quiet?: boolean;
+
+  /**
+   * Include auto-tracked MCP tool calls from tests without explicit eval results.
+   * When true, any test using the MCP fixture will have its tool calls
+   * included in the report, even without using runEvalCase/runEvalDataset.
+   * When false, only tests with explicit eval results are included.
+   * @default true
+   */
+  includeAutoTracking?: boolean;
+}
+
+/**
  * Experiment tracking metadata for an eval run
  */
 export interface EvalRunMetadata {

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -3,7 +3,7 @@ import { defineConfig } from 'tsup';
 export default defineConfig([
   // Library build
   {
-    entry: ['src/index.ts'],
+    entry: ['src/index.ts', 'src/types/index.ts'],
     format: ['esm', 'cjs'],
     dts: true,
     splitting: false,


### PR DESCRIPTION
## Summary
- Add a canonical public type export surface under src/types with logical domain barrels.
- Add @gleanwork/mcp-server-tester/types as an explicit package export.
- Update the package root to export public types from the canonical barrel while keeping runtime exports grouped by implementation area.

## Why
Types were spread across implementation modules, which made imports inconsistent and increased cross-file type coupling. This consolidates shared contracts behind the types directory while keeping the public API explicit instead of wildcarding every internal type.

## Impact
Consumers can import shared types from either the package root or @gleanwork/mcp-server-tester/types. Existing root-level public type exports remain available, and reporter config now lives with the canonical reporter type definitions.

## Public API compatibility
Compared generated declaration exports for the latest published package, @gleanwork/mcp-server-tester@1.0.1, against this branch after running tsup. No exported names from the published root, reporter, or fixture entrypoints are missing in this branch.

The generated root declaration is a superset of 1.0.1 because main already includes newer eval-run comparison exports and this PR keeps those intact.

## Validation
- npm run format:check
- npm run typecheck
- ./node_modules/.bin/tsup
- npm test
- npm pack @gleanwork/mcp-server-tester@1.0.1 --pack-destination /private/tmp
- compared dist/index.d.ts, dist/reporters/mcpReporter.d.ts, dist/fixtures/mcp.d.ts, and dist/fixtures/mcpAuth.d.ts exported names against the 1.0.1 tarball