### PR TITLE
[Evals] Phase 2: runEvalSuite with scio-compatible dataset building

### DIFF
--- a/src/cli/commands/run/index.ts
+++ b/src/cli/commands/run/index.ts
@@ -1,73 +1,48 @@
-import fs from 'node:fs';
 import path from 'node:path';
 import {
-  loadEvalConfig,
-  resolveEvalModeConfig,
-  resolveEvalsetPaths,
-} from '../../../evals/evalConfigSchema.js';
-import { loadPlugins } from '../../../plugins/loadPlugins.js';
+  runEvalSuite,
+  type RunEvalSuiteOptions,
+} from '../../../evals/runEvalSuite.js';
 
 export interface RunOptions {
   config: string;
   plugins?: string[];
   rootDir?: string;
   dryRun?: boolean;
+  outputDir?: string;
 }
 
 export async function run(options: RunOptions): Promise<void> {
-  const rootDir = options.rootDir ?? process.cwd();
-  const config = loadEvalConfig(options.config, {
-    rootDir,
-    skipEvalsetValidation: options.dryRun,
-  });
-  const modeConfig = resolveEvalModeConfig(config.mode);
-
-  const pluginPaths =
-    options.plugins ??
-    config.plugins?.map((plugin) =>
-      path.isAbsolute(plugin.dir) ? plugin.dir : path.resolve(rootDir, plugin.dir),
-    ) ??
-    [];
-
-  if (pluginPaths.length > 0) {
-    await loadPlugins(pluginPaths);
-  }
-
-  const evalsetPaths = resolveEvalsetPaths(config, rootDir);
-  const output = {
-    name: config.name,
-    mode: config.mode,
-    filterTags: modeConfig.filterTags,
-    requiresJudges: modeConfig.requiresJudges,
-    isServerComparison: modeConfig.isServerComparison,
-    judges: config.judges ?? [],
-    evalsetPaths,
-    concurrency: config.concurrency ?? 1,
-    maxCases: config.maxCases,
-    mcpUrl: config.mcpUrl,
-    clientHost: config.clientHost,
-    pluginsLoaded: pluginPaths,
+  const suiteOptions: RunEvalSuiteOptions = {
+    configPath: options.config,
+    rootDir: options.rootDir,
+    pluginPaths: options.plugins,
+    outputDir: options.outputDir,
+    dryRun: options.dryRun,
   };
 
+  const result = await runEvalSuite(suiteOptions);
+
   if (options.dryRun) {
-    process.stdout.write(`${JSON.stringify(output, null, 2)}\n`);
+    process.stdout.write(
+      `${JSON.stringify(
+        {
+          name: result.config.name,
+          mode: result.config.mode,
+          outputDir: result.outputDir,
+          datasets: result.datasets.map((d) => d.path),
+        },
+        null,
+        2,
+      )}\n`,
+    );
     return;
   }
 
-  // Phase 1: validate config + plugins. Full runEvalSuite wiring lands in a follow-up.
-  const resultsDir = path.join(rootDir, '.mcp-test-results', config.name);
-  fs.mkdirSync(resultsDir, { recursive: true });
-  fs.writeFileSync(
-    path.join(resultsDir, 'run-plan.json'),
-    `${JSON.stringify(output, null, 2)}\n`,
-  );
-
-  console.log(`Eval config validated: ${config.name}`);
-  console.log(`Mode: ${config.mode} → filterTags=${output.filterTags.join(',') || '(none)'}`);
-  console.log(`Evalsets: ${evalsetPaths.length}`);
-  console.log(`Plugins loaded: ${pluginPaths.length}`);
-  console.log(`Run plan written to ${path.join(resultsDir, 'run-plan.json')}`);
+  const { merged } = result;
+  console.log(`\nEval complete: ${merged.configName}`);
   console.log(
-    'Note: full campaign execution (runEvalSuite) is not wired yet — config + plugin loading only.',
+    `Results: ${merged.metrics.passed}/${merged.metrics.total} passed (${(merged.metrics.passRate * 100).toFixed(1)}%)`,
   );
+  console.log(`Output: ${path.join(result.outputDir, 'results.json')}`);
 }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -72,6 +72,7 @@ program
     'Plugin directories to load before the run (registers judges, auth, hosts)',
   )
   .option('--root-dir <dir>', 'Base directory for resolving relative paths', '.')
+  .option('--output-dir <dir>', 'Directory for results.json output')
   .option('--dry-run', 'Validate config and plugins without executing evals')
   .action(run);
 

