### PR TITLE
feat(evals): surface variant-experiment results in the reporter

### DIFF
--- a/src/evals/variantExperiment.test.ts
+++ b/src/evals/variantExperiment.test.ts
@@ -340,3 +340,90 @@ describe('runVariantExperiment — multi-round proposeVariants', () => {
     expect(result.reason).toBe('no-improvement');
   });
 });
+
+describe('runVariantExperiment — reporter integration', () => {
+  it('attaches winner results and an experiment summary when testInfo is present', async () => {
+    setRuns({
+      __baseline__: makeResult([
+        { id: 'c1', pass: false },
+        { id: 'c2', pass: false },
+      ]),
+      v1: makeResult([
+        { id: 'c1', pass: true },
+        { id: 'c2', pass: true },
+      ]),
+    });
+    const attach = vi.fn();
+    const ctx = { mcp: {}, testInfo: { attach } } as unknown as EvalContext;
+
+    await runVariantExperiment(
+      { dataset, variants: [variant('v1')], metric: 'passRate' },
+      ctx
+    );
+
+    const names = attach.mock.calls.map((c) => c[0] as string);
+    expect(names).toContain('mcp-test-results');
+    expect(names).toContain('mcp-variant-experiment');
+
+    const expCall = attach.mock.calls.find(
+      (c) => c[0] === 'mcp-variant-experiment'
+    );
+    const summaryBody = (expCall![1] as { body: Buffer }).body;
+    const summary = JSON.parse(summaryBody.toString()) as {
+      metric: string;
+      baselineValue: number;
+      bestValue: number;
+      winnerVariantId?: string;
+      recommendation?: string;
+      rounds: unknown[];
+    };
+    expect(summary.metric).toBe('passRate');
+    expect(summary.baselineValue).toBe(0);
+    expect(summary.bestValue).toBe(1);
+    expect(summary.winnerVariantId).toBe('v1');
+    expect(summary.recommendation).toBe('apply');
+    expect(summary.rounds).toHaveLength(1);
+
+    // The surfaced case results are the WINNER's (both passing), not baseline.
+    const resCall = attach.mock.calls.find((c) => c[0] === 'mcp-test-results');
+    const surfacedBody = (resCall![1] as { body: Buffer }).body;
+    const surfaced = JSON.parse(surfacedBody.toString()) as {
+      caseResults: Array<{ pass: boolean }>;
+    };
+    expect(surfaced.caseResults.every((r) => r.pass)).toBe(true);
+  });
+
+  it('does not attach when testInfo is absent', async () => {
+    setRuns({
+      __baseline__: makeResult([{ id: 'c1', pass: true }]),
+      v1: makeResult([{ id: 'c1', pass: true }]),
+    });
+    // context has testInfo: undefined — should complete without attaching.
+    await expect(
+      runVariantExperiment(
+        { dataset, variants: [variant('v1')], metric: 'passRate' },
+        context
+      )
+    ).resolves.toBeDefined();
+  });
+
+  it('runs internal evals without testInfo so the reporter is not spammed', async () => {
+    setRuns({
+      __baseline__: makeResult([{ id: 'c1', pass: false }]),
+      v1: makeResult([{ id: 'c1', pass: true }]),
+    });
+    const attach = vi.fn();
+    const ctx = { mcp: {}, testInfo: { attach } } as unknown as EvalContext;
+
+    await runVariantExperiment(
+      { dataset, variants: [variant('v1')], metric: 'passRate' },
+      ctx
+    );
+
+    // Every internal runEvalDataset call received a context WITHOUT testInfo.
+    for (const call of mocks.runEvalDataset.mock.calls) {
+      const passedCtx = call[1] as EvalContext;
+      expect(passedCtx.testInfo).toBeUndefined();
+    }
+  });
+});

