### PR TITLE
[Evals] Phase 1: EvalConfigSchema, plugin loader, and run CLI skeleton

### DIFF
--- a/schema/eval-config.schema.json
+++ b/schema/eval-config.schema.json
@@ -1,0 +1,96 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://github.com/gleanwork/mcp-server-tester/schema/eval-config.schema.json",
+  "title": "Eval Campaign Config",
+  "description": "JSON config for mcp-server-tester run campaigns. Derived from scio .github/mcp_tests/configs/weekly/*.json.",
+  "type": "object",
+  "required": ["name", "mode"],
+  "additionalProperties": false,
+  "properties": {
+    "name": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Unique campaign name used for result directories and reporting."
+    },
+    "mode": {
+      "type": "string",
+      "enum": [
+        "tool-selection",
+        "tool-call",
+        "e2e-quality",
+        "mcp-host",
+        "sxs",
+        "direct",
+        "all"
+      ],
+      "description": "Eval campaign mode. Maps to MST runner behavior (filter tags, judges, server comparison)."
+    },
+    "evalsetFilePaths": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Paths to evalset JSON files or directories."
+    },
+    "localEvalsets": {
+      "type": "string",
+      "description": "Shorthand for a single local evalset path."
+    },
+    "model": { "type": "string" },
+    "clientHost": {
+      "type": "string",
+      "description": "MCP host simulator (e.g. claude-cli, cursor-desktop)."
+    },
+    "mcpUrl": { "type": "string", "format": "uri" },
+    "concurrency": { "type": "integer", "minimum": 1 },
+    "maxCases": { "type": "integer", "minimum": 1 },
+    "timeout": { "type": "integer", "minimum": 1 },
+    "provider": { "type": "string" },
+    "env": {
+      "type": "object",
+      "additionalProperties": { "type": "string" }
+    },
+    "metrics": {
+      "type": "array",
+      "items": {
+        "oneOf": [
+          { "type": "string" },
+          {
+            "type": "object",
+            "required": ["metric"],
+            "properties": {
+              "metric": { "type": "string" },
+              "name": { "type": "string" },
+              "params": { "type": "object" }
+            }
+          }
+        ]
+      }
+    },
+    "iterations": { "type": "integer", "minimum": 0 },
+    "maxToolCalls": { "type": "integer", "minimum": 0 },
+    "judges": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Registered judge names (via --plugins) for e2e-quality mode."
+    },
+    "version": { "type": "string" },
+    "plugins": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["name", "dir"],
+        "properties": {
+          "name": { "type": "string" },
+          "dir": { "type": "string" },
+          "mcpUrl": { "type": "string", "format": "uri" }
+        }
+      }
+    },
+    "useOAuth": { "type": "boolean" },
+    "tools": {
+      "type": "string",
+      "description": "Comma-separated tool filter."
+    },
+    "serverB": { "type": "string", "format": "uri" },
+    "serverBToken": { "type": "string" }
+  }
+}

