### PR TITLE
fix(evals): warn once when testInfo is missing

### DIFF
--- a/src/evals/evalRunner.ts
+++ b/src/evals/evalRunner.ts
@@ -1078,6 +1078,10 @@ async function getGitHash(): Promise<string | undefined> {
   return result.status === 0 ? result.stdout.trim() : undefined;
 }
 
+// ponytail: warn once per process, not per call — the message is identical and
+// runVariantExperiment / scripted loops call this many times.
+let warnedNoTestInfo = false;
+
 export async function runEvalDataset(
   options: EvalRunnerOptions,
   context: EvalContext
@@ -1328,7 +1332,8 @@ export async function runEvalDataset(
       contentType: 'application/json',
       body: Buffer.from(JSON.stringify({ caseResults })),
     });
-  } else if (caseResults.length > 0) {
+  } else if (caseResults.length > 0 && !warnedNoTestInfo) {
+    warnedNoTestInfo = true;
     console.warn(
       '[mcp-server-tester] runEvalDataset: testInfo not provided — results will not appear in the MCP reporter.\n' +
         'To enable reporting, pass testInfo from the Playwright test function:\n' +


### PR DESCRIPTION
## Summary

`runEvalDataset`'s "testInfo not provided" warning fired on **every** call without `testInfo`. When driving it programmatically (`runVariantExperiment`, scripted loops), that's the same message printed dozens of times, drowning real output.

Gate it behind a process-level flag so it warns once.

## Validation

`format:check`, `typecheck`, `lint`, `docs:check`, `build`, `test` (960 passing) all pass locally. No dedicated test: the flag is process-global (not resettable without exporting it), so an assertion would be order-dependent across the suite — not worth the brittleness for a one-line warn-dedup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)