--- a/src/evals/variantExperiment.ts
+++ b/src/evals/variantExperiment.ts
@@ -8,6 +8,7 @@ import type {
 import type { EvalDataset } from './datasetTypes.js';
 import { compareEvalRuns } from './evalRunComparison.js';
 import type { EvalRunComparisonResult } from './evalRunComparison.js';
+import type { MCPVariantExperimentData } from '../types/reporter.js';
 import type { ZodType } from 'zod';
 
 /**
@@ -212,9 +213,17 @@ export async function runVariantExperiment(
   const minImprovement = options.minImprovement ?? 0;
   const allowRegressions = options.allowRegressions ?? false;
 
+  // Internal eval runs must not attach to the reporter individually, or the
+  // report would show only the baseline run. We attach the winner's results
+  // plus an experiment summary once, at the end, when testInfo is present.
+  const internalContext: EvalContext = {
+    mcp: context.mcp,
+    expect: context.expect,
+  };
+
   const baseline = await runEvalDataset(
     buildRunOptions(options, undefined),
-    context
+    internalContext
   );
 
   const baselineValue = readMetric(baseline, metric);
@@ -249,7 +258,7 @@ export async function runVariantExperiment(
     for (const variant of variants) {
       const candidate = await scoreVariant(
         options,
-        context,
+        internalContext,
         baseline,
         baselineValue,
         metric,
@@ -283,7 +292,7 @@ export async function runVariantExperiment(
     ? buildProposal(metric, baselineValue, proposalSource, winner !== undefined)
     : undefined;
 
-  return {
+  const result: VariantExperimentResult = {
     metric,
     baseline,
     rounds,
@@ -291,6 +300,53 @@ export async function runVariantExperiment(
     proposal,
     converged: true,
     reason,
+  };
+
+  if (context.testInfo) {
+    // Surface the best run's case results so the report reflects the optimized
+    // state, plus a compact summary of how the experiment got there.
+    const surfaceRun = winner?.result ?? bestAttempted?.result ?? baseline;
+    await context.testInfo.attach('mcp-test-results', {
+      contentType: 'application/json',
+      body: Buffer.from(
+        JSON.stringify({ caseResults: surfaceRun.caseResults })
+      ),
+    });
+    await context.testInfo.attach('mcp-variant-experiment', {
+      contentType: 'application/json',
+      body: Buffer.from(
+        JSON.stringify(buildExperimentData(result, baselineValue))
+      ),
+    });
+  }
+
+  return result;
+}
+
+function buildExperimentData(
+  result: VariantExperimentResult,
+  baselineValue: number
+): MCPVariantExperimentData {
+  return {
+    metric: result.metric,
+    baselineValue,
+    bestValue:
+      result.winner?.metricValue ??
+      result.proposal?.candidateValue ??
+      baselineValue,
+    rounds: result.rounds.map((round) => {
+      const best = round.best ?? round.candidates[0];
+      return {
+        round: round.round,
+        variantId: best?.variant.id ?? '(none)',
+        metricValue: best?.metricValue ?? baselineValue,
+        metricDelta: best?.metricDelta ?? 0,
+        disqualified: best?.disqualified ?? false,
+      };
+    }),
+    winnerVariantId: result.winner?.variant.id,
+    recommendation: result.proposal?.recommendation,
+    reason: result.reason,
   };
 }
 

--- a/src/reporters/mcpReporter.ts
+++ b/src/reporters/mcpReporter.ts
@@ -16,6 +16,7 @@ import type {
   MCPEvalHistoricalSummary,
   MCPConformanceResultData,
   MCPServerCapabilitiesData,
+  MCPVariantExperimentData,
   EvalCaseResult,
   MCPConformanceCheck,
 } from '../types/reporter.js';
@@ -61,6 +62,7 @@ export default class MCPReporter implements Reporter {
   private allResults: Array<EvalCaseResult> = [];
   private conformanceChecks: Array<MCPConformanceResultData> = [];
   private serverCapabilities: Array<MCPServerCapabilitiesData> = [];
+  private variantExperiment: MCPVariantExperimentData | undefined;
 
   constructor(options: MCPEvalReporterConfig = {}) {
     this.config = {
@@ -150,6 +152,28 @@ export default class MCPReporter implements Reporter {
       } catch (error) {
         this.logError(
           `[MCP Reporter] Failed to parse eval results from test "${test.title}":`,
+          error
+        );
+      }
+    }
+
+    // Strategy 1b: Extract variant-experiment summary (runVariantExperiment)
+    const experimentAttachment = result.attachments.find(
+      (a) =>
+        a.name === 'mcp-variant-experiment' &&
+        a.contentType === 'application/json'
+    );
+    const experimentContent = experimentAttachment
+      ? await this.getAttachmentContent(experimentAttachment)
+      : null;
+    if (experimentContent) {
+      try {
+        this.variantExperiment = JSON.parse(
+          experimentContent
+        ) as MCPVariantExperimentData;
+      } catch (error) {
+        this.logError(
+          `[MCP Reporter] Failed to parse variant-experiment attachment for "${test.title}":`,
           error
         );
       }
@@ -439,6 +463,7 @@ export default class MCPReporter implements Reporter {
         this.serverCapabilities.length > 0
           ? this.serverCapabilities
           : undefined,
+      variantExperiment: this.variantExperiment,
     };
   }
 

--- a/src/reporters/ui-src/App.tsx
+++ b/src/reporters/ui-src/App.tsx
@@ -11,6 +11,7 @@ import {
 import { ByToolTable } from './components/Dashboard/ByToolTable';
 import { FailureBreakdown } from './components/Dashboard/FailureBreakdown';
 import { TrendChart } from './components/Dashboard/TrendChart';
+import { VariantExperimentCard } from './components/Dashboard/VariantExperimentCard';
 import { ResultsTable } from './components/Results/ResultsTable';
 import { DetailModal } from './components/Results/DetailModal';
 import { ConformancePanel } from './components/Conformance/ConformancePanel';
@@ -172,8 +173,15 @@ function App() {
             >
               <ErrorBoundary label="Evals tab">
                 <>
-                  {/* Eval-specific metrics: accuracy, tool discovery, regressions */}
+                  {/* Eval-specific metrics: accuracy, tool recall, regressions */}
                   <MetricsCards results={evalResults} mode="eval" />