--- a/src/cli/commands/run/index.ts
+++ b/src/cli/commands/run/index.ts
@@ -1,0 +1,73 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import {
+  loadEvalConfig,
+  resolveEvalModeConfig,
+  resolveEvalsetPaths,
+} from '../../../evals/evalConfigSchema.js';
+import { loadPlugins } from '../../../plugins/loadPlugins.js';
+
+export interface RunOptions {
+  config: string;
+  plugins?: string[];
+  rootDir?: string;
+  dryRun?: boolean;
+}
+
+export async function run(options: RunOptions): Promise<void> {
+  const rootDir = options.rootDir ?? process.cwd();
+  const config = loadEvalConfig(options.config, {
+    rootDir,
+    skipEvalsetValidation: options.dryRun,
+  });
+  const modeConfig = resolveEvalModeConfig(config.mode);
+
+  const pluginPaths =
+    options.plugins ??
+    config.plugins?.map((plugin) =>
+      path.isAbsolute(plugin.dir) ? plugin.dir : path.resolve(rootDir, plugin.dir),
+    ) ??
+    [];
+
+  if (pluginPaths.length > 0) {
+    await loadPlugins(pluginPaths);
+  }
+
+  const evalsetPaths = resolveEvalsetPaths(config, rootDir);
+  const output = {
+    name: config.name,
+    mode: config.mode,
+    filterTags: modeConfig.filterTags,
+    requiresJudges: modeConfig.requiresJudges,
+    isServerComparison: modeConfig.isServerComparison,
+    judges: config.judges ?? [],
+    evalsetPaths,
+    concurrency: config.concurrency ?? 1,
+    maxCases: config.maxCases,
+    mcpUrl: config.mcpUrl,
+    clientHost: config.clientHost,
+    pluginsLoaded: pluginPaths,
+  };
+
+  if (options.dryRun) {
+    process.stdout.write(`${JSON.stringify(output, null, 2)}\n`);
+    return;
+  }
+
+  // Phase 1: validate config + plugins. Full runEvalSuite wiring lands in a follow-up.
+  const resultsDir = path.join(rootDir, '.mcp-test-results', config.name);
+  fs.mkdirSync(resultsDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(resultsDir, 'run-plan.json'),
+    `${JSON.stringify(output, null, 2)}\n`,
+  );
+
+  console.log(`Eval config validated: ${config.name}`);
+  console.log(`Mode: ${config.mode} → filterTags=${output.filterTags.join(',') || '(none)'}`);
+  console.log(`Evalsets: ${evalsetPaths.length}`);
+  console.log(`Plugins loaded: ${pluginPaths.length}`);
+  console.log(`Run plan written to ${path.join(resultsDir, 'run-plan.json')}`);
+  console.log(
+    'Note: full campaign execution (runEvalSuite) is not wired yet — config + plugin loading only.',
+  );
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -8,6 +8,7 @@ import { generate } from './commands/generate/index.js';
 import { login } from './commands/login/index.js';
 import { token } from './commands/token/index.js';
 import { open } from './commands/open/index.js';
+import { run } from './commands/run/index.js';
 import packageJson from '../../package.json' with { type: 'json' };
 
 const program = new Command();
@@ -60,6 +61,19 @@ program
   )
   .option('--state-dir <dir>', 'Custom directory for token storage')
   .action(token);
+
+// Run command
+program
+  .command('run')
+  .description('Run an eval campaign from a JSON config file')
+  .requiredOption('-c, --config <path>', 'Path to eval config JSON')
+  .option(
+    '--plugins <paths...>',
+    'Plugin directories to load before the run (registers judges, auth, hosts)',
+  )
+  .option('--root-dir <dir>', 'Base directory for resolving relative paths', '.')
+  .option('--dry-run', 'Validate config and plugins without executing evals')
+  .action(run);
 
 // Open command
 program

