### PR TITLE
fix(evals): surface the real provider error on mcp_host 404s

### DIFF
--- a/src/evals/mcpHost/adapters/vercel.test.ts
+++ b/src/evals/mcpHost/adapters/vercel.test.ts
@@ -406,7 +406,10 @@ describe('createVercelOrchestrator', () => {
       });
 
       expect(result.success).toBe(false);
-      expect(result.error).toContain('model not found');
+      // Raw provider error is preserved, not collapsed to a misleading guess.
+      expect(result.error).toContain('404 Not Found: model not found');
+      // Hint points at the real causes (model id / base-URL override).
+      expect(result.error).toContain('ANTHROPIC_BASE_URL');
     });
   });
 });

--- a/src/evals/mcpHost/adapters/vercel.ts
+++ b/src/evals/mcpHost/adapters/vercel.ts
@@ -54,7 +54,9 @@ function enrichErrorMessage(err: unknown, provider: string): string {
     );
   }
 
-  // Model not found (404 or explicit "model … not found" phrasing)
+  // 404 / not-found: the SDK collapses several distinct causes here — a wrong
+  // or retired model id, or a base-URL override routing to a gateway that
+  // doesn't serve the model. Preserve the raw error instead of guessing.
   if (
     raw.includes('404') ||
     raw.includes('Not Found') ||
@@ -62,8 +64,11 @@ function enrichErrorMessage(err: unknown, provider: string): string {
       raw.toLowerCase().includes('not found'))
   ) {
     return (
-      `MCP host simulation failed: model not found.\n` +
-      `Hint: check the model name format for your provider. For vertex-anthropic use 'claude-3-5-haiku@20241022' (with @).`
+      `MCP host simulation failed: ${raw}\n` +
+      `Hint: a 404 usually means the model id is wrong or retired, or a ` +
+      `base-URL override (e.g. ANTHROPIC_BASE_URL / OPENAI_BASE_URL pointing ` +
+      `at a gateway) is routing requests somewhere that doesn't serve this ` +
+      `model. Verify the model id and that no unexpected *_BASE_URL is set.`
     );
   }
 


### PR DESCRIPTION
## Summary

The mcp_host error classifier collapsed **every** 404 / Not Found into `model not found` with a vertex-anthropic-only hint, throwing away the raw provider error. But a 404 has several distinct causes — a wrong/retired model id, *or* a base-URL override (e.g. `ANTHROPIC_BASE_URL` pointing at a corporate gateway) routing requests somewhere that doesn't serve the model. The collapsed message actively misdirected debugging.

## Change

The 404 branch now **preserves the raw provider error** and points the hint at the real causes (model id correctness, and unexpected `*_BASE_URL` overrides) instead of a vertex-only format guess.

## Validation

Updated the 404 classification test to assert the raw error survives and the hint names the real causes. `format:check`, `typecheck`, `lint`, `docs:check`, `build`, `test` (960 passing) all pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)