+
+                  {/* Variant experiment summary, when this run was one */}
+                  {data.runData.variantExperiment && (
+                    <VariantExperimentCard
+                      data={data.runData.variantExperiment}
+                    />
+                  )}
 
                   {/* Diagnostic panels with shared toggle above */}
                   <div className="space-y-2">

--- a/src/reporters/ui-src/components/Dashboard/VariantExperimentCard.tsx
+++ b/src/reporters/ui-src/components/Dashboard/VariantExperimentCard.tsx
@@ -1,0 +1,99 @@
+import React from 'react';
+import { FlaskConical } from 'lucide-react';
+import type { MCPVariantExperimentData } from '../../types';
+import { rateColorClass } from '../../utils';
+
+const pct = (n: number) => `${Math.round(n * 100)}%`;
+
+const RECO_STYLE: Record<string, string> = {
+  apply:
+    'bg-green-500/10 text-green-600 dark:text-green-400 border-green-500/20',
+  reject: 'bg-red-500/10 text-red-600 dark:text-red-400 border-red-500/20',
+  inconclusive: 'bg-muted text-muted-foreground border-border',
+};
+
+/**
+ * Compact summary of a runVariantExperiment run: how tool-metadata wording was
+ * optimized from the baseline to the winning variant, round by round.
+ */
+export function VariantExperimentCard({
+  data,
+}: {
+  data: MCPVariantExperimentData;
+}) {
+  const delta = data.bestValue - data.baselineValue;
+  const reco = data.recommendation ?? 'inconclusive';
+
+  return (
+    <div className="rounded-lg border bg-card p-4 shadow-sm">
+      <div className="mb-3 flex items-center justify-between gap-2">
+        <div className="flex items-center gap-2">
+          <FlaskConical
+            size={16}
+            className="text-blue-600 dark:text-blue-400"
+          />
+          <h3 className="font-semibold">Variant Experiment</h3>
+          <span className="text-xs text-muted-foreground">
+            optimizing {data.metric}
+          </span>
+        </div>
+        <span
+          className={`inline-flex items-center rounded border px-2 py-0.5 text-xs font-medium ${
+            RECO_STYLE[reco] ?? RECO_STYLE.inconclusive
+          }`}
+        >
+          {reco}
+        </span>
+      </div>
+
+      <div className="mb-3 flex items-baseline gap-2">
+        <span className="tabular-nums text-muted-foreground">
+          {pct(data.baselineValue)}
+        </span>
+        <span className="text-muted-foreground">→</span>
+        <span
+          className={`text-xl font-bold tabular-nums ${rateColorClass(data.bestValue)}`}
+        >
+          {pct(data.bestValue)}
+        </span>
+        {delta > 0 && (
+          <span className="text-sm font-semibold text-green-600 dark:text-green-400">
+            +{pct(delta)}
+          </span>
+        )}
+        <span className="text-xs text-muted-foreground">
+          {data.metric} · {data.rounds.length} round
+          {data.rounds.length !== 1 ? 's' : ''}
+        </span>
+      </div>
+
+      {data.rounds.length > 0 && (
+        <ol className="space-y-1 text-sm">
+          {data.rounds.map((r) => (
+            <li key={r.round} className="flex items-center gap-2">
+              <span className="w-8 tabular-nums text-muted-foreground">
+                #{r.round}
+              </span>
+              <span
+                className={`w-12 font-medium tabular-nums ${rateColorClass(r.metricValue)}`}
+              >
+                {pct(r.metricValue)}
+              </span>
+              <span className="truncate font-mono text-xs">{r.variantId}</span>
+              {r.disqualified && (
+                <span className="text-xs text-red-600 dark:text-red-400">
+                  regressed
+                </span>
+              )}
+              {r.variantId === data.winnerVariantId && (
+                <span className="text-xs text-green-600 dark:text-green-400">
+                  ✓ winner
+                </span>
+              )}
+            </li>
+          ))}
+        </ol>
+      )}
+    </div>
+  );
+}