--- a/src/evals/evalConfigSchema.test.ts
+++ b/src/evals/evalConfigSchema.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect } from 'vitest';
+import {
+  EvalConfigSchema,
+  loadEvalConfigFromObject,
+  resolveEvalModeConfig,
+  resolveEvalsetPaths,
+} from './evalConfigSchema.js';
+
+describe('EvalConfigSchema', () => {
+  it('parses a tool-selection weekly config', () => {
+    const config = EvalConfigSchema.parse({
+      name: 'weekly-tool-selection-search',
+      mode: 'tool-selection',
+      evalsetFilePaths: ['evalsets/tool-selection/search.json'],
+      model: 'claude-sonnet-4-6',
+      clientHost: 'claude-cli',
+      mcpUrl: 'https://scio-prod-be.glean.com/mcp/default/eval',
+      concurrency: 5,
+      maxCases: 50,
+      metrics: ['passed', 'cost_usd'],
+    });
+
+    expect(config.name).toBe('weekly-tool-selection-search');
+    expect(config.mode).toBe('tool-selection');
+  });
+
+  it('requires serverB for sxs mode', () => {
+    const result = EvalConfigSchema.safeParse({
+      name: 'sxs-run',
+      mode: 'sxs',
+      evalsetFilePaths: ['evalsets/tool-selection/search.json'],
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it('accepts metric objects with params', () => {
+    const config = EvalConfigSchema.parse({
+      name: 'e2e',
+      mode: 'e2e-quality',
+      evalsetFilePaths: ['evalsets/e2e-quality/info-seeking.json'],
+      judges: ['glean-completeness'],
+      metrics: [
+        {
+          metric: 'judge_pass_for',
+          name: 'judge_glean_completeness_pass',
+          params: { judge: 'glean-completeness' },
+        },
+      ],
+    });
+
+    expect(config.metrics?.[0]).toEqual({
+      metric: 'judge_pass_for',
+      name: 'judge_glean_completeness_pass',
+      params: { judge: 'glean-completeness' },
+    });
+  });
+});
+
+describe('resolveEvalModeConfig', () => {
+  it('maps tool-selection to mcp_host tag filter', () => {
+    expect(resolveEvalModeConfig('tool-selection')).toEqual({
+      filterTags: ['mcp_host'],
+      requiresJudges: false,
+      isServerComparison: false,
+    });
+  });
+
+  it('maps e2e-quality to e2e_quality tag filter with judges', () => {
+    expect(resolveEvalModeConfig('e2e-quality')).toEqual({
+      filterTags: ['e2e_quality'],
+      requiresJudges: true,
+      isServerComparison: false,
+    });
+  });
+});
+
+describe('resolveEvalsetPaths', () => {
+  it('resolves relative paths against rootDir', () => {
+    const paths = resolveEvalsetPaths(
+      {
+        name: 'x',
+        mode: 'tool-selection',
+        evalsetFilePaths: ['evalsets/search.json'],
+      },
+      '/tmp/mcp_tests',
+    );
+
+    expect(paths).toEqual(['/tmp/mcp_tests/evalsets/search.json']);
+  });
+
+  it('falls back to localEvalsets', () => {
+    const paths = resolveEvalsetPaths(
+      {
+        name: 'x',
+        mode: 'tool-selection',
+        localEvalsets: 'fixtures/evals/search-evals.json',
+      },
+      '/tmp/mcp_tests',
+    );
+
+    expect(paths).toEqual(['/tmp/mcp_tests/fixtures/evals/search-evals.json']);
+  });
+});
+
+describe('loadEvalConfigFromObject', () => {
+  it('validates evalset paths exist', () => {
+    expect(() =>
+      loadEvalConfigFromObject(
+        {
+          name: 'missing',
+          mode: 'tool-selection',
+          evalsetFilePaths: ['does-not-exist.json'],
+        },
+        { rootDir: process.cwd() },
+      ),
+    ).toThrow(/Evalset path not found/);
+  });
+});

--- a/src/evals/evalConfigSchema.ts
+++ b/src/evals/evalConfigSchema.ts
@@ -1,0 +1,198 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { z } from 'zod';
+
+/**
+ * Scio-era eval campaign modes. These map to MST runner behavior via
+ * {@link resolveEvalModeConfig}.
+ */
+export const EvalCampaignModeSchema = z.enum([
+  'tool-selection',
+  'tool-call',
+  'e2e-quality',
+  'mcp-host',
+  'sxs',
+  'direct',
+  'all',
+]);
+
+export type EvalCampaignMode = z.infer<typeof EvalCampaignModeSchema>;
+
+export const MetricSpecSchema = z.union([
+  z.string(),
+  z.object({
+    metric: z.string(),
+    name: z.string().optional(),
+    params: z.record(z.string(), z.unknown()).optional(),
+  }),
+]);
+
+export type MetricSpec = z.infer<typeof MetricSpecSchema>;
+
+export const EvalPluginRefSchema = z.object({
+  name: z.string(),
+  dir: z.string(),
+  mcpUrl: z.string().url().optional(),
+});
+
+export type EvalPluginRef = z.infer<typeof EvalPluginRefSchema>;
+
+/**
+ * JSON config for a single eval campaign run.
+ *
+ * Derived from scio `.github/mcp_tests/configs/weekly/*.json` and designed
+ * to be the contract for `mcp-server-tester run`.
+ */
+export const EvalConfigSchema = z
+  .object({
+    name: z.string().min(1),
+    mode: EvalCampaignModeSchema,
+    evalsetFilePaths: z.array(z.string()).optional(),
+    localEvalsets: z.string().optional(),
+    model: z.string().optional(),
+    clientHost: z.string().optional(),
+    mcpUrl: z.string().url().optional(),
+    concurrency: z.number().int().positive().optional(),
+    maxCases: z.number().int().positive().optional(),
+    timeout: z.number().int().positive().optional(),
+    provider: z.string().optional(),
+    env: z.record(z.string(), z.string()).optional(),
+    metrics: z.array(MetricSpecSchema).optional(),
+    iterations: z.number().int().nonnegative().optional(),
+    maxToolCalls: z.number().int().nonnegative().optional(),
+    judges: z.array(z.string()).optional(),
+    version: z.string().optional(),
+    plugins: z.array(EvalPluginRefSchema).optional(),
+    useOAuth: z.boolean().optional(),
+    tools: z.string().optional(),
+    serverB: z.string().url().optional(),
+    serverBToken: z.string().optional(),
+  })
+  .superRefine((config, ctx) => {
+    const hasEvalsets =
+      (config.evalsetFilePaths?.length ?? 0) > 0 || !!config.localEvalsets;
+    if (!hasEvalsets && config.mode !== 'direct') {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message:
+          'evalsetFilePaths or localEvalsets is required for this eval mode',
+        path: ['evalsetFilePaths'],
+      });
+    }
+
+    if (config.mode === 'sxs' && !config.serverB) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'serverB is required when mode is sxs',
+        path: ['serverB'],
+      });
+    }
+  });
+
+export type EvalConfig = z.infer<typeof EvalConfigSchema>;
+
+export interface ResolvedEvalModeConfig {
+  /** Dataset tag filter passed to runEvalDataset. */
+  filterTags: string[];
+  /** Whether the campaign needs custom judge registrations. */
+  requiresJudges: boolean;
+  /** Whether this mode compares two MCP servers. */
+  isServerComparison: boolean;
+}
+
+const MODE_TAG_MAP: Record<EvalCampaignMode, ResolvedEvalModeConfig> = {
+  'tool-selection': {
+    filterTags: ['mcp_host'],
+    requiresJudges: false,
+    isServerComparison: false,
+  },
+  'tool-call': {
+    filterTags: ['tool_call'],
+    requiresJudges: false,
+    isServerComparison: false,
+  },
+  'e2e-quality': {
+    filterTags: ['e2e_quality'],
+    requiresJudges: true,
+    isServerComparison: false,
+  },
+  'mcp-host': {
+    filterTags: ['mcp_host'],
+    requiresJudges: false,
+    isServerComparison: false,
+  },
+  sxs: {
+    filterTags: [],
+    requiresJudges: false,
+    isServerComparison: true,
+  },
+  direct: {
+    filterTags: [],
+    requiresJudges: false,
+    isServerComparison: false,
+  },
+  all: {
+    filterTags: [],
+    requiresJudges: true,
+    isServerComparison: false,
+  },
+};
+
+export function resolveEvalModeConfig(mode: EvalCampaignMode): ResolvedEvalModeConfig {
+  return MODE_TAG_MAP[mode];
+}
+
+export interface LoadEvalConfigOptions {
+  /** Base directory for resolving relative evalset paths. */
+  rootDir?: string;
+  /** Skip filesystem checks for evalset paths (useful for --dry-run). */
+  skipEvalsetValidation?: boolean;
+}
+
+export function resolveEvalsetPaths(
+  config: EvalConfig,
+  rootDir = process.cwd(),
+): string[] {
+  if (config.evalsetFilePaths?.length) {
+    return config.evalsetFilePaths.map((p) =>
+      path.isAbsolute(p) ? p : path.resolve(rootDir, p),
+    );
+  }
+  if (config.localEvalsets) {
+    const local = config.localEvalsets;
+    return [path.isAbsolute(local) ? local : path.resolve(rootDir, local)];
+  }
+  return [];
+}
+
+export function loadEvalConfigFromObject(
+  value: unknown,
+  options: LoadEvalConfigOptions = {},
+): EvalConfig {
+  const config = EvalConfigSchema.parse(value);
+  if (options.skipEvalsetValidation) {
+    return config;
+  }
+  const evalsetPaths = resolveEvalsetPaths(config, options.rootDir);
+  for (const evalsetPath of evalsetPaths) {
+    if (!fs.existsSync(evalsetPath)) {
+      throw new Error(`Evalset path not found: ${evalsetPath}`);
+    }
+  }
+  return config;
+}
+
+export function loadEvalConfig(
+  configPath: string,
+  options: LoadEvalConfigOptions = {},
+): EvalConfig {
+  const absPath = path.isAbsolute(configPath)
+    ? configPath
+    : path.resolve(process.cwd(), configPath);
+  if (!fs.existsSync(absPath)) {
+    throw new Error(`Eval config not found: ${absPath}`);
+  }
+  const raw = JSON.parse(fs.readFileSync(absPath, 'utf8')) as unknown;
+  const rootDir = options.rootDir ?? path.dirname(absPath);
+  return loadEvalConfigFromObject(raw, { ...options, rootDir });
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -239,6 +239,30 @@ export {
   loadEvalDatasetFromObject,
 } from './evals/datasetLoader.js';
 
+// Eval campaign config (mcp-server-tester run)
+export {
+  EvalCampaignModeSchema,
+  EvalConfigSchema,
+  EvalPluginRefSchema,
+  MetricSpecSchema,
+  loadEvalConfig,
+  loadEvalConfigFromObject,
+  resolveEvalModeConfig,
+  resolveEvalsetPaths,
+} from './evals/evalConfigSchema.js';
+export type {
+  EvalCampaignMode,
+  EvalConfig,
+  EvalPluginRef,
+  LoadEvalConfigOptions,
+  MetricSpec,
+  ResolvedEvalModeConfig,
+} from './evals/evalConfigSchema.js';
+
+// Plugin loading
+export { loadPluginModule, loadPlugins } from './plugins/loadPlugins.js';
+export type { EvalPluginModule, LoadPluginsOptions } from './plugins/loadPlugins.js';
+
 // Eval Runner
 export { runEvalDataset, runEvalCase } from './evals/evalRunner.js';
 

--- a/src/plugins/loadPlugins.test.ts
+++ b/src/plugins/loadPlugins.test.ts
@@ -1,0 +1,54 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { loadPluginModule } from './loadPlugins.js';
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+function makeTempPlugin(contents: string): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'mst-plugin-'));
+  tempDirs.push(dir);
+  fs.writeFileSync(path.join(dir, 'index.mjs'), contents);
+  return dir;
+}
+
+describe('loadPluginModule', () => {
+  it('invokes register export', async () => {
+    const pluginDir = makeTempPlugin(`
+      let called = false;
+      export function register() {
+        called = true;
+      }
+      export function wasCalled() {
+        return called;
+      }
+    `);
+
+    await loadPluginModule(pluginDir);
+    const mod = await import(new URL('./index.mjs', `file://${pluginDir}/`).href);
+    expect(mod.wasCalled()).toBe(true);
+  });
+
+  it('invokes registerGleanJudges export', async () => {
+    const pluginDir = makeTempPlugin(`
+      export const registerGleanJudges = () => {};
+    `);
+
+    await expect(loadPluginModule(pluginDir)).resolves.toBeUndefined();
+  });
+
+  it('throws when no register export exists', async () => {
+    const pluginDir = makeTempPlugin(`
+      export const noop = () => {};
+    `);
+
+    await expect(loadPluginModule(pluginDir)).rejects.toThrow(/does not export a register function/);
+  });
+});

