### PR TITLE
feat: capture tool call outputs and reference them by id in transcript

### DIFF
--- a/src/evals/mcpHost/adapters/cli/parsers.test.ts
+++ b/src/evals/mcpHost/adapters/cli/parsers.test.ts
@@ -232,7 +232,7 @@ describe('parseStreamJson', () => {
     expect(result.usage).toBeUndefined();
   });
 
-  it('collects tool_result blocks into conversationHistory', () => {
+  it('keeps orphan tool_result inline in conversationHistory (no matching call)', () => {
     const stdout = JSON.stringify({
       type: 'user',
       message: {
@@ -246,6 +246,85 @@ describe('parseStreamJson', () => {
       role: 'tool',
       content: 'tool output here',
     });
+  });
+
+  it('stores output on the matching call and references it by id in the transcript', () => {
+    const stdout = [
+      JSON.stringify({
+        type: 'assistant',
+        message: {
+          content: [
+            {
+              type: 'tool_use',
+              name: 'search',
+              id: 'call_1',
+              input: { query: 'abcd' },
+            },
+          ],
+        },
+      }),
+      JSON.stringify({
+        type: 'user',
+        message: {
+          content: [
+            {
+              type: 'tool_result',
+              tool_use_id: 'call_1',
+              content: '{"abc":"xyz"}',
+            },
+          ],
+        },
+      }),
+    ].join('\n');
+
+    const result = parseStreamJson(stdout);
+    // Payload stored once, on the call.
+    expect(result.toolCalls[0]).toEqual({
+      name: 'search',
+      arguments: { query: 'abcd' },
+      id: 'call_1',
+      output: '{"abc":"xyz"}',
+    });
+    // Transcript references the call by id, without duplicating the payload.
+    expect(result.conversationHistory![0]).toEqual({
+      role: 'tool',
+      toolCallId: 'call_1',
+    });
+  });
+
+  it('serializes object tool_result content as JSON onto the call', () => {
+    const stdout = [
+      JSON.stringify({
+        type: 'assistant',
+        message: {
+          content: [{ type: 'tool_use', name: 'search', id: 'c1', input: {} }],
+        },
+      }),
+      JSON.stringify({
+        type: 'user',
+        message: {
+          content: [
+            { type: 'tool_result', tool_use_id: 'c1', content: { abc: 'xyz' } },
+          ],
+        },
+      }),
+    ].join('\n');
+
+    const result = parseStreamJson(stdout);
+    expect(result.toolCalls[0]!.output).toBe('{"abc":"xyz"}');
+  });
+
+  it('leaves output undefined when tool_result has no matching tool_use_id', () => {
+    const stdout = JSON.stringify({
+      type: 'user',
+      message: {
+        content: [{ type: 'tool_result', content: 'orphan output' }],
+      },
+    });
+
+    const result = parseStreamJson(stdout);
+    expect(result.toolCalls).toHaveLength(0);
+    expect(result.conversationHistory).toHaveLength(1);
   });
 });
 

--- a/src/evals/mcpHost/adapters/cli/parsers.ts
+++ b/src/evals/mcpHost/adapters/cli/parsers.ts
@@ -12,7 +12,8 @@ export function parseStreamJson(stdout: string): MCPHostSimulationResult {
   let usage: UsageMetrics | undefined;
   const conversationHistory: Array<{
     role: 'user' | 'assistant' | 'tool';
-    content: string;
+    content?: string;
+    toolCallId?: string;
   }> = [];
 
   for (const line of lines) {
@@ -49,7 +50,17 @@ export function parseStreamJson(stdout: string): MCPHostSimulationResult {
             typeof block.content === 'string'
               ? block.content
               : JSON.stringify(block.content);
-          conversationHistory.push({ role: 'tool', content });
+          const call = block.tool_use_id
+            ? toolCalls.find((tc) => tc.id === block.tool_use_id)
+            : undefined;
+          if (call) {
+            // Store the payload once on the call; the transcript just references it.
+            call.output = content;
+            conversationHistory.push({ role: 'tool', toolCallId: call.id });
+          } else {
+            // Orphan result (no matching tool_use) — keep inline so nothing is lost.
+            conversationHistory.push({ role: 'tool', content });
+          }
         }
       }
     }

--- a/src/evals/mcpHost/adapters/vercel.ts
+++ b/src/evals/mcpHost/adapters/vercel.ts
@@ -222,13 +222,22 @@ export function createVercelOrchestrator(): MCPHostSimulator {
           tools[toolName] = {
             description: mcpTool.description ?? '',
             inputSchema: jsonSchema(rawSchema),
-            execute: async (args: Record<string, unknown>) => {
+            execute: async (
+              args: Record<string, unknown>,
+              opts?: { toolCallId?: string },
+            ) => {
               const mcpStart = Date.now();
               const result = await mcp.callTool(toolName, args);
               mcpDurationMs += Date.now() - mcpStart;
 
-              allToolCalls.push({ name: toolName, arguments: args });
-              return extractText(result);
+              const output = extractText(result);
+              allToolCalls.push({
+                id: opts?.toolCallId,
+                name: toolName,
+                arguments: args,
+                output,
+              });
+              return output;
             },
           };
         }
@@ -257,15 +266,22 @@ export function createVercelOrchestrator(): MCPHostSimulator {
             }
           : undefined;
 
-        const conversationHistory = (result.steps ?? []).map((step: any) => ({
-          role: (step.toolCalls?.length > 0 ? 'tool' : 'assistant') as
-            | 'tool'
-            | 'assistant',
-          content:
-            step.toolCalls?.length > 0
-              ? JSON.stringify(step.toolResults)
-              : (step.text ?? ''),
-        }));
+        const conversationHistory: Array<{
+          role: 'tool' | 'assistant';
+          content?: string;
+          toolCallId?: string;
+        }> = (result.steps ?? []).flatMap((step: any) => {
+          if (step.toolCalls?.length > 0) {
+            // Reference each call by id; the payload lives once on allToolCalls.
+            return step.toolCalls.map((tc: any) => ({
+              role: 'tool' as const,
+              toolCallId: tc.toolCallId as string | undefined,
+            }));
+          }
+          return step.text
+            ? [{ role: 'assistant' as const, content: step.text as string }]
+            : [];
+        });
 
         return {
           success: true,

--- a/src/evals/mcpHost/mcpHostTypes.ts
+++ b/src/evals/mcpHost/mcpHostTypes.ts
@@ -237,6 +237,8 @@ export interface LLMToolCall {
   arguments: Record<string, unknown>;
   /** Optional tool call ID (for tracking) */
   id?: string;
+  /** Tool result text, when the host surfaces it (paired to this call) */
+  output?: string;
 }
 
 /**
@@ -258,10 +260,17 @@ export interface MCPHostSimulationResult {
   /** The scenario prompt that was given to the LLM */
   scenario?: string;
 
-  /** The conversation turns for attribution analysis */
+  /**
+   * The conversation turns for attribution analysis.
+   *
+   * Tool turns reference their call via `toolCallId` rather than inlining the
+   * (potentially large) result — hydrate the output from the matching
+   * `toolCalls[]` entry. `content` holds assistant/user text.
+   */
   conversationHistory?: Array<{
     role: 'user' | 'assistant' | 'tool';
-    content: string;
+    content?: string;
+    toolCallId?: string;
   }>;
 
   /**


### PR DESCRIPTION
Add `output` to LLMToolCall so each tool call carries its own result, making toolCalls the single source of truth for tool payloads.

Conversation history tool turns now reference their call via `toolCallId` instead of inlining the (potentially large) result, eliminating the duplication between toolCalls and conversationHistory. Orphan tool_results with no matching call fall back to inline content so nothing is dropped.

Applied to both hosts:
- Claude CLI (stream-json): pair tool_result to tool_use by tool_use_id.
- Vercel AI SDK: capture the SDK toolCallId in execute() and reference it per step.