--- a/src/reporters/ui-src/types.ts
+++ b/src/reporters/ui-src/types.ts
@@ -17,6 +17,7 @@ export type {
   MCPConformanceCheck,
   MCPConformanceResultData,
   MCPServerCapabilitiesData,
+  MCPVariantExperimentData,
   EvalCaseRequest,
   EvalCaseResult,
   MCPEvalRunData,

--- a/src/types/reporter.ts
+++ b/src/types/reporter.ts
@@ -480,6 +480,39 @@ export interface MCPEvalRunData {
    * Server capabilities discovered via listTools (optional)
    */
   serverCapabilities?: MCPServerCapabilitiesData[];
+
+  /**
+   * Summary of a tool-metadata variant experiment (runVariantExperiment),
+   * present when the run was produced by one. The `results` above reflect the
+   * winning variant; this records how the experiment got there.
+   */
+  variantExperiment?: MCPVariantExperimentData;
+}
+
+/**
+ * Compact summary of a `runVariantExperiment` run, for the reporter UI.
+ */
+export interface MCPVariantExperimentData {
+  /** Metric optimized: passRate | toolF1 | toolPrecision | toolRecall. */
+  metric: string;
+  /** Baseline metric value (0-1), before any variant. */
+  baselineValue: number;
+  /** Best metric value achieved (the winner, or best attempt) (0-1). */
+  bestValue: number;
+  /** The best candidate from each round, in order. */
+  rounds: Array<{
+    round: number;
+    variantId: string;
+    metricValue: number;
+    metricDelta: number;
+    disqualified: boolean;
+  }>;
+  /** Winning variant id, if a non-regressing candidate beat the baseline. */
+  winnerVariantId?: string;
+  /** apply | reject | inconclusive */
+  recommendation?: string;
+  /** Why the experiment stopped. */
+  reason: string;
 }
 
 /**


### PR DESCRIPTION
## Problem

A `runVariantExperiment` run showed only its **baseline** in the HTML report. The experiment runs the dataset multiple times (baseline + each variant), each attaching its own `mcp-test-results`; the reporter reads the first attachment — the baseline — so the optimized outcome never appeared. You had to do a separate "after" run to get a report that reflected the win.

## Change

`runVariantExperiment` now runs its internal evals **without** attaching, then attaches once at the end (when `testInfo` is present):

- The **winning variant's** case results as `mcp-test-results` — so the report's results table and the recall headline reflect the optimized state.
- A compact **experiment summary** (`mcp-variant-experiment`): metric, baseline → best with delta, the per-round climb, the winning variant, and the apply/reject/inconclusive verdict.

The reporter ingests the summary into `MCPEvalRunData.variantExperiment`, and a new **"Variant Experiment"** card renders in the Evals tab showing the climb round-by-round.

## Notes

- Behavior change: the report now reflects the winner, not the baseline. This is the intended fix.
- New type `MCPVariantExperimentData` in `types/reporter.ts` (re-exported to the UI).

## Validation

3 new unit tests cover the attachments (winner results + summary) and that internal runs receive no `testInfo`. `format:check`, `typecheck`, `lint`, `docs:check`, `build` (incl. UI reporter), and `test` (963 passing) all pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)