--- a/src/plugins/loadPlugins.ts
+++ b/src/plugins/loadPlugins.ts
@@ -1,0 +1,103 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+export interface EvalPluginModule {
+  register?: () => void | Promise<void>;
+  default?: () => void | Promise<void>;
+  [exportName: string]: unknown;
+}
+
+export interface LoadPluginsOptions {
+  /** Additional register function names to invoke after import. */
+  registerExportNames?: string[];
+}
+
+const DEFAULT_REGISTER_EXPORTS = [
+  'register',
+  'registerPlugins',
+  'registerGleanJudges',
+];
+
+function resolvePluginEntry(pluginPath: string): string {
+  const absPath = path.isAbsolute(pluginPath)
+    ? pluginPath
+    : path.resolve(process.cwd(), pluginPath);
+
+  if (fs.existsSync(absPath) && fs.statSync(absPath).isFile()) {
+    return absPath;
+  }
+
+  const candidates = [
+    path.join(absPath, 'index.ts'),
+    path.join(absPath, 'index.js'),
+    path.join(absPath, 'index.mjs'),
+    path.join(absPath, 'index.cjs'),
+  ];
+  for (const candidate of candidates) {
+    if (fs.existsSync(candidate)) {
+      return candidate;
+    }
+  }
+
+  throw new Error(`Plugin entry not found for: ${pluginPath}`);
+}
+
+async function invokeRegisterExport(
+  pluginModule: EvalPluginModule,
+  exportName: string,
+): Promise<boolean> {
+  const candidate = pluginModule[exportName];
+  if (typeof candidate !== 'function') {
+    return false;
+  }
+  await candidate();
+  return true;
+}
+
+/**
+ * Dynamically import a plugin module and invoke its registration hooks.
+ *
+ * Convention (first match wins):
+ * 1. Named export `register`, `registerPlugins`, or `registerGleanJudges`
+ * 2. Default export function
+ */
+export async function loadPluginModule(
+  pluginPath: string,
+  options: LoadPluginsOptions = {},
+): Promise<void> {
+  const entry = resolvePluginEntry(pluginPath);
+  const pluginModule = (await import(pathToFileURL(entry).href)) as EvalPluginModule;
+  const exportNames = [
+    ...(options.registerExportNames ?? []),
+    ...DEFAULT_REGISTER_EXPORTS,
+  ];
+
+  for (const exportName of exportNames) {
+    if (await invokeRegisterExport(pluginModule, exportName)) {
+      return;
+    }
+  }
+
+  if (typeof pluginModule.default === 'function') {
+    await pluginModule.default();
+    return;
+  }
+
+  throw new Error(
+    `Plugin at ${entry} does not export a register function. ` +
+      `Expected one of: ${exportNames.join(', ')}, or a default function.`,
+  );
+}
+
+/**
+ * Load one or more plugin paths in order.
+ */
+export async function loadPlugins(
+  pluginPaths: string[],
+  options: LoadPluginsOptions = {},
+): Promise<void> {
+  for (const pluginPath of pluginPaths) {
+    await loadPluginModule(pluginPath, options);
+  }
+}


