### PR TITLE
fix: unblock CI on main after #227 (format:check + lint)

### DIFF
--- a/src/evals/mcpHost/adapters/vercel.ts
+++ b/src/evals/mcpHost/adapters/vercel.ts
@@ -278,10 +278,12 @@ export function createVercelOrchestrator(): MCPHostSimulator {
         }> = (result.steps ?? []).flatMap((step: any) => {
           if (step.toolCalls?.length > 0) {
             // Reference each call by id; the payload lives once on allToolCalls.
-            return step.toolCalls.map((tc: any) => ({
-              role: 'tool' as const,
-              toolCallId: tc.toolCallId as string | undefined,
-            }));
+            return (step.toolCalls as Array<{ toolCallId?: string }>).map(
+              (tc) => ({
+                role: 'tool' as const,
+                toolCallId: tc.toolCallId,
+              })
+            );
           }
           return step.text
             ? [{ role: 'assistant' as const, content: step.text as string }]

--- a/src/evals/mcpHost/adapters/vercel.ts
+++ b/src/evals/mcpHost/adapters/vercel.ts
@@ -229,7 +229,7 @@ export function createVercelOrchestrator(): MCPHostSimulator {
             inputSchema: jsonSchema(rawSchema),
             execute: async (
               args: Record<string, unknown>,
-              opts?: { toolCallId?: string },
+              opts?: { toolCallId?: string }
             ) => {
               const mcpStart = Date.now();
               const result = await mcp.callTool(toolName, args);


### PR DESCRIPTION
## Problem

The `test` check on #227 (`feat: capture tool call outputs...`) went red and was merged anyway. CI runs its steps sequentially (`npm ci` -> `format:check` -> `typecheck` -> `lint` -> `docs:check` -> `build` -> `test` -> playwright), and `format:check` failed at step 2 — which short-circuited every later step. So `main` currently has **two** CI-blocking issues in `src/evals/mcpHost/adapters/vercel.ts`, only the first of which was visible:

1. **format:check** — the new `execute()` signature had a trailing comma after the last parameter, violating `trailingComma: 'es5'` (es5 disallows trailing commas on function params).
2. **lint** — `no-unsafe-return`: mapping over `step.toolCalls` (typed `any`) returns `any`, which is then returned from the `flatMap` callback.

Both block a release too, since `prepublishOnly` -> `test:all` runs `format:check` and `lint`.

## Fix

```diff
             execute: async (
               args: Record<string, unknown>,
-              opts?: { toolCallId?: string },
+              opts?: { toolCallId?: string }
             ) => {
```

```diff
-            return step.toolCalls.map((tc: any) => ({
-              role: 'tool' as const,
-              toolCallId: tc.toolCallId as string | undefined,
-            }));
+            return (step.toolCalls as Array<{ toolCallId?: string }>).map(
+              (tc) => ({
+                role: 'tool' as const,
+                toolCallId: tc.toolCallId,
+              })
+            );
```

Both are behavior-identical (formatting + a cast to give the mapped array a concrete type).

## Verification

- `prettier --check` across all tracked files: clean
- `eslint` on the file: 0 problems
- Parser unit tests (`parsers.test.ts`) pass 23/23
- Relying on this PR's CI to exercise the full chain (`typecheck`/`lint`/`docs`/`build`/`test`/playwright) that never ran on #227.