--- a/src/evals/buildEvalDataset.test.ts
+++ b/src/evals/buildEvalDataset.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from 'vitest';
+import { buildEvalDataset } from './buildEvalDataset.js';
+import type { EvalConfig } from './evalConfigSchema.js';
+import { getBuiltinHostConfig } from './builtinHosts.js';
+
+const baseConfig: EvalConfig = {
+  name: 'test',
+  mode: 'tool-selection',
+  evalsetFilePaths: ['x.json'],
+};
+
+const hostConfig = getBuiltinHostConfig('vercel-sdk');
+
+describe('buildEvalDataset', () => {
+  it('builds tool-selection dataset from raw evalset', () => {
+    const dataset = buildEvalDataset(
+      {
+        name: 'search',
+        cases: [
+          {
+            id: 'case-1',
+            scenario: 'find the PTO policy',
+            expected_tool: 'search',
+          },
+        ],
+      },
+      'tool-selection',
+      hostConfig,
+      baseConfig,
+    );
+
+    expect(dataset.cases).toHaveLength(1);
+    expect(dataset.cases[0]?.mode).toBe('mcp_host');
+    expect(dataset.cases[0]?.expect?.toolsTriggered?.calls[0]?.name).toBe(
+      'search',
+    );
+    expect(dataset.cases[0]?.tags).toContain('tool_selection');
+  });
+
+  it('builds e2e-quality dataset with judges from config', () => {
+    const dataset = buildEvalDataset(
+      {
+        name: 'info-seeking',
+        cases: [
+          {
+            id: 'q1',
+            scenario: 'What is our parental leave policy?',
+            reference: '12 weeks paid leave',
+          },
+        ],
+      },
+      'e2e-quality',
+      hostConfig,
+      {
+        ...baseConfig,
+        mode: 'e2e-quality',
+        judges: ['glean-completeness', 'glean-correctness'],
+      },
+    );
+
+    expect(dataset.cases[0]?.tags).toContain('e2e_quality');
+    const judges = dataset.cases[0]?.expect?.passesJudge;
+    expect(Array.isArray(judges)).toBe(true);
+    expect(judges).toHaveLength(2);
+  });
+
+  it('passes through prebuilt datasets unchanged', () => {
+    const prebuilt = {
+      name: 'search-evals',
+      cases: [
+        {
+          id: 'search-basic',
+          toolName: 'search',
+          args: { query: 'pto policy' },
+          expect: { isError: false },
+        },
+      ],
+    };
+
+    const dataset = buildEvalDataset(
+      prebuilt,
+      'direct',
+      hostConfig,
+      { ...baseConfig, mode: 'direct' },
+    );
+
+    expect(dataset.cases[0]?.toolName).toBe('search');
+    expect(dataset.cases[0]?.args).toEqual({ query: 'pto policy' });
+  });
+
+  it('truncates to maxCases', () => {
+    const dataset = buildEvalDataset(
+      {
+        cases: [
+          { id: 'a', scenario: 'one', expected_tool: 'search' },
+          { id: 'b', scenario: 'two', expected_tool: 'search' },
+        ],
+      },
+      'tool-selection',
+      hostConfig,
+      { ...baseConfig, maxCases: 1 },
+    );
+
+    expect(dataset.cases).toHaveLength(1);
+    expect(dataset.cases[0]?.id).toBe('a');
+  });
+});