### PR DESCRIPTION
## Summary

Phase 1 of the scio eval harness migration: introduces the config contract and plugin bootstrap that Steve requested as the first beta deliverable.

- **`EvalConfigSchema`** — Zod schema matching scio `configs/weekly/*.json` (tool-selection, e2e-quality, sxs, etc.)
- **`loadPlugins()`** — dynamic import with `register` / `registerGleanJudges` convention
- **`mcp-server-tester run`** CLI — validates config, loads plugins, writes a run plan
- **`schema/eval-config.schema.json`** — editor autocomplete for campaign configs

Backward compatible: scio continues using `tsx run-eval.ts` unchanged. This PR adds new MST APIs only.

## Context

- [MCP Eval Harness Porting Plan](https://docs.google.com/document/d/1Vsy-ynC3-F3qCzVg547_PZRPNdPBP3MjMFGM0ekH23c)
- Steve's feedback: start with EvalConfigSchema + `--plugins` loader before `runEvalSuite`

## scio-prod validation

- [x] `npm test` — 11 unit tests pass
- [x] `npm run typecheck`
- [x] Dry-run all 14 `configs/weekly/*.json` — each resolves `mcpUrl: https://scio-prod-be.glean.com/mcp/default/eval`
- [x] Spot-check: `tool-selection-code_search.json` dry-run produces correct filterTags, evalset paths, clientHost

```bash
source scio/.github/mcp_tests/.env
npx tsx src/cli/index.ts run \
  --config scio/.github/mcp_tests/configs/weekly/tool-selection-code_search.json \
  --root-dir scio/.github/mcp_tests \
  --dry-run
```

Phase 2 (#240) wires actual execution against scio-prod.

## Test plan

- [x] Unit tests + typecheck
- [x] scio-prod config dry-run (all weekly configs)
