### PR TITLE
feat(reporter): promote tool recall to a headline metric

### DIFF
--- a/src/reporters/ui-src/components/Dashboard/MetricsCards.tsx
+++ b/src/reporters/ui-src/components/Dashboard/MetricsCards.tsx
@@ -51,6 +51,8 @@ function computeMetrics(results: EvalCaseResult[]): MetricsSummary {
 
 interface ToolDiscoveryMetrics {
   meanRecall: number;
+  meanPrecision: number;
+  meanF1: number;
   count: number;
 }
 
@@ -64,10 +66,17 @@ function computeToolDiscovery(
 ): ToolDiscoveryMetrics | null {
   const withRecall = results.filter((r) => r.toolRecall !== undefined);
   if (withRecall.length === 0) return null;
-  const meanRecall =
-    withRecall.reduce((sum, r) => sum + (r.toolRecall ?? 0), 0) /
-    withRecall.length;
-  return { meanRecall, count: withRecall.length };
+  const mean = (fn: (r: EvalCaseResult) => number) =>
+    withRecall.reduce((sum, r) => sum + fn(r), 0) / withRecall.length;
+  const meanRecall = mean((r) => r.toolRecall ?? 0);
+  const meanPrecision = mean((r) => r.toolPrecision ?? 0);
+  // Per-case F1 (harmonic mean of that case's precision & recall), then averaged.
+  const meanF1 = mean((r) => {
+    const p = r.toolPrecision ?? 0;
+    const rec = r.toolRecall ?? 0;
+    return p + rec > 0 ? (2 * p * rec) / (p + rec) : 0;
+  });
+  return { meanRecall, meanPrecision, meanF1, count: withRecall.length };
 }
 
 function computeRegressions(
@@ -107,6 +116,28 @@ export function MetricsCards({
         </span>
         <span className="text-xs text-muted-foreground">pass rate</span>
       </div>
+
+      {/* Tool recall — co-headline for mcp_host runs: this is what tool
+          discoverability is measured by. Precision / F1 ride alongside. */}
+      {showEvalCards && toolDiscovery !== null && (
+        <>
+          <Divider />
+          <div className="flex items-baseline gap-1.5">
+            <span
+              className={`text-xl font-bold tabular-nums ${rateColorClass(toolDiscovery.meanRecall)}`}
+            >
+              {(toolDiscovery.meanRecall * 100).toFixed(0)}%
+            </span>
+            <span className="text-xs text-muted-foreground">tool recall</span>
+          </div>
+          <div className="flex items-baseline gap-2 text-sm text-muted-foreground tabular-nums">
+            <span>
+              precision {(toolDiscovery.meanPrecision * 100).toFixed(0)}%
+            </span>
+            <span>F1 {(toolDiscovery.meanF1 * 100).toFixed(0)}%</span>
+          </div>
+        </>
+      )}
 
       <Divider />
 
@@ -161,20 +192,6 @@ export function MetricsCards({
             <span className="text-xs text-muted-foreground">
               ({overall.totalIterations} iterations)
             </span>
-          </div>
-        </>
-      )}
-
-      {showEvalCards && toolDiscovery !== null && (
-        <>
-          <Divider />
-          <div className="flex items-baseline gap-1.5 text-sm">
-            <span
-              className={`font-semibold tabular-nums ${rateColorClass(toolDiscovery.meanRecall)}`}
-            >
-              {(toolDiscovery.meanRecall * 100).toFixed(0)}%
-            </span>
-            <span className="text-muted-foreground">tool discovery</span>
           </div>
         </>
       )}

--- a/src/reporters/ui-src/components/Results/ResultsTable.tsx
+++ b/src/reporters/ui-src/components/Results/ResultsTable.tsx
@@ -7,6 +7,7 @@ import {
   Folder,
 } from 'lucide-react';
 import type { EvalCaseResult } from '../../types';
+import { rateColorClass } from '../../utils';
 
 interface ResultsTableProps {
   results: EvalCaseResult[];
@@ -153,7 +154,7 @@ function ResultRow({
       )}
       {result.toolRecall !== undefined && (
         <span
-          className="inline-flex items-center px-2 py-0.5 rounded text-xs shrink-0 bg-muted text-muted-foreground"
+          className={`inline-flex items-center px-2 py-0.5 rounded text-xs font-semibold shrink-0 bg-muted ${rateColorClass(result.toolRecall)}`}
           title="Tool recall: fraction of required tools that were called"
         >
           R: {(result.toolRecall * 100).toFixed(0)}%


### PR DESCRIPTION
## Summary

For `mcp_host` runs, **tool recall** is the headline signal — it's what tool discoverability is measured by. But the reporter buried it: a small trailing stat labeled "tool discovery", behind pass rate, with precision and F1 not surfaced at all.

## Changes

- **MetricsCards:** tool recall is now a co-headline next to pass rate (same `text-xl font-bold` weight), renamed **"tool recall"**. Mean **precision** and **F1** now show alongside it. (F1 is the per-case harmonic mean of precision & recall, averaged.) Only renders when the run has tool-call data.
- **ResultsTable:** the per-case recall badge is now color-coded by value (red→green), so a 0% miss stands out instead of looking identical to a 100% hit. Precision stays muted (secondary).

## Validation

`format:check`, `typecheck`, `lint`, `docs:check`, `build` (incl. UI reporter), and `test` (960 passing) all pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)