### PR TITLE
fix(reporter): align tab nav width with content

### DIFF
--- a/src/reporters/ui-src/App.tsx
+++ b/src/reporters/ui-src/App.tsx
@@ -101,41 +101,44 @@ function App() {
         ci={data.runData.environment.ci}
       >
         {/* Tab navigation — underline style, familiar from VS Code / Chrome DevTools */}
-        <div className="border-b border-border px-6">
-          <nav
-            role="tablist"
-            aria-label="Report sections"
-            className="-mb-px flex gap-1"
-          >
-            {tabs.map((tab) => (
-              <button
-                key={tab.id}
-                role="tab"
-                id={`tab-${tab.id}`}
-                aria-selected={activeTab === tab.id}
-                aria-controls={`${tab.id}-panel`}
-                onClick={() => setActiveTab(tab.id)}
-                className={`flex items-center gap-2 px-4 py-3 text-sm font-medium border-b-2 transition-colors ${
-                  activeTab === tab.id
-                    ? 'border-primary text-foreground'
-                    : 'border-transparent text-muted-foreground hover:text-foreground hover:border-border'
-                }`}
-              >
-                {tab.label}
-                {tab.count !== undefined && (
-                  <span
-                    className={`inline-flex items-center justify-center rounded-full px-2 py-0.5 text-xs font-medium ${
-                      activeTab === tab.id
-                        ? 'bg-primary/10 text-primary'
-                        : 'bg-muted text-muted-foreground'
-                    }`}
-                  >
-                    {tab.count}
-                  </span>
-                )}
-              </button>
-            ))}
-          </nav>
+        {/* Full-bleed border, but tabs align to the same max width as the content below. */}
+        <div className="border-b border-border">
+          <div className="mx-auto w-full max-w-[1600px] px-6">
+            <nav
+              role="tablist"
+              aria-label="Report sections"
+              className="-mb-px flex gap-1"
+            >
+              {tabs.map((tab) => (
+                <button
+                  key={tab.id}
+                  role="tab"
+                  id={`tab-${tab.id}`}
+                  aria-selected={activeTab === tab.id}
+                  aria-controls={`${tab.id}-panel`}
+                  onClick={() => setActiveTab(tab.id)}
+                  className={`flex items-center gap-2 px-4 py-3 text-sm font-medium border-b-2 transition-colors ${
+                    activeTab === tab.id
+                      ? 'border-primary text-foreground'
+                      : 'border-transparent text-muted-foreground hover:text-foreground hover:border-border'
+                  }`}
+                >
+                  {tab.label}
+                  {tab.count !== undefined && (
+                    <span
+                      className={`inline-flex items-center justify-center rounded-full px-2 py-0.5 text-xs font-medium ${
+                        activeTab === tab.id
+                          ? 'bg-primary/10 text-primary'
+                          : 'bg-muted text-muted-foreground'
+                      }`}
+                    >
+                      {tab.count}
+                    </span>
+                  )}
+                </button>
+              ))}
+            </nav>
+          </div>
         </div>
 
         <div className="max-w-[1600px] mx-auto p-6 h-full flex flex-col gap-6">


### PR DESCRIPTION
## Summary

The reporter's tab navigation stretched full-width while the rest of the UI is constrained to `max-w-[1600px]`. On wide viewports the tabs and their underline ran to the window edge while the content below stayed centered — they looked disconnected.

## Fix

Wrap the tabs in a `max-w-[1600px] mx-auto px-6` container (matching the content area and the header), while keeping the bottom border full-bleed. Now the tabs align with the content at any window width.

```
<div className="border-b border-border">           // full-bleed border
  <div className="mx-auto w-full max-w-[1600px] px-6">  // tabs align to content
    <nav role="tablist"> … </nav>
```

UI-only change to `src/reporters/ui-src/App.tsx`; the large diff is just the +2 indent from the new wrapper.

## Validation

`format:check`, `typecheck`, `lint`, `docs:check`, `build` (incl. UI reporter build), and `test` (960 passing) all pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)