--- a/src/evals/buildEvalDataset.ts
+++ b/src/evals/buildEvalDataset.ts
@@ -244,7 +244,14 @@ export function buildEvalDataset(
   config: EvalConfig,
 ): EvalDataset {
   if (isPrebuiltDataset(raw)) {
-    return loadEvalDatasetFromObject(raw);
+    let dataset = loadEvalDatasetFromObject(raw);
+    if (config.maxCases && dataset.cases.length > config.maxCases) {
+      dataset = {
+        ...dataset,
+        cases: dataset.cases.slice(0, config.maxCases),
+      };
+    }
+    return dataset;
   }
 
   const builder = BUILDERS[mode];

--- a/src/evals/buildEvalDataset.ts
+++ b/src/evals/buildEvalDataset.ts
@@ -1,0 +1,268 @@
+import type { EvalCampaignMode } from './evalConfigSchema.js';
+import type { EvalConfig } from './evalConfigSchema.js';
+import type { EvalDataset } from './datasetTypes.js';
+import type { MCPHostConfig } from './mcpHost/mcpHostTypes.js';
+import { loadEvalDatasetFromObject } from './datasetLoader.js';
+
+type RawEvalset = {
+  name?: string;
+  description?: string;
+  cases: RawEvalCase[];
+};
+
+type RawEvalCase = Record<string, unknown>;
+
+function isPrebuiltDataset(data: unknown): data is EvalDataset {
+  if (!data || typeof data !== 'object' || !('cases' in data)) {
+    return false;
+  }
+  const cases = (data as { cases: unknown[] }).cases;
+  if (!cases?.length) {
+    return false;
+  }
+  const first = cases[0];
+  if (!first || typeof first !== 'object') {
+    return false;
+  }
+  return (
+    'mode' in first ||
+    ('expect' in first &&
+      typeof (first as { expect?: unknown }).expect === 'object')
+  );
+}
+
+function fixtureIterations(config: EvalConfig): number {
+  if (config.iterations && config.iterations > 0) {
+    return config.iterations;
+  }
+  const raw = process.env.EVAL_ITERATIONS;
+  return raw ? parseInt(raw, 10) : 5;
+}
+
+function enabledJudges(config: EvalConfig): Set<string> {
+  if (config.judges?.length) {
+    return new Set(config.judges);
+  }
+  const raw = process.env.EVAL_JUDGES ?? '';
+  return new Set(raw.split(',').map((j) => j.trim()).filter(Boolean));
+}
+
+function buildJudges(
+  scenario: string,
+  reference: string | undefined,
+  judges: Set<string>,
+): Array<Record<string, unknown>> {
+  const result: Array<Record<string, unknown>> = [];
+  if (judges.has('glean-completeness')) {
+    result.push({
+      judge: 'glean-completeness',
+      reference: scenario,
+      threshold: 0.5,
+    });
+  }
+  if (judges.has('glean-correctness') && reference) {
+    result.push({
+      judge: 'glean-correctness',
+      reference: JSON.stringify({ question: scenario, answer: reference }),
+      threshold: 0.5,
+    });
+  }
+  if (judges.has('task-completion')) {
+    result.push({
+      judge: 'task-completion',
+      reference: scenario,
+      threshold: 0.5,
+    });
+  }
+  for (const signalJudge of ['glean-rate-limit', 'glean-timeout'] as const) {
+    if (judges.has(signalJudge)) {
+      result.push({
+        judge: signalJudge,
+        reference: scenario,
+        threshold: 0.5,
+      });
+    }
+  }
+  return result;
+}
+
+function buildToolSelectionDataset(
+  evalset: RawEvalset,
+  hostConfig: MCPHostConfig,
+  config: EvalConfig,
+): EvalDataset {
+  const iterations = fixtureIterations(config);
+  const cases = evalset.cases.map((case_) => {
+    const expectedTool = String(case_.expected_tool);
+    const scenario = String(case_.scenario);
+    const tags = Array.isArray(case_.tags)
+      ? (case_.tags as string[])
+      : [];
+    return {
+      id: String(case_.id),
+      description:
+        typeof case_.description === 'string'
+          ? case_.description
+          : `Tool selection: should trigger ${expectedTool}`,
+      toolName: expectedTool,
+      mode: 'mcp_host' as const,
+      scenario,
+      mcpHostConfig: hostConfig,
+      tags: ['mcp_host', 'tool_selection', ...tags],
+      iterations,
+      accuracyThreshold: iterations === 1 ? 1.0 : 0.8,
+      expect: {
+        toolsTriggered: {
+          calls: [{ name: expectedTool, required: true }],
+        },
+      },
+    };
+  });
+
+  return loadEvalDatasetFromObject({
+    name: evalset.name ?? 'tool-selection',
+    description:
+      evalset.description ?? 'Tool selection evaluation.',
+    cases,
+  });
+}
+
+function buildToolCallDataset(
+  evalset: RawEvalset,
+  hostConfig: MCPHostConfig,
+): EvalDataset {
+  const cases = evalset.cases.map((case_) => {
+    const tool = String(case_.tool);
+    const tags = Array.isArray(case_.tags)
+      ? (case_.tags as string[])
+      : [];
+    const fixtureCase: Record<string, unknown> = {
+      id: String(case_.id),
+      description:
+        typeof case_.description === 'string'
+          ? case_.description
+          : `Tool call: ${tool}`,
+      toolName: tool,
+      tags: ['tool_call', ...tags],
+      expect:
+        case_.expect ??
+        ({
+          isError: false,
+          responseSize: { minBytes: 50 },
+        } as const),
+    };
+    if (case_.args !== undefined) {
+      fixtureCase.args = case_.args;
+    }
+    for (const key of [
+      'mode',
+      'scenario',
+      'iterations',
+      'accuracyThreshold',
+    ] as const) {
+      if (case_[key] !== undefined) {
+        fixtureCase[key] = case_[key];
+      }
+    }
+    if (case_.mode === 'mcp_host') {
+      fixtureCase.mcpHostConfig = hostConfig;
+    }
+    return fixtureCase;
+  });
+
+  return loadEvalDatasetFromObject({
+    name: evalset.name ?? 'tool-call',
+    description: evalset.description ?? 'Tool call evaluation.',
+    cases,
+  });
+}
+
+function buildE2eQualityDataset(
+  evalset: RawEvalset,
+  hostConfig: MCPHostConfig,
+  config: EvalConfig,
+): EvalDataset {
+  const judges = enabledJudges(config);
+  const cases = evalset.cases.map((case_) => {
+    const scenario = String(case_.scenario);
+    const reference =
+      typeof case_.reference === 'string' ? case_.reference : undefined;
+    const tags = Array.isArray(case_.tags)
+      ? (case_.tags as string[])
+      : [];
+    const fixtureCase: Record<string, unknown> = {
+      id: String(case_.id),
+      description:
+        typeof case_.description === 'string'
+          ? case_.description
+          : `E2E quality: ${scenario.slice(0, 80)}`,
+      mode: 'mcp_host',
+      scenario,
+      mcpHostConfig: hostConfig,
+      tags: ['e2e_quality', ...tags],
+      iterations: 1,
+    };
+    const judgeList = buildJudges(scenario, reference, judges);
+    if (judgeList.length > 0) {
+      fixtureCase.expect = { passesJudge: judgeList };
+    }
+    return fixtureCase;
+  });
+
+  const withRef = evalset.cases.filter((c) => c.reference).length;
+  return loadEvalDatasetFromObject({
+    name: evalset.name ?? 'e2e-quality',
+    description:
+      evalset.description ??
+      `E2E quality evaluation. ${cases.length} cases (${withRef} with correctness judge).`,
+    cases,
+  });
+}
+
+const BUILDERS: Record<
+  EvalCampaignMode,
+  | ((
+      evalset: RawEvalset,
+      hostConfig: MCPHostConfig,
+      config: EvalConfig,
+    ) => EvalDataset)
+  | null
+> = {
+  'tool-selection': buildToolSelectionDataset,
+  'tool-call': (evalset, hostConfig) => buildToolCallDataset(evalset, hostConfig),
+  'e2e-quality': buildE2eQualityDataset,
+  'mcp-host': buildToolSelectionDataset,
+  direct: null,
+  sxs: null,
+  all: null,
+};
+
+export function buildEvalDataset(
+  raw: unknown,
+  mode: EvalCampaignMode,
+  hostConfig: MCPHostConfig,
+  config: EvalConfig,
+): EvalDataset {
+  if (isPrebuiltDataset(raw)) {
+    return loadEvalDatasetFromObject(raw);
+  }
+
+  const builder = BUILDERS[mode];
+  if (!builder) {
+    throw new Error(`Cannot build dataset for mode "${mode}" from raw evalset`);
+  }
+
+  const evalset = raw as RawEvalset;
+  if (!Array.isArray(evalset.cases)) {
+    throw new Error('Evalset must contain a cases array');
+  }
+
+  let dataset = builder(evalset, hostConfig, config);
+  if (config.maxCases && dataset.cases.length > config.maxCases) {
+    dataset = {
+      ...dataset,
+      cases: dataset.cases.slice(0, config.maxCases),
+    };
+  }
+  return dataset;
+}

--- a/src/evals/builtinHosts.ts
+++ b/src/evals/builtinHosts.ts
@@ -1,0 +1,135 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import type { MCPHostConfig } from './mcpHost/mcpHostTypes.js';
+
+export interface BuiltinHostOptions {
+  model?: string;
+  maxToolCalls?: number;
+  timeout?: number;
+  provider?: string;
+  mcpUrl?: string;
+  apiToken?: string;
+  pluginDir?: string;
+  pluginMcpUrl?: string;
+}
+
+/**
+ * Built-in client host configs matching scio's python/hosts registry.
+ * Glean-specific plugin wiring stays env-driven for backward compatibility.
+ */
+export function getBuiltinHostConfig(
+  name: string,
+  options: BuiltinHostOptions = {},
+): MCPHostConfig {
+  const factory = BUILTIN_HOSTS[name];
+  if (!factory) {
+    const valid = Object.keys(BUILTIN_HOSTS).sort().join(', ');
+    throw new Error(`Unknown client host "${name}". Valid hosts: ${valid}`);
+  }
+  return factory(options);
+}
+
+const BUILTIN_HOSTS: Record<
+  string,
+  (options: BuiltinHostOptions) => MCPHostConfig
+> = {
+  'claude-cli': claudeCliHost,
+  'vercel-sdk': vercelSdkHost,
+};
+
+function vercelSdkHost(options: BuiltinHostOptions): MCPHostConfig {
+  return {
+    hostType: 'sdk',
+    provider: (options.provider as MCPHostConfig['provider']) ?? 'anthropic',
+    model: options.model ?? 'claude-sonnet-4-20250514',
+    maxToolCalls: options.maxToolCalls ?? 5,
+  };
+}
+
+function claudeCliHost(options: BuiltinHostOptions): MCPHostConfig {
+  const provider = options.provider ?? 'anthropic';
+  if (provider === 'vertex') {
+    process.env.CLAUDE_CODE_USE_VERTEX = '1';
+    process.env.ANTHROPIC_VERTEX_PROJECT_ID ??=
+      process.env.GOOGLE_VERTEX_PROJECT ?? 'dev-sandbox-334901';
+  }
+
+  const mcpUrl =
+    options.mcpUrl ??
+    process.env.GLEAN_MCP_URL ??
+    'https://scio-prod-be.glean.com/mcp/default';
+  const apiToken = options.apiToken ?? process.env.GLEAN_API_TOKEN ?? '';
+  const pluginDir = options.pluginDir ?? process.env.PLUGIN_DIR ?? '';
+
+  const mcpServers: Record<string, unknown> = {
+    'glean-mcp': {
+      type: 'http',
+      url: mcpUrl,
+      headers: {
+        Authorization: `Bearer ${apiToken}`,
+      },
+    },
+  };
+
+  if (pluginDir) {
+    const dataDir =
+      process.env.PLUGIN_DATA_DIR ??
+      path.join(os.homedir(), '.claude/plugins/data/glean-vnext-glean-plugins-vnext');
+    const serverUrl =
+      options.pluginMcpUrl ??
+      process.env.GLEAN_PLUGIN_MCP_URL ??
+      'https://scio-prod-be.glean.com/mcp/gateway/proxy';
+    fs.mkdirSync(dataDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(dataDir, 'mcp-server-url.json'),
+      `${JSON.stringify({ serverUrl }, null, 2)}\n`,
+    );
+    mcpServers['glean-plugin'] = {
+      command: 'bash',
+      args: [path.join(pluginDir, 'start.sh')],
+      env: {
+        GLEAN_MCP_SERVER_URL: serverUrl,
+        ENABLE_HITL: 'false',
+        CLAUDE_PLUGIN_DATA: dataDir,
+        NODE_TLS_REJECT_UNAUTHORIZED: '0',
+      },
+      alwaysLoad: process.env.PLUGIN_ALWAYS_LOAD !== '0',
+    };
+  }
+
+  const mcpConfigFile = path.join(
+    fs.mkdtempSync(path.join(os.tmpdir(), 'mcp_config_')),
+    'mcp.json',
+  );
+  fs.writeFileSync(
+    mcpConfigFile,
+    `${JSON.stringify({ mcpServers }, null, 2)}\n`,
+  );
+
+  const baseArgs = [
+    '-p',
+    '{{scenario}}',
+    '--output-format',
+    'stream-json',
+    '--verbose',
+    '--mcp-config',
+    mcpConfigFile,
+    '--strict-mcp-config',
+    '--permission-mode',
+    'bypassPermissions',
+  ];
+
+  return {
+    hostType: 'cli',
+    provider: provider as MCPHostConfig['provider'],
+    model: options.model ?? 'claude-sonnet-4-20250514',
+    cli: {
+      command: 'claude',
+      args: baseArgs,
+      outputFormat: 'stream-json',
+      timeout: options.timeout ?? 180_000,
+    },
+    maxToolCalls: options.maxToolCalls ?? 5,
+  };
+}

--- a/src/evals/runEvalSuite.ts
+++ b/src/evals/runEvalSuite.ts
@@ -1,0 +1,346 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import {
+  createMCPClientForConfig,
+  closeMCPClient,
+} from '../mcp/clientFactory.js';
+import { createMCPFixture } from '../mcp/fixtures/mcpFixture.js';
+import type { MCPConfig } from '../config/mcpConfig.js';
+import type { EvalConfig } from './evalConfigSchema.js';
+import {
+  loadEvalConfig,
+  resolveEvalModeConfig,
+  resolveEvalsetPaths,
+} from './evalConfigSchema.js';
+import { buildEvalDataset } from './buildEvalDataset.js';
+import { getBuiltinHostConfig } from './builtinHosts.js';
+import { runEvalDataset } from './evalRunner.js';
+import type { EvalRunnerResult } from './evalRunner.js';
+import type { EvalCaseResult } from '../types/reporter.js';
+import type { UsageMetrics } from '../types/index.js';
+import { loadPlugins } from '../plugins/loadPlugins.js';
+
+export interface RunEvalSuiteOptions {
+  configPath: string;
+  rootDir?: string;
+  pluginPaths?: string[];
+  outputDir?: string;
+  mcpConfig?: MCPConfig;
+  dryRun?: boolean;
+}
+
+export interface RunEvalSuiteResult {
+  config: EvalConfig;
+  outputDir: string;
+  datasets: Array<{ path: string; name: string; result?: EvalRunnerResult }>;
+  merged: ScioCompatibleResults;
+}
+
+export interface ScioCompatibleResults {
+  timestamp: string;
+  durationMs: number;
+  configName: string;
+  evalMode: string;
+  mcpUrl?: string;
+  evalsetFilePaths?: string[];
+  metrics: {
+    total: number;
+    passed: number;
+    failed: number;
+    passRate: number;
+    datasetBreakdown: Record<string, number>;
+    totalHostUsage?: Partial<UsageMetrics>;
+  };
+  results: EvalCaseResult[];
+}
+
+function applyConfigEnv(config: EvalConfig): void {
+  if (config.mcpUrl) {
+    process.env.GLEAN_MCP_URL = config.mcpUrl;
+  }
+  if (config.model) {
+    process.env.EVAL_MODEL = config.model;
+  }
+  if (config.timeout) {
+    process.env.EVAL_HOST_TIMEOUT = String(config.timeout);
+  }
+  if (config.iterations) {
+    process.env.EVAL_ITERATIONS = String(config.iterations);
+  }
+  if (config.maxToolCalls) {
+    process.env.EVAL_MAX_TOOL_CALLS = String(config.maxToolCalls);
+  }
+  if (config.provider) {
+    process.env.EVAL_PROVIDER = config.provider;
+  }
+  if (config.judges?.length) {
+    process.env.EVAL_JUDGES = config.judges.join(',');
+  }
+  if (config.plugins?.[0]) {
+    const plugin = config.plugins[0];
+    process.env.PLUGIN_DIR = plugin.dir.replace(/^~/, process.env.HOME ?? '');
+    if (plugin.mcpUrl) {
+      process.env.GLEAN_PLUGIN_MCP_URL = plugin.mcpUrl;
+    }
+  }
+  if (config.env) {
+    for (const [key, value] of Object.entries(config.env)) {
+      process.env[key] = value;
+    }
+  }
+}
+
+function resolveMcpConfig(
+  config: EvalConfig,
+  override?: MCPConfig,
+): MCPConfig {
+  if (override) {
+    return override;
+  }
+  const serverUrl =
+    config.mcpUrl ??
+    process.env.GLEAN_MCP_URL ??
+    'https://scio-prod-be.glean.com/mcp/default';
+  const accessToken = process.env.GLEAN_API_TOKEN;
+  if (!accessToken) {
+    throw new Error(
+      'GLEAN_API_TOKEN is required to run evals against the MCP server',
+    );
+  }
+  return {
+    transport: 'http',
+    serverUrl,
+    auth: { accessToken },
+  };
+}
+
+async function expandEvalsetPaths(paths: string[]): Promise<string[]> {
+  const files: string[] = [];
+  for (const evalsetPath of paths) {
+    const stat = await fs.stat(evalsetPath);
+    if (stat.isDirectory()) {
+      const dirFiles = (await fs.readdir(evalsetPath))
+        .filter((name) => name.endsWith('.json'))
+        .sort()
+        .map((name) => path.join(evalsetPath, name));
+      files.push(...dirFiles);
+    } else {
+      files.push(evalsetPath);
+    }
+  }
+  return files;
+}
+
+function mergeResults(
+  config: EvalConfig,
+  datasetResults: Array<{ name: string; result: EvalRunnerResult }>,
+): ScioCompatibleResults {
+  const allResults: EvalCaseResult[] = [];
+  const datasetBreakdown: Record<string, number> = {};
+  let durationMs = 0;
+  let totalHostUsage: Partial<UsageMetrics> | undefined;
+
+  for (const { name, result } of datasetResults) {
+    allResults.push(...result.caseResults);
+    datasetBreakdown[name] = result.total;
+    durationMs += result.durationMs;
+    if (result.totalHostUsage) {
+      totalHostUsage = sumUsage(totalHostUsage, result.totalHostUsage);
+    }
+  }
+
+  const passed = allResults.filter((r) => r.pass).length;
+  const total = allResults.length;
+
+  return {
+    timestamp: new Date().toISOString(),
+    durationMs,
+    configName: config.name,
+    evalMode: config.mode,
+    mcpUrl: config.mcpUrl,
+    evalsetFilePaths: config.evalsetFilePaths,
+    metrics: {
+      total,
+      passed,
+      failed: total - passed,
+      passRate: total > 0 ? passed / total : 0,
+      datasetBreakdown,
+      totalHostUsage,
+    },
+    results: allResults,
+  };
+}
+
+function sumUsage(
+  a: Partial<UsageMetrics> | undefined,
+  b: Partial<UsageMetrics>,
+): Partial<UsageMetrics> {
+  const keys = [
+    'inputTokens',
+    'outputTokens',
+    'totalCostUsd',
+    'durationMs',
+    'cacheReadInputTokens',
+    'cacheCreationInputTokens',
+  ] as const;
+  const result: Partial<UsageMetrics> = { ...(a ?? {}) };
+  for (const key of keys) {
+    const va = a?.[key];
+    const vb = b[key];
+    if (va !== undefined || vb !== undefined) {
+      result[key] = (va ?? 0) + (vb ?? 0);
+    }
+  }
+  return result;
+}
+
+export async function runEvalSuite(
+  options: RunEvalSuiteOptions,
+): Promise<RunEvalSuiteResult> {
+  const rootDir = options.rootDir ?? process.cwd();
+  const config = loadEvalConfig(options.configPath, { rootDir });
+  applyConfigEnv(config);
+
+  const pluginPaths =
+    options.pluginPaths ??
+    config.plugins?.map((plugin) =>
+      path.isAbsolute(plugin.dir)
+        ? plugin.dir
+        : path.resolve(rootDir, plugin.dir),
+    ) ??
+    [];
+
+  if (pluginPaths.length > 0) {
+    await loadPlugins(pluginPaths);
+  }
+
+  const modeConfig = resolveEvalModeConfig(config.mode);
+  const evalsetPaths = await expandEvalsetPaths(
+    resolveEvalsetPaths(config, rootDir),
+  );
+
+  const hostConfig = getBuiltinHostConfig(config.clientHost ?? 'claude-cli', {
+    model: config.model,
+    maxToolCalls: config.maxToolCalls,
+    timeout: config.timeout,
+    provider: config.provider,
+    mcpUrl: config.mcpUrl,
+    pluginDir: process.env.PLUGIN_DIR,
+    pluginMcpUrl: process.env.GLEAN_PLUGIN_MCP_URL,
+  });
+
+  const outputDir =
+    options.outputDir ??
+    path.join(rootDir, '.mcp-test-results', config.name);
+
+  if (options.dryRun) {
+    return {
+      config,
+      outputDir,
+      datasets: evalsetPaths.map((evalsetPath) => ({
+        path: evalsetPath,
+        name: path.basename(evalsetPath, '.json'),
+      })),
+      merged: {
+        timestamp: new Date().toISOString(),
+        durationMs: 0,
+        configName: config.name,
+        evalMode: config.mode,
+        mcpUrl: config.mcpUrl,
+        evalsetFilePaths: config.evalsetFilePaths,
+        metrics: {
+          total: 0,
+          passed: 0,
+          failed: 0,
+          passRate: 0,
+          datasetBreakdown: {},
+        },
+        results: [],
+      },
+    };
+  }
+
+  if (modeConfig.isServerComparison) {
+    throw new Error(
+      'sxs mode is not yet supported by runEvalSuite — use runServerComparison directly',
+    );
+  }
+
+  const mcpConfig = resolveMcpConfig(config, options.mcpConfig);
+  const client = await createMCPClientForConfig(mcpConfig);
+  const mcp = createMCPFixture(client, undefined, { authType: 'api-token' });
+
+  const datasetResults: Array<{ path: string; name: string; result: EvalRunnerResult }> =
+    [];
+
+  try {
+    for (const evalsetPath of evalsetPaths) {
+      const raw = JSON.parse(await fs.readFile(evalsetPath, 'utf8')) as unknown;
+      const dataset = buildEvalDataset(
+        raw,
+        config.mode,
+        hostConfig,
+        config,
+      );
+      const result = await runEvalDataset(
+        {
+          dataset,
+          filterTags:
+            modeConfig.filterTags.length > 0
+              ? modeConfig.filterTags
+              : undefined,
+          concurrency: config.concurrency ?? 1,
+          defaultLlmIterations: config.iterations || undefined,
+        },
+        { mcp },
+      );
+      datasetResults.push({
+        path: evalsetPath,
+        name: dataset.name,
+        result,
+      });
+    }
+  } finally {
+    await closeMCPClient(client);
+  }
+
+  const merged = mergeResults(
+    config,
+    datasetResults.map(({ name, result }) => ({ name, result })),
+  );
+
+  await fs.mkdir(outputDir, { recursive: true });
+  await fs.writeFile(
+    path.join(outputDir, 'results.json'),
+    `${JSON.stringify(merged, null, 2)}\n`,
+  );
+
+  for (const { name, result } of datasetResults) {
+    await fs.writeFile(
+      path.join(outputDir, `run-${name}.json`),
+      `${JSON.stringify(
+        {
+          timestamp: merged.timestamp,
+          durationMs: result.durationMs,
+          metrics: {
+            total: result.total,
+            passed: result.passed,
+            failed: result.failed,
+            passRate: result.total > 0 ? result.passed / result.total : 0,
+            totalHostUsage: result.totalHostUsage,
+          },
+          results: result.caseResults,
+        },
+        null,
+        2,
+      )}\n`,
+    );
+  }
+
+  return {
+    config,
+    outputDir,
+    datasets: datasetResults,
+    merged,
+  };
+}

--- a/src/evals/runEvalSuite.ts
+++ b/src/evals/runEvalSuite.ts
@@ -55,6 +55,10 @@ export interface ScioCompatibleResults {
 }
 
 function applyConfigEnv(config: EvalConfig): void {
+  // Match scio run-eval.ts — required for scio-prod in corp TLS environments.
+  process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
+  process.env.CLAUDE_CODE_DISABLE_AUTO_MEMORY = '1';
+  process.env.CLAUDE_CODE_DISABLE_CLAUDE_MDS = '1';
   if (config.mcpUrl) {
     process.env.GLEAN_MCP_URL = config.mcpUrl;
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -259,6 +259,16 @@ export type {
   ResolvedEvalModeConfig,
 } from './evals/evalConfigSchema.js';
 
+// Eval dataset building and suite runner
+export { buildEvalDataset } from './evals/buildEvalDataset.js';
+export { getBuiltinHostConfig } from './evals/builtinHosts.js';
+export { runEvalSuite } from './evals/runEvalSuite.js';
+export type {
+  RunEvalSuiteOptions,
+  RunEvalSuiteResult,
+  ScioCompatibleResults,
+} from './evals/runEvalSuite.js';
+
 // Plugin loading
 export { loadPluginModule, loadPlugins } from './plugins/loadPlugins.js';
 export type { EvalPluginModule, LoadPluginsOptions } from './plugins/loadPlugins.js';


### PR DESCRIPTION
## Summary

Phase 2 of the scio eval harness migration: wires `runEvalSuite()` so `mcp-server-tester run` can execute campaigns end-to-end.

**Stacked on:** #239 (Phase 1)

### What's new

- **`buildEvalDataset()`** — ports scio's Python fixture builders (tool-selection, tool-call, e2e-quality) to TypeScript
- **`getBuiltinHostConfig()`** — built-in `claude-cli` and `vercel-sdk` hosts matching scio's `python/hosts` registry
- **`runEvalSuite()`** — loads config → plugins → evalsets → runs `runEvalDataset` → writes scio-compatible `results.json`
- **`run` CLI** — now executes evals (not just dry-run validation)

### Backward compatibility

- Accepts existing scio `configs/weekly/*.json` unchanged
- Sets `NODE_TLS_REJECT_UNAUTHORIZED=0` like scio `run-eval.ts` (required for scio-prod in corp TLS)
- Raw GCS evalset format works without Python pipeline
- Output `results.json` matches scio's `pipeline merge` + `metrics` shape

## scio-prod validation

Tested locally with `GLEAN_API_TOKEN` from `scio/.github/mcp_tests/.env` against `https://scio-prod-be.glean.com/mcp/default/eval`:

| Test | Result | Notes |
|------|--------|-------|
| Direct `search` tool call (1 case) | **1/1 PASS** | MCP auth + tool invocation confirmed |
| `tool-selection` via claude-cli (1 case) | 0/1 | CLI host timed out at 120s — claude-cli cold start, not an MST connectivity issue |

```bash
source scio/.github/mcp_tests/.env

# Direct MCP smoke (fast, no LLM)
npx tsx src/cli/index.ts run \
  --config /tmp/scio-prod-direct-smoke.json \
  --root-dir scio/.github/mcp_tests \
  --output-dir /tmp/mst-scio-prod-smoke

# Tool-selection (needs claude CLI + longer timeout)
npx tsx src/cli/index.ts run \
  --config scio/.github/mcp_tests/configs/weekly/tool-selection-code_search.json \
  --root-dir scio/.github/mcp_tests \
  --max-cases 1
```

- [x] `npm test` — 15 unit tests
- [x] `npm run typecheck`
- [x] scio-prod direct MCP call passes

### Not yet in Phase 2

- `sxs` mode (use existing `runServerComparison`)
- GCS evalset download
- Token pricing for SDK-mode `cost_usd`

## Test plan

- [x] Unit tests + typecheck
- [x] scio-prod direct tool call (`search`)
- [ ] scio-prod tool-selection via claude-cli (blocked on CLI timeout in local env; increase `timeout` to retry)
