### PR TITLE
[Evals] Add manifest-driven dataset and suite execution

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gleanwork/mcp-server-tester",
-  "version": "1.1.1",
+  "version": "1.2.0-dev.0",
   "description": "Playwright-based testing and evaluation framework for MCP servers",
   "keywords": [
     "playwright",

--- a/src/evals/buildEvalDataset.test.ts
+++ b/src/evals/buildEvalDataset.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from 'vitest';
+import { buildEvalDataset } from './buildEvalDataset.js';
+import type { EvalConfig } from './evalConfigSchema.js';
+import { getBuiltinHostConfig } from './builtinHosts.js';
+
+const baseConfig: EvalConfig = {
+  name: 'test',
+  mode: 'tool-selection',
+  evalsetFilePaths: ['x.json'],
+};
+
+const hostConfig = getBuiltinHostConfig('vercel-sdk');
+
+describe('buildEvalDataset', () => {
+  it('builds tool-selection dataset from raw evalset', () => {
+    const dataset = buildEvalDataset(
+      {
+        name: 'search',
+        cases: [
+          {
+            id: 'case-1',
+            scenario: 'find the PTO policy',
+            expected_tool: 'search',
+          },
+        ],
+      },
+      'tool-selection',
+      hostConfig,
+      baseConfig,
+    );
+
+    expect(dataset.cases).toHaveLength(1);
+    expect(dataset.cases[0]?.mode).toBe('mcp_host');
+    expect(dataset.cases[0]?.expect?.toolsTriggered?.calls[0]?.name).toBe(
+      'search',
+    );
+    expect(dataset.cases[0]?.tags).toContain('tool_selection');
+  });
+
+  it('builds e2e-quality dataset with judges from config', () => {
+    const dataset = buildEvalDataset(
+      {
+        name: 'info-seeking',
+        cases: [
+          {
+            id: 'q1',
+            scenario: 'What is our parental leave policy?',
+            reference: '12 weeks paid leave',
+          },
+        ],
+      },
+      'e2e-quality',
+      hostConfig,
+      {
+        ...baseConfig,
+        mode: 'e2e-quality',
+        judges: ['glean-completeness', 'glean-correctness'],
+      },
+    );
+
+    expect(dataset.cases[0]?.tags).toContain('e2e_quality');
+    const judges = dataset.cases[0]?.expect?.passesJudge;
+    expect(Array.isArray(judges)).toBe(true);
+    expect(judges).toHaveLength(2);
+  });
+
+  it('passes through prebuilt datasets unchanged', () => {
+    const prebuilt = {
+      name: 'search-evals',
+      cases: [
+        {
+          id: 'search-basic',
+          toolName: 'search',
+          args: { query: 'pto policy' },
+          expect: { isError: false },
+        },
+      ],
+    };
+
+    const dataset = buildEvalDataset(
+      prebuilt,
+      'direct',
+      hostConfig,
+      { ...baseConfig, mode: 'direct' },
+    );
+
+    expect(dataset.cases[0]?.toolName).toBe('search');
+    expect(dataset.cases[0]?.args).toEqual({ query: 'pto policy' });
+  });
+
+  it('truncates to maxCases', () => {
+    const dataset = buildEvalDataset(
+      {
+        cases: [
+          { id: 'a', scenario: 'one', expected_tool: 'search' },
+          { id: 'b', scenario: 'two', expected_tool: 'search' },
+        ],
+      },
+      'tool-selection',
+      hostConfig,
+      { ...baseConfig, maxCases: 1 },
+    );
+
+    expect(dataset.cases).toHaveLength(1);
+    expect(dataset.cases[0]?.id).toBe('a');
+  });
+});

--- a/src/evals/buildEvalDataset.test.ts
+++ b/src/evals/buildEvalDataset.test.ts
@@ -1,18 +1,17 @@
 import { describe, expect, it } from 'vitest';
 import { buildEvalDataset } from './buildEvalDataset.js';
-import type { EvalConfig } from './evalConfigSchema.js';
+import type { EvalManifest } from './evalManifest.js';
 import { getBuiltinHostConfig } from './builtinHosts.js';
 
-const baseConfig: EvalConfig = {
+const baseManifest: EvalManifest = {
   name: 'test',
-  mode: 'tool-selection',
-  evalsetFilePaths: ['x.json'],
+  datasets: [{ type: 'file', path: 'x.json' }],
 };
 
 const hostConfig = getBuiltinHostConfig('vercel-sdk');
 
 describe('buildEvalDataset', () => {
-  it('builds tool-selection dataset from raw evalset', () => {
+  it('builds a tool-selection dataset from its fixture shape', () => {
     const dataset = buildEvalDataset(
       {
         name: 'search',
@@ -24,20 +23,19 @@ describe('buildEvalDataset', () => {
           },
         ],
       },
-      'tool-selection',
       hostConfig,
-      baseConfig,
+      baseManifest
     );
 
     expect(dataset.cases).toHaveLength(1);
     expect(dataset.cases[0]?.mode).toBe('mcp_host');
     expect(dataset.cases[0]?.expect?.toolsTriggered?.calls[0]?.name).toBe(
-      'search',
+      'search'
     );
     expect(dataset.cases[0]?.tags).toContain('tool_selection');
   });
 
-  it('builds e2e-quality dataset with judges from config', () => {
+  it('builds an e2e-quality dataset with manifest judges', () => {
     const dataset = buildEvalDataset(
       {
         name: 'info-seeking',
@@ -49,13 +47,11 @@ describe('buildEvalDataset', () => {
           },
         ],
       },
-      'e2e-quality',
       hostConfig,
       {
-        ...baseConfig,
-        mode: 'e2e-quality',
-        judges: ['glean-completeness', 'glean-correctness'],
-      },
+        ...baseManifest,
+        judges: [{ type: 'glean-completeness' }, { type: 'glean-correctness' }],
+      }
     );
 
     expect(dataset.cases[0]?.tags).toContain('e2e_quality');
@@ -64,24 +60,21 @@ describe('buildEvalDataset', () => {
     expect(judges).toHaveLength(2);
   });
 
-  it('passes through prebuilt datasets unchanged', () => {
-    const prebuilt = {
-      name: 'search-evals',
-      cases: [
-        {
-          id: 'search-basic',
-          toolName: 'search',
-          args: { query: 'pto policy' },
-          expect: { isError: false },
-        },
-      ],
-    };
-
+  it('passes through canonical datasets unchanged', () => {
     const dataset = buildEvalDataset(
-      prebuilt,
-      'direct',
+      {
+        name: 'search-evals',
+        cases: [
+          {
+            id: 'search-basic',
+            toolName: 'search',
+            args: { query: 'pto policy' },
+            expect: { isError: false },
+          },
+        ],
+      },
       hostConfig,
-      { ...baseConfig, mode: 'direct' },
+      baseManifest
     );
 
     expect(dataset.cases[0]?.toolName).toBe('search');
@@ -96,9 +89,8 @@ describe('buildEvalDataset', () => {
           { id: 'b', scenario: 'two', expected_tool: 'search' },
         ],
       },
-      'tool-selection',
       hostConfig,
-      { ...baseConfig, maxCases: 1 },
+      { ...baseManifest, maxCases: 1 }
     );
 
     expect(dataset.cases).toHaveLength(1);

--- a/src/evals/buildEvalDataset.ts
+++ b/src/evals/buildEvalDataset.ts
@@ -244,7 +244,14 @@ export function buildEvalDataset(
   config: EvalConfig,
 ): EvalDataset {
   if (isPrebuiltDataset(raw)) {
-    return loadEvalDatasetFromObject(raw);
+    let dataset = loadEvalDatasetFromObject(raw);
+    if (config.maxCases && dataset.cases.length > config.maxCases) {
+      dataset = {
+        ...dataset,
+        cases: dataset.cases.slice(0, config.maxCases),
+      };
+    }
+    return dataset;
   }
 
   const builder = BUILDERS[mode];

--- a/src/evals/buildEvalDataset.ts
+++ b/src/evals/buildEvalDataset.ts
@@ -1,0 +1,268 @@
+import type { EvalCampaignMode } from './evalConfigSchema.js';
+import type { EvalConfig } from './evalConfigSchema.js';
+import type { EvalDataset } from './datasetTypes.js';
+import type { MCPHostConfig } from './mcpHost/mcpHostTypes.js';
+import { loadEvalDatasetFromObject } from './datasetLoader.js';
+
+type RawEvalset = {
+  name?: string;
+  description?: string;
+  cases: RawEvalCase[];
+};
+
+type RawEvalCase = Record<string, unknown>;
+
+function isPrebuiltDataset(data: unknown): data is EvalDataset {
+  if (!data || typeof data !== 'object' || !('cases' in data)) {
+    return false;
+  }
+  const cases = (data as { cases: unknown[] }).cases;
+  if (!cases?.length) {
+    return false;
+  }
+  const first = cases[0];
+  if (!first || typeof first !== 'object') {
+    return false;
+  }
+  return (
+    'mode' in first ||
+    ('expect' in first &&
+      typeof (first as { expect?: unknown }).expect === 'object')
+  );
+}
+
+function fixtureIterations(config: EvalConfig): number {
+  if (config.iterations && config.iterations > 0) {
+    return config.iterations;
+  }
+  const raw = process.env.EVAL_ITERATIONS;
+  return raw ? parseInt(raw, 10) : 5;
+}
+
+function enabledJudges(config: EvalConfig): Set<string> {
+  if (config.judges?.length) {
+    return new Set(config.judges);
+  }
+  const raw = process.env.EVAL_JUDGES ?? '';
+  return new Set(raw.split(',').map((j) => j.trim()).filter(Boolean));
+}
+
+function buildJudges(
+  scenario: string,
+  reference: string | undefined,
+  judges: Set<string>,
+): Array<Record<string, unknown>> {
+  const result: Array<Record<string, unknown>> = [];
+  if (judges.has('glean-completeness')) {
+    result.push({
+      judge: 'glean-completeness',
+      reference: scenario,
+      threshold: 0.5,
+    });
+  }
+  if (judges.has('glean-correctness') && reference) {
+    result.push({
+      judge: 'glean-correctness',
+      reference: JSON.stringify({ question: scenario, answer: reference }),
+      threshold: 0.5,
+    });
+  }
+  if (judges.has('task-completion')) {
+    result.push({
+      judge: 'task-completion',
+      reference: scenario,
+      threshold: 0.5,
+    });
+  }
+  for (const signalJudge of ['glean-rate-limit', 'glean-timeout'] as const) {
+    if (judges.has(signalJudge)) {
+      result.push({
+        judge: signalJudge,
+        reference: scenario,
+        threshold: 0.5,
+      });
+    }
+  }
+  return result;
+}
+
+function buildToolSelectionDataset(
+  evalset: RawEvalset,
+  hostConfig: MCPHostConfig,
+  config: EvalConfig,
+): EvalDataset {
+  const iterations = fixtureIterations(config);
+  const cases = evalset.cases.map((case_) => {
+    const expectedTool = String(case_.expected_tool);
+    const scenario = String(case_.scenario);
+    const tags = Array.isArray(case_.tags)
+      ? (case_.tags as string[])
+      : [];
+    return {
+      id: String(case_.id),
+      description:
+        typeof case_.description === 'string'
+          ? case_.description
+          : `Tool selection: should trigger ${expectedTool}`,
+      toolName: expectedTool,
+      mode: 'mcp_host' as const,
+      scenario,
+      mcpHostConfig: hostConfig,
+      tags: ['mcp_host', 'tool_selection', ...tags],
+      iterations,
+      accuracyThreshold: iterations === 1 ? 1.0 : 0.8,
+      expect: {
+        toolsTriggered: {
+          calls: [{ name: expectedTool, required: true }],
+        },
+      },
+    };
+  });
+
+  return loadEvalDatasetFromObject({
+    name: evalset.name ?? 'tool-selection',
+    description:
+      evalset.description ?? 'Tool selection evaluation.',
+    cases,
+  });
+}
+
+function buildToolCallDataset(
+  evalset: RawEvalset,
+  hostConfig: MCPHostConfig,
+): EvalDataset {
+  const cases = evalset.cases.map((case_) => {
+    const tool = String(case_.tool);
+    const tags = Array.isArray(case_.tags)
+      ? (case_.tags as string[])
+      : [];
+    const fixtureCase: Record<string, unknown> = {
+      id: String(case_.id),
+      description:
+        typeof case_.description === 'string'
+          ? case_.description
+          : `Tool call: ${tool}`,
+      toolName: tool,
+      tags: ['tool_call', ...tags],
+      expect:
+        case_.expect ??
+        ({
+          isError: false,
+          responseSize: { minBytes: 50 },
+        } as const),
+    };
+    if (case_.args !== undefined) {
+      fixtureCase.args = case_.args;
+    }
+    for (const key of [
+      'mode',
+      'scenario',
+      'iterations',
+      'accuracyThreshold',
+    ] as const) {
+      if (case_[key] !== undefined) {
+        fixtureCase[key] = case_[key];
+      }
+    }
+    if (case_.mode === 'mcp_host') {
+      fixtureCase.mcpHostConfig = hostConfig;
+    }
+    return fixtureCase;
+  });
+
+  return loadEvalDatasetFromObject({
+    name: evalset.name ?? 'tool-call',
+    description: evalset.description ?? 'Tool call evaluation.',
+    cases,
+  });
+}
+
+function buildE2eQualityDataset(
+  evalset: RawEvalset,
+  hostConfig: MCPHostConfig,
+  config: EvalConfig,
+): EvalDataset {
+  const judges = enabledJudges(config);
+  const cases = evalset.cases.map((case_) => {
+    const scenario = String(case_.scenario);
+    const reference =
+      typeof case_.reference === 'string' ? case_.reference : undefined;
+    const tags = Array.isArray(case_.tags)
+      ? (case_.tags as string[])
+      : [];
+    const fixtureCase: Record<string, unknown> = {
+      id: String(case_.id),
+      description:
+        typeof case_.description === 'string'
+          ? case_.description
+          : `E2E quality: ${scenario.slice(0, 80)}`,
+      mode: 'mcp_host',
+      scenario,
+      mcpHostConfig: hostConfig,
+      tags: ['e2e_quality', ...tags],
+      iterations: 1,
+    };
+    const judgeList = buildJudges(scenario, reference, judges);
+    if (judgeList.length > 0) {
+      fixtureCase.expect = { passesJudge: judgeList };
+    }
+    return fixtureCase;
+  });
+
+  const withRef = evalset.cases.filter((c) => c.reference).length;
+  return loadEvalDatasetFromObject({
+    name: evalset.name ?? 'e2e-quality',
+    description:
+      evalset.description ??
+      `E2E quality evaluation. ${cases.length} cases (${withRef} with correctness judge).`,
+    cases,
+  });
+}
+
+const BUILDERS: Record<
+  EvalCampaignMode,
+  | ((
+      evalset: RawEvalset,
+      hostConfig: MCPHostConfig,
+      config: EvalConfig,
+    ) => EvalDataset)
+  | null
+> = {
+  'tool-selection': buildToolSelectionDataset,
+  'tool-call': (evalset, hostConfig) => buildToolCallDataset(evalset, hostConfig),
+  'e2e-quality': buildE2eQualityDataset,
+  'mcp-host': buildToolSelectionDataset,
+  direct: null,
+  sxs: null,
+  all: null,
+};
+
+export function buildEvalDataset(
+  raw: unknown,
+  mode: EvalCampaignMode,
+  hostConfig: MCPHostConfig,
+  config: EvalConfig,
+): EvalDataset {
+  if (isPrebuiltDataset(raw)) {
+    return loadEvalDatasetFromObject(raw);
+  }
+
+  const builder = BUILDERS[mode];
+  if (!builder) {
+    throw new Error(`Cannot build dataset for mode "${mode}" from raw evalset`);
+  }
+
+  const evalset = raw as RawEvalset;
+  if (!Array.isArray(evalset.cases)) {
+    throw new Error('Evalset must contain a cases array');
+  }
+
+  let dataset = builder(evalset, hostConfig, config);
+  if (config.maxCases && dataset.cases.length > config.maxCases) {
+    dataset = {
+      ...dataset,
+      cases: dataset.cases.slice(0, config.maxCases),
+    };
+  }
+  return dataset;
+}

--- a/src/evals/buildEvalDataset.ts
+++ b/src/evals/buildEvalDataset.ts
@@ -1,4 +1,4 @@
-import type { EvalCampaignMode } from './evalConfigSchema.js';
+import type { EvalConfigMode } from './evalConfigSchema.js';
 import type { EvalConfig } from './evalConfigSchema.js';
 import type { EvalDataset } from './datasetTypes.js';
 import type { MCPHostConfig } from './mcpHost/mcpHostTypes.js';
@@ -44,13 +44,18 @@ function enabledJudges(config: EvalConfig): Set<string> {
     return new Set(config.judges);
   }
   const raw = process.env.EVAL_JUDGES ?? '';
-  return new Set(raw.split(',').map((j) => j.trim()).filter(Boolean));
+  return new Set(
+    raw
+      .split(',')
+      .map((j) => j.trim())
+      .filter(Boolean)
+  );
 }
 
 function buildJudges(
   scenario: string,
   reference: string | undefined,
-  judges: Set<string>,
+  judges: Set<string>
 ): Array<Record<string, unknown>> {
   const result: Array<Record<string, unknown>> = [];
   if (judges.has('glean-completeness')) {
@@ -89,15 +94,13 @@ function buildJudges(
 function buildToolSelectionDataset(
   evalset: RawEvalset,
   hostConfig: MCPHostConfig,
-  config: EvalConfig,
+  config: EvalConfig
 ): EvalDataset {
   const iterations = fixtureIterations(config);
   const cases = evalset.cases.map((case_) => {
     const expectedTool = String(case_.expected_tool);
     const scenario = String(case_.scenario);
-    const tags = Array.isArray(case_.tags)
-      ? (case_.tags as string[])
-      : [];
+    const tags = Array.isArray(case_.tags) ? (case_.tags as string[]) : [];
     return {
       id: String(case_.id),
       description:
@@ -121,21 +124,18 @@ function buildToolSelectionDataset(
 
   return loadEvalDatasetFromObject({
     name: evalset.name ?? 'tool-selection',
-    description:
-      evalset.description ?? 'Tool selection evaluation.',
+    description: evalset.description ?? 'Tool selection evaluation.',
     cases,
   });
 }
 
 function buildToolCallDataset(
   evalset: RawEvalset,
-  hostConfig: MCPHostConfig,
+  hostConfig: MCPHostConfig
 ): EvalDataset {
   const cases = evalset.cases.map((case_) => {
     const tool = String(case_.tool);
-    const tags = Array.isArray(case_.tags)
-      ? (case_.tags as string[])
-      : [];
+    const tags = Array.isArray(case_.tags) ? (case_.tags as string[]) : [];
     const fixtureCase: Record<string, unknown> = {
       id: String(case_.id),
       description:
@@ -180,16 +180,14 @@ function buildToolCallDataset(
 function buildE2eQualityDataset(
   evalset: RawEvalset,
   hostConfig: MCPHostConfig,
-  config: EvalConfig,
+  config: EvalConfig
 ): EvalDataset {
   const judges = enabledJudges(config);
   const cases = evalset.cases.map((case_) => {
     const scenario = String(case_.scenario);
     const reference =
       typeof case_.reference === 'string' ? case_.reference : undefined;
-    const tags = Array.isArray(case_.tags)
-      ? (case_.tags as string[])
-      : [];
+    const tags = Array.isArray(case_.tags) ? (case_.tags as string[]) : [];
     const fixtureCase: Record<string, unknown> = {
       id: String(case_.id),
       description:
@@ -220,16 +218,17 @@ function buildE2eQualityDataset(
 }
 
 const BUILDERS: Record<
-  EvalCampaignMode,
+  EvalConfigMode,
   | ((
       evalset: RawEvalset,
       hostConfig: MCPHostConfig,
-      config: EvalConfig,
+      config: EvalConfig
     ) => EvalDataset)
   | null
 > = {
   'tool-selection': buildToolSelectionDataset,
-  'tool-call': (evalset, hostConfig) => buildToolCallDataset(evalset, hostConfig),
+  'tool-call': (evalset, hostConfig) =>
+    buildToolCallDataset(evalset, hostConfig),
   'e2e-quality': buildE2eQualityDataset,
   'mcp-host': buildToolSelectionDataset,
   direct: null,
@@ -239,9 +238,9 @@ const BUILDERS: Record<
 
 export function buildEvalDataset(
   raw: unknown,
-  mode: EvalCampaignMode,
+  mode: EvalConfigMode,
   hostConfig: MCPHostConfig,
-  config: EvalConfig,
+  config: EvalConfig
 ): EvalDataset {
   if (isPrebuiltDataset(raw)) {
     let dataset = loadEvalDatasetFromObject(raw);

--- a/src/evals/buildEvalDataset.ts
+++ b/src/evals/buildEvalDataset.ts
@@ -1,6 +1,5 @@
-import type { EvalConfigMode } from './evalConfigSchema.js';
-import type { EvalConfig } from './evalConfigSchema.js';
 import type { EvalDataset } from './datasetTypes.js';
+import type { EvalManifest, ExtensionConfig } from './evalManifest.js';
 import type { MCPHostConfig } from './mcpHost/mcpHostTypes.js';
 import { loadEvalDatasetFromObject } from './datasetLoader.js';
 
@@ -13,17 +12,11 @@ type RawEvalset = {
 type RawEvalCase = Record<string, unknown>;
 
 function isPrebuiltDataset(data: unknown): data is EvalDataset {
-  if (!data || typeof data !== 'object' || !('cases' in data)) {
-    return false;
-  }
+  if (!data || typeof data !== 'object' || !('cases' in data)) return false;
   const cases = (data as { cases: unknown[] }).cases;
-  if (!cases?.length) {
-    return false;
-  }
+  if (!cases?.length) return false;
   const first = cases[0];
-  if (!first || typeof first !== 'object') {
-    return false;
-  }
+  if (!first || typeof first !== 'object') return false;
   return (
     'mode' in first ||
     ('expect' in first &&
@@ -31,25 +24,20 @@ function isPrebuiltDataset(data: unknown): data is EvalDataset {
   );
 }
 
-function fixtureIterations(config: EvalConfig): number {
-  if (config.iterations && config.iterations > 0) {
-    return config.iterations;
+function fixtureIterations(manifest: EvalManifest): number {
+  if (manifest.iterations && manifest.iterations > 0) {
+    return manifest.iterations;
   }
   const raw = process.env.EVAL_ITERATIONS;
   return raw ? parseInt(raw, 10) : 5;
 }
 
-function enabledJudges(config: EvalConfig): Set<string> {
-  if (config.judges?.length) {
-    return new Set(config.judges);
-  }
-  const raw = process.env.EVAL_JUDGES ?? '';
-  return new Set(
-    raw
-      .split(',')
-      .map((j) => j.trim())
-      .filter(Boolean)
-  );
+function extensionName(extension: ExtensionConfig): string {
+  return extension.name ?? extension.type;
+}
+
+function enabledJudges(manifest: EvalManifest): Set<string> {
+  return new Set((manifest.judges ?? []).map(extensionName));
 }
 
 function buildJudges(
@@ -81,11 +69,7 @@ function buildJudges(
   }
   for (const signalJudge of ['glean-rate-limit', 'glean-timeout'] as const) {
     if (judges.has(signalJudge)) {
-      result.push({
-        judge: signalJudge,
-        reference: scenario,
-        threshold: 0.5,
-      });
+      result.push({ judge: signalJudge, reference: scenario, threshold: 0.5 });
     }
   }
   return result;
@@ -94,9 +78,9 @@ function buildJudges(
 function buildToolSelectionDataset(
   evalset: RawEvalset,
   hostConfig: MCPHostConfig,
-  config: EvalConfig
+  manifest: EvalManifest
 ): EvalDataset {
-  const iterations = fixtureIterations(config);
+  const iterations = fixtureIterations(manifest);
   const cases = evalset.cases.map((case_) => {
     const expectedTool = String(case_.expected_tool);
     const scenario = String(case_.scenario);
@@ -144,29 +128,21 @@ function buildToolCallDataset(
           : `Tool call: ${tool}`,
       toolName: tool,
       tags: ['tool_call', ...tags],
-      expect:
-        case_.expect ??
-        ({
-          isError: false,
-          responseSize: { minBytes: 50 },
-        } as const),
+      expect: case_.expect ?? {
+        isError: false,
+        responseSize: { minBytes: 50 },
+      },
     };
-    if (case_.args !== undefined) {
-      fixtureCase.args = case_.args;
-    }
+    if (case_.args !== undefined) fixtureCase.args = case_.args;
     for (const key of [
       'mode',
       'scenario',
       'iterations',
       'accuracyThreshold',
     ] as const) {
-      if (case_[key] !== undefined) {
-        fixtureCase[key] = case_[key];
-      }
+      if (case_[key] !== undefined) fixtureCase[key] = case_[key];
     }
-    if (case_.mode === 'mcp_host') {
-      fixtureCase.mcpHostConfig = hostConfig;
-    }
+    if (case_.mode === 'mcp_host') fixtureCase.mcpHostConfig = hostConfig;
     return fixtureCase;
   });
 
@@ -180,9 +156,9 @@ function buildToolCallDataset(
 function buildE2eQualityDataset(
   evalset: RawEvalset,
   hostConfig: MCPHostConfig,
-  config: EvalConfig
+  manifest: EvalManifest
 ): EvalDataset {
-  const judges = enabledJudges(config);
+  const judges = enabledJudges(manifest);
   const cases = evalset.cases.map((case_) => {
     const scenario = String(case_.scenario);
     const reference =
@@ -201,9 +177,7 @@ function buildE2eQualityDataset(
       iterations: 1,
     };
     const judgeList = buildJudges(scenario, reference, judges);
-    if (judgeList.length > 0) {
-      fixtureCase.expect = { passesJudge: judgeList };
-    }
+    if (judgeList.length > 0) fixtureCase.expect = { passesJudge: judgeList };
     return fixtureCase;
   });
 
@@ -217,58 +191,51 @@ function buildE2eQualityDataset(
   });
 }
 
-const BUILDERS: Record<
-  EvalConfigMode,
-  | ((
-      evalset: RawEvalset,
-      hostConfig: MCPHostConfig,
-      config: EvalConfig
-    ) => EvalDataset)
-  | null
-> = {
-  'tool-selection': buildToolSelectionDataset,
-  'tool-call': (evalset, hostConfig) =>
-    buildToolCallDataset(evalset, hostConfig),
-  'e2e-quality': buildE2eQualityDataset,
-  'mcp-host': buildToolSelectionDataset,
-  direct: null,
-  sxs: null,
-  all: null,
-};
-
+/**
+ * Convert a tagged dataset source into the canonical EvalDataset model.
+ * Legacy fixture shapes are inferred from their fields; configuration does not
+ * need a second top-level evaluation mode.
+ */
 export function buildEvalDataset(
   raw: unknown,
-  mode: EvalConfigMode,
   hostConfig: MCPHostConfig,
-  config: EvalConfig
+  manifest: EvalManifest
 ): EvalDataset {
   if (isPrebuiltDataset(raw)) {
     let dataset = loadEvalDatasetFromObject(raw);
-    if (config.maxCases && dataset.cases.length > config.maxCases) {
+    if (manifest.maxCases && dataset.cases.length > manifest.maxCases) {
       dataset = {
         ...dataset,
-        cases: dataset.cases.slice(0, config.maxCases),
+        cases: dataset.cases.slice(0, manifest.maxCases),
       };
     }
     return dataset;
   }
 
-  const builder = BUILDERS[mode];
-  if (!builder) {
-    throw new Error(`Cannot build dataset for mode "${mode}" from raw evalset`);
+  if (
+    !raw ||
+    typeof raw !== 'object' ||
+    !Array.isArray((raw as RawEvalset).cases)
+  ) {
+    throw new Error('Dataset must contain a cases array');
   }
-
   const evalset = raw as RawEvalset;
-  if (!Array.isArray(evalset.cases)) {
-    throw new Error('Evalset must contain a cases array');
+  const firstCase = evalset.cases[0] ?? {};
+  let dataset: EvalDataset;
+  if ('expected_tool' in firstCase) {
+    dataset = buildToolSelectionDataset(evalset, hostConfig, manifest);
+  } else if ('tool' in firstCase) {
+    dataset = buildToolCallDataset(evalset, hostConfig);
+  } else if ('scenario' in firstCase) {
+    dataset = buildE2eQualityDataset(evalset, hostConfig, manifest);
+  } else {
+    throw new Error(
+      'Unable to infer dataset shape; provide canonical EvalDataset cases.'
+    );
   }
 
-  let dataset = builder(evalset, hostConfig, config);
-  if (config.maxCases && dataset.cases.length > config.maxCases) {
-    dataset = {
-      ...dataset,
-      cases: dataset.cases.slice(0, config.maxCases),
-    };
+  if (manifest.maxCases && dataset.cases.length > manifest.maxCases) {
+    dataset = { ...dataset, cases: dataset.cases.slice(0, manifest.maxCases) };
   }
   return dataset;
 }

--- a/src/evals/builtinHosts.ts
+++ b/src/evals/builtinHosts.ts
@@ -1,0 +1,135 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import type { MCPHostConfig } from './mcpHost/mcpHostTypes.js';
+
+export interface BuiltinHostOptions {
+  model?: string;
+  maxToolCalls?: number;
+  timeout?: number;
+  provider?: string;
+  mcpUrl?: string;
+  apiToken?: string;
+  pluginDir?: string;
+  pluginMcpUrl?: string;
+}
+
+/**
+ * Built-in client host configs matching scio's python/hosts registry.
+ * Glean-specific plugin wiring stays env-driven for backward compatibility.
+ */
+export function getBuiltinHostConfig(
+  name: string,
+  options: BuiltinHostOptions = {},
+): MCPHostConfig {
+  const factory = BUILTIN_HOSTS[name];
+  if (!factory) {
+    const valid = Object.keys(BUILTIN_HOSTS).sort().join(', ');
+    throw new Error(`Unknown client host "${name}". Valid hosts: ${valid}`);
+  }
+  return factory(options);
+}
+
+const BUILTIN_HOSTS: Record<
+  string,
+  (options: BuiltinHostOptions) => MCPHostConfig
+> = {
+  'claude-cli': claudeCliHost,
+  'vercel-sdk': vercelSdkHost,
+};
+
+function vercelSdkHost(options: BuiltinHostOptions): MCPHostConfig {
+  return {
+    hostType: 'sdk',
+    provider: (options.provider as MCPHostConfig['provider']) ?? 'anthropic',
+    model: options.model ?? 'claude-sonnet-4-20250514',
+    maxToolCalls: options.maxToolCalls ?? 5,
+  };
+}
+
+function claudeCliHost(options: BuiltinHostOptions): MCPHostConfig {
+  const provider = options.provider ?? 'anthropic';
+  if (provider === 'vertex') {
+    process.env.CLAUDE_CODE_USE_VERTEX = '1';
+    process.env.ANTHROPIC_VERTEX_PROJECT_ID ??=
+      process.env.GOOGLE_VERTEX_PROJECT ?? 'dev-sandbox-334901';
+  }
+
+  const mcpUrl =
+    options.mcpUrl ??
+    process.env.GLEAN_MCP_URL ??
+    'https://scio-prod-be.glean.com/mcp/default';
+  const apiToken = options.apiToken ?? process.env.GLEAN_API_TOKEN ?? '';
+  const pluginDir = options.pluginDir ?? process.env.PLUGIN_DIR ?? '';
+
+  const mcpServers: Record<string, unknown> = {
+    'glean-mcp': {
+      type: 'http',
+      url: mcpUrl,
+      headers: {
+        Authorization: `Bearer ${apiToken}`,
+      },
+    },
+  };
+
+  if (pluginDir) {
+    const dataDir =
+      process.env.PLUGIN_DATA_DIR ??
+      path.join(os.homedir(), '.claude/plugins/data/glean-vnext-glean-plugins-vnext');
+    const serverUrl =
+      options.pluginMcpUrl ??
+      process.env.GLEAN_PLUGIN_MCP_URL ??
+      'https://scio-prod-be.glean.com/mcp/gateway/proxy';
+    fs.mkdirSync(dataDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(dataDir, 'mcp-server-url.json'),
+      `${JSON.stringify({ serverUrl }, null, 2)}\n`,
+    );
+    mcpServers['glean-plugin'] = {
+      command: 'bash',
+      args: [path.join(pluginDir, 'start.sh')],
+      env: {
+        GLEAN_MCP_SERVER_URL: serverUrl,
+        ENABLE_HITL: 'false',
+        CLAUDE_PLUGIN_DATA: dataDir,
+        NODE_TLS_REJECT_UNAUTHORIZED: '0',
+      },
+      alwaysLoad: process.env.PLUGIN_ALWAYS_LOAD !== '0',
+    };
+  }
+
+  const mcpConfigFile = path.join(
+    fs.mkdtempSync(path.join(os.tmpdir(), 'mcp_config_')),
+    'mcp.json',
+  );
+  fs.writeFileSync(
+    mcpConfigFile,
+    `${JSON.stringify({ mcpServers }, null, 2)}\n`,
+  );
+
+  const baseArgs = [
+    '-p',
+    '{{scenario}}',
+    '--output-format',
+    'stream-json',
+    '--verbose',
+    '--mcp-config',
+    mcpConfigFile,
+    '--strict-mcp-config',
+    '--permission-mode',
+    'bypassPermissions',
+  ];
+
+  return {
+    hostType: 'cli',
+    provider: provider as MCPHostConfig['provider'],
+    model: options.model ?? 'claude-sonnet-4-20250514',
+    cli: {
+      command: 'claude',
+      args: baseArgs,
+      outputFormat: 'stream-json',
+      timeout: options.timeout ?? 180_000,
+    },
+    maxToolCalls: options.maxToolCalls ?? 5,
+  };
+}

--- a/src/evals/builtinHosts.ts
+++ b/src/evals/builtinHosts.ts
@@ -12,6 +12,7 @@ export interface BuiltinHostOptions {
   apiToken?: string;
   pluginDir?: string;
   pluginMcpUrl?: string;
+  mcpServers?: Record<string, Record<string, unknown>>;
 }
 
 /**
@@ -20,7 +21,7 @@ export interface BuiltinHostOptions {
  */
 export function getBuiltinHostConfig(
   name: string,
-  options: BuiltinHostOptions = {},
+  options: BuiltinHostOptions = {}
 ): MCPHostConfig {
   const factory = BUILTIN_HOSTS[name];
   if (!factory) {
@@ -75,7 +76,10 @@ function claudeCliHost(options: BuiltinHostOptions): MCPHostConfig {
   if (pluginDir) {
     const dataDir =
       process.env.PLUGIN_DATA_DIR ??
-      path.join(os.homedir(), '.claude/plugins/data/glean-vnext-glean-plugins-vnext');
+      path.join(
+        os.homedir(),
+        '.claude/plugins/data/glean-vnext-glean-plugins-vnext'
+      );
     const serverUrl =
       options.pluginMcpUrl ??
       process.env.GLEAN_PLUGIN_MCP_URL ??
@@ -83,7 +87,7 @@ function claudeCliHost(options: BuiltinHostOptions): MCPHostConfig {
     fs.mkdirSync(dataDir, { recursive: true });
     fs.writeFileSync(
       path.join(dataDir, 'mcp-server-url.json'),
-      `${JSON.stringify({ serverUrl }, null, 2)}\n`,
+      `${JSON.stringify({ serverUrl }, null, 2)}\n`
     );
     mcpServers['glean-plugin'] = {
       command: 'bash',
@@ -100,11 +104,11 @@ function claudeCliHost(options: BuiltinHostOptions): MCPHostConfig {
 
   const mcpConfigFile = path.join(
     fs.mkdtempSync(path.join(os.tmpdir(), 'mcp_config_')),
-    'mcp.json',
+    'mcp.json'
   );
   fs.writeFileSync(
     mcpConfigFile,
-    `${JSON.stringify({ mcpServers }, null, 2)}\n`,
+    `${JSON.stringify({ mcpServers }, null, 2)}\n`
   );
 
   const baseArgs = [

--- a/src/evals/builtinHosts.ts
+++ b/src/evals/builtinHosts.ts
@@ -18,8 +18,8 @@ export interface BuiltinHostOptions {
 }
 
 /**
- * Built-in client host configs matching scio's python/hosts registry.
- * Glean-specific plugin wiring stays env-driven for backward compatibility.
+ * Built-in client host configs. Organization-specific plugin wiring stays
+ * outside the framework and is provided through generic plugin options.
  */
 let builtinsRegistered = false;
 
@@ -65,22 +65,23 @@ function claudeCliHost(options: BuiltinHostOptions): MCPHostConfig {
   const provider = options.provider ?? 'anthropic';
   if (provider === 'vertex') {
     process.env.CLAUDE_CODE_USE_VERTEX = '1';
-    process.env.ANTHROPIC_VERTEX_PROJECT_ID ??=
-      process.env.GOOGLE_VERTEX_PROJECT ?? 'dev-sandbox-334901';
+    if (process.env.GOOGLE_VERTEX_PROJECT) {
+      process.env.ANTHROPIC_VERTEX_PROJECT_ID ??=
+        process.env.GOOGLE_VERTEX_PROJECT;
+    }
   }
 
   const server = options.server;
-  const mcpUrl =
+  const defaultServerUrl =
     server?.transport === 'http'
       ? server.serverUrl
-      : (process.env.GLEAN_MCP_URL ??
-        'https://scio-prod-be.glean.com/mcp/default');
+      : process.env.MCP_SERVER_URL;
   const apiToken =
     options.apiToken ??
     (server?.transport === 'http' ? server.auth?.accessToken : undefined) ??
-    process.env.GLEAN_API_TOKEN ??
+    process.env.MCP_ACCESS_TOKEN ??
     '';
-  const pluginDir = options.pluginDir ?? process.env.PLUGIN_DIR ?? '';
+  const pluginDir = options.pluginDir ?? process.env.MCP_PLUGIN_DIR ?? '';
 
   const mcpServers: Record<string, unknown> = server
     ? server.transport === 'http'
@@ -102,43 +103,42 @@ function claudeCliHost(options: BuiltinHostOptions): MCPHostConfig {
             env: server.env,
           },
         }
-    : {
-        'glean-mcp': {
-          type: 'http',
-          url: mcpUrl,
-          headers: {
-            Authorization: `Bearer ${apiToken}`,
+    : defaultServerUrl
+      ? {
+          'mcp-server': {
+            type: 'http',
+            url: defaultServerUrl,
+            headers: apiToken
+              ? { Authorization: `Bearer ${apiToken}` }
+              : undefined,
           },
-        },
-      };
+        }
+      : {};
 
   if (pluginDir) {
     const dataDir =
-      process.env.PLUGIN_DATA_DIR ??
-      path.join(
-        os.homedir(),
-        '.claude/plugins/data/glean-vnext-glean-plugins-vnext'
-      );
+      process.env.MCP_PLUGIN_DATA_DIR ??
+      path.join(os.homedir(), '.mcp-server-tester', 'plugins');
     const serverUrl =
-      options.pluginMcpUrl ??
-      process.env.GLEAN_PLUGIN_MCP_URL ??
-      'https://scio-prod-be.glean.com/mcp/gateway/proxy';
+      options.pluginMcpUrl ?? process.env.MCP_PLUGIN_SERVER_URL ?? '';
     fs.mkdirSync(dataDir, { recursive: true });
     fs.writeFileSync(
       path.join(dataDir, 'mcp-server-url.json'),
       `${JSON.stringify({ serverUrl }, null, 2)}\n`
     );
-    mcpServers['glean-plugin'] = {
-      command: 'bash',
-      args: [path.join(pluginDir, 'start.sh')],
-      env: {
-        GLEAN_MCP_SERVER_URL: serverUrl,
-        ENABLE_HITL: 'false',
-        CLAUDE_PLUGIN_DATA: dataDir,
-        NODE_TLS_REJECT_UNAUTHORIZED: '0',
-      },
-      alwaysLoad: process.env.PLUGIN_ALWAYS_LOAD !== '0',
-    };
+    if (serverUrl) {
+      mcpServers['plugin'] = {
+        command: 'bash',
+        args: [path.join(pluginDir, 'start.sh')],
+        env: {
+          MCP_PLUGIN_SERVER_URL: serverUrl,
+          ENABLE_HITL: 'false',
+          CLAUDE_PLUGIN_DATA: dataDir,
+          NODE_TLS_REJECT_UNAUTHORIZED: '0',
+        },
+        alwaysLoad: process.env.MCP_PLUGIN_ALWAYS_LOAD !== '0',
+      };
+    }
   }
 
   const mcpConfigFile = path.join(

--- a/src/evals/builtinHosts.ts
+++ b/src/evals/builtinHosts.ts
@@ -1,6 +1,7 @@
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
+import { z } from 'zod';
 import type { MCPConfig } from '../config/mcpConfig.js';
 import { getHost, registerHost } from './frameworkRegistries.js';
 import type { MCPHostConfig } from './mcpHost/mcpHostTypes.js';
@@ -21,6 +22,7 @@ export interface BuiltinHostOptions {
  * Built-in client host configs. Organization-specific plugin wiring stays
  * outside the framework and is provided through generic plugin options.
  */
+const BuiltinHostSchema = z.object({}).passthrough();
 let builtinsRegistered = false;
 
 export function registerBuiltinHosts(): void {
@@ -28,6 +30,7 @@ export function registerBuiltinHosts(): void {
   for (const [name, factory] of Object.entries(BUILTIN_HOSTS)) {
     registerHost({
       name,
+      schema: BuiltinHostSchema,
       createConfig: (options) => factory(options ?? {}),
     });
   }

--- a/src/evals/builtinHosts.ts
+++ b/src/evals/builtinHosts.ts
@@ -28,7 +28,7 @@ export function registerBuiltinHosts(): void {
   for (const [name, factory] of Object.entries(BUILTIN_HOSTS)) {
     registerHost({
       name,
-      createConfig: (options) => factory((options ?? {}) as BuiltinHostOptions),
+      createConfig: (options) => factory(options ?? {}),
     });
   }
   builtinsRegistered = true;

--- a/src/evals/builtinHosts.ts
+++ b/src/evals/builtinHosts.ts
@@ -1,6 +1,7 @@
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
+import type { MCPConfig } from '../config/mcpConfig.js';
 import type { MCPHostConfig } from './mcpHost/mcpHostTypes.js';
 
 export interface BuiltinHostOptions {
@@ -8,7 +9,7 @@ export interface BuiltinHostOptions {
   maxToolCalls?: number;
   timeout?: number;
   provider?: string;
-  mcpUrl?: string;
+  server?: MCPConfig;
   apiToken?: string;
   pluginDir?: string;
   pluginMcpUrl?: string;
@@ -56,22 +57,48 @@ function claudeCliHost(options: BuiltinHostOptions): MCPHostConfig {
       process.env.GOOGLE_VERTEX_PROJECT ?? 'dev-sandbox-334901';
   }
 
+  const server = options.server;
   const mcpUrl =
-    options.mcpUrl ??
-    process.env.GLEAN_MCP_URL ??
-    'https://scio-prod-be.glean.com/mcp/default';
-  const apiToken = options.apiToken ?? process.env.GLEAN_API_TOKEN ?? '';
+    server?.transport === 'http'
+      ? server.serverUrl
+      : (process.env.GLEAN_MCP_URL ??
+        'https://scio-prod-be.glean.com/mcp/default');
+  const apiToken =
+    options.apiToken ??
+    (server?.transport === 'http' ? server.auth?.accessToken : undefined) ??
+    process.env.GLEAN_API_TOKEN ??
+    '';
   const pluginDir = options.pluginDir ?? process.env.PLUGIN_DIR ?? '';
 
-  const mcpServers: Record<string, unknown> = {
-    'glean-mcp': {
-      type: 'http',
-      url: mcpUrl,
-      headers: {
-        Authorization: `Bearer ${apiToken}`,
-      },
-    },
-  };
+  const mcpServers: Record<string, unknown> = server
+    ? server.transport === 'http'
+      ? {
+          [server.label ?? 'mcp-server']: {
+            type: 'http',
+            url: server.serverUrl,
+            headers: {
+              ...server.headers,
+              ...(apiToken ? { Authorization: `Bearer ${apiToken}` } : {}),
+            },
+          },
+        }
+      : {
+          [server.label ?? 'mcp-server']: {
+            command: server.command,
+            args: server.args,
+            cwd: server.cwd,
+            env: server.env,
+          },
+        }
+    : {
+        'glean-mcp': {
+          type: 'http',
+          url: mcpUrl,
+          headers: {
+            Authorization: `Bearer ${apiToken}`,
+          },
+        },
+      };
 
   if (pluginDir) {
     const dataDir =

--- a/src/evals/builtinHosts.ts
+++ b/src/evals/builtinHosts.ts
@@ -2,6 +2,7 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import type { MCPConfig } from '../config/mcpConfig.js';
+import { getHost, registerHost } from './frameworkRegistries.js';
 import type { MCPHostConfig } from './mcpHost/mcpHostTypes.js';
 
 export interface BuiltinHostOptions {
@@ -20,16 +21,27 @@ export interface BuiltinHostOptions {
  * Built-in client host configs matching scio's python/hosts registry.
  * Glean-specific plugin wiring stays env-driven for backward compatibility.
  */
+let builtinsRegistered = false;
+
+export function registerBuiltinHosts(): void {
+  if (builtinsRegistered) return;
+  for (const [name, factory] of Object.entries(BUILTIN_HOSTS)) {
+    registerHost({
+      name,
+      createConfig: (options) => factory((options ?? {}) as BuiltinHostOptions),
+    });
+  }
+  builtinsRegistered = true;
+}
+
 export function getBuiltinHostConfig(
   name: string,
   options: BuiltinHostOptions = {}
 ): MCPHostConfig {
-  const factory = BUILTIN_HOSTS[name];
-  if (!factory) {
-    const valid = Object.keys(BUILTIN_HOSTS).sort().join(', ');
-    throw new Error(`Unknown client host "${name}". Valid hosts: ${valid}`);
-  }
-  return factory(options);
+  registerBuiltinHosts();
+  return getHost(name).createConfig(
+    options as unknown as Record<string, unknown>
+  );
 }
 
 const BUILTIN_HOSTS: Record<

--- a/src/evals/evalFrameworkTypes.ts
+++ b/src/evals/evalFrameworkTypes.ts
@@ -3,7 +3,6 @@ import type { EvalDataset, EvalCase } from './datasetTypes.js';
 import type { EvalCaseResult } from '../types/reporter.js';
 import type { EvalRunnerResult, UsageMetrics } from '../types/index.js';
 import type { MCPConfig } from '../config/mcpConfig.js';
-import type { MCPHostConfig } from './mcpHost/mcpHostTypes.js';
 import type {
   DatasetConfig,
   EvalArm,

--- a/src/evals/evalFrameworkTypes.ts
+++ b/src/evals/evalFrameworkTypes.ts
@@ -3,6 +3,7 @@ import type { EvalDataset, EvalCase } from './datasetTypes.js';
 import type { EvalCaseResult } from '../types/reporter.js';
 import type { EvalRunnerResult, UsageMetrics } from '../types/index.js';
 import type { MCPConfig } from '../config/mcpConfig.js';
+import type { MCPHostConfig } from './mcpHost/mcpHostTypes.js';
 import type {
   DatasetConfig,
   EvalArm,

--- a/src/evals/evalFrameworkTypes.ts
+++ b/src/evals/evalFrameworkTypes.ts
@@ -1,7 +1,7 @@
 import type { ZodType } from 'zod';
 import type { EvalDataset, EvalCase } from './datasetTypes.js';
 import type { EvalCaseResult } from '../types/reporter.js';
-import type { EvalRunnerResult } from '../types/index.js';
+import type { EvalRunnerResult, UsageMetrics } from '../types/index.js';
 import type { MCPConfig } from '../config/mcpConfig.js';
 import type {
   DatasetConfig,
@@ -98,7 +98,14 @@ export interface EvaluationSuiteOptions {
 export interface EvaluationArmResult {
   name: string;
   servers: MCPConfig[];
-  result?: EvalRunnerResult;
+  result?: {
+    caseResults: EvalCaseResult[];
+    total: number;
+    passed: number;
+    failed: number;
+    durationMs: number;
+    totalHostUsage?: Partial<UsageMetrics>;
+  };
   comparison?: Record<string, unknown>;
 }
 

--- a/src/evals/runEvalSuite.ts
+++ b/src/evals/runEvalSuite.ts
@@ -1,0 +1,346 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import {
+  createMCPClientForConfig,
+  closeMCPClient,
+} from '../mcp/clientFactory.js';
+import { createMCPFixture } from '../mcp/fixtures/mcpFixture.js';
+import type { MCPConfig } from '../config/mcpConfig.js';
+import type { EvalConfig } from './evalConfigSchema.js';
+import {
+  loadEvalConfig,
+  resolveEvalModeConfig,
+  resolveEvalsetPaths,
+} from './evalConfigSchema.js';
+import { buildEvalDataset } from './buildEvalDataset.js';
+import { getBuiltinHostConfig } from './builtinHosts.js';
+import { runEvalDataset } from './evalRunner.js';
+import type { EvalRunnerResult } from './evalRunner.js';
+import type { EvalCaseResult } from '../types/reporter.js';
+import type { UsageMetrics } from '../types/index.js';
+import { loadPlugins } from '../plugins/loadPlugins.js';
+
+export interface RunEvalSuiteOptions {
+  configPath: string;
+  rootDir?: string;
+  pluginPaths?: string[];
+  outputDir?: string;
+  mcpConfig?: MCPConfig;
+  dryRun?: boolean;
+}
+
+export interface RunEvalSuiteResult {
+  config: EvalConfig;
+  outputDir: string;
+  datasets: Array<{ path: string; name: string; result?: EvalRunnerResult }>;
+  merged: ScioCompatibleResults;
+}
+
+export interface ScioCompatibleResults {
+  timestamp: string;
+  durationMs: number;
+  configName: string;
+  evalMode: string;
+  mcpUrl?: string;
+  evalsetFilePaths?: string[];
+  metrics: {
+    total: number;
+    passed: number;
+    failed: number;
+    passRate: number;
+    datasetBreakdown: Record<string, number>;
+    totalHostUsage?: Partial<UsageMetrics>;
+  };
+  results: EvalCaseResult[];
+}
+
+function applyConfigEnv(config: EvalConfig): void {
+  if (config.mcpUrl) {
+    process.env.GLEAN_MCP_URL = config.mcpUrl;
+  }
+  if (config.model) {
+    process.env.EVAL_MODEL = config.model;
+  }
+  if (config.timeout) {
+    process.env.EVAL_HOST_TIMEOUT = String(config.timeout);
+  }
+  if (config.iterations) {
+    process.env.EVAL_ITERATIONS = String(config.iterations);
+  }
+  if (config.maxToolCalls) {
+    process.env.EVAL_MAX_TOOL_CALLS = String(config.maxToolCalls);
+  }
+  if (config.provider) {
+    process.env.EVAL_PROVIDER = config.provider;
+  }
+  if (config.judges?.length) {
+    process.env.EVAL_JUDGES = config.judges.join(',');
+  }
+  if (config.plugins?.[0]) {
+    const plugin = config.plugins[0];
+    process.env.PLUGIN_DIR = plugin.dir.replace(/^~/, process.env.HOME ?? '');
+    if (plugin.mcpUrl) {
+      process.env.GLEAN_PLUGIN_MCP_URL = plugin.mcpUrl;
+    }
+  }
+  if (config.env) {
+    for (const [key, value] of Object.entries(config.env)) {
+      process.env[key] = value;
+    }
+  }
+}
+
+function resolveMcpConfig(
+  config: EvalConfig,
+  override?: MCPConfig,
+): MCPConfig {
+  if (override) {
+    return override;
+  }
+  const serverUrl =
+    config.mcpUrl ??
+    process.env.GLEAN_MCP_URL ??
+    'https://scio-prod-be.glean.com/mcp/default';
+  const accessToken = process.env.GLEAN_API_TOKEN;
+  if (!accessToken) {
+    throw new Error(
+      'GLEAN_API_TOKEN is required to run evals against the MCP server',
+    );
+  }
+  return {
+    transport: 'http',
+    serverUrl,
+    auth: { accessToken },
+  };
+}
+
+async function expandEvalsetPaths(paths: string[]): Promise<string[]> {
+  const files: string[] = [];
+  for (const evalsetPath of paths) {
+    const stat = await fs.stat(evalsetPath);
+    if (stat.isDirectory()) {
+      const dirFiles = (await fs.readdir(evalsetPath))
+        .filter((name) => name.endsWith('.json'))
+        .sort()
+        .map((name) => path.join(evalsetPath, name));
+      files.push(...dirFiles);
+    } else {
+      files.push(evalsetPath);
+    }
+  }
+  return files;
+}
+
+function mergeResults(
+  config: EvalConfig,
+  datasetResults: Array<{ name: string; result: EvalRunnerResult }>,
+): ScioCompatibleResults {
+  const allResults: EvalCaseResult[] = [];
+  const datasetBreakdown: Record<string, number> = {};
+  let durationMs = 0;
+  let totalHostUsage: Partial<UsageMetrics> | undefined;
+
+  for (const { name, result } of datasetResults) {
+    allResults.push(...result.caseResults);
+    datasetBreakdown[name] = result.total;
+    durationMs += result.durationMs;
+    if (result.totalHostUsage) {
+      totalHostUsage = sumUsage(totalHostUsage, result.totalHostUsage);
+    }
+  }
+
+  const passed = allResults.filter((r) => r.pass).length;
+  const total = allResults.length;
+
+  return {
+    timestamp: new Date().toISOString(),
+    durationMs,
+    configName: config.name,
+    evalMode: config.mode,
+    mcpUrl: config.mcpUrl,
+    evalsetFilePaths: config.evalsetFilePaths,
+    metrics: {
+      total,
+      passed,
+      failed: total - passed,
+      passRate: total > 0 ? passed / total : 0,
+      datasetBreakdown,
+      totalHostUsage,
+    },
+    results: allResults,
+  };
+}
+
+function sumUsage(
+  a: Partial<UsageMetrics> | undefined,
+  b: Partial<UsageMetrics>,
+): Partial<UsageMetrics> {
+  const keys = [
+    'inputTokens',
+    'outputTokens',
+    'totalCostUsd',
+    'durationMs',
+    'cacheReadInputTokens',
+    'cacheCreationInputTokens',
+  ] as const;
+  const result: Partial<UsageMetrics> = { ...(a ?? {}) };
+  for (const key of keys) {
+    const va = a?.[key];
+    const vb = b[key];
+    if (va !== undefined || vb !== undefined) {
+      result[key] = (va ?? 0) + (vb ?? 0);
+    }
+  }
+  return result;
+}
+
+export async function runEvalSuite(
+  options: RunEvalSuiteOptions,
+): Promise<RunEvalSuiteResult> {
+  const rootDir = options.rootDir ?? process.cwd();
+  const config = loadEvalConfig(options.configPath, { rootDir });
+  applyConfigEnv(config);
+
+  const pluginPaths =
+    options.pluginPaths ??
+    config.plugins?.map((plugin) =>
+      path.isAbsolute(plugin.dir)
+        ? plugin.dir
+        : path.resolve(rootDir, plugin.dir),
+    ) ??
+    [];
+
+  if (pluginPaths.length > 0) {
+    await loadPlugins(pluginPaths);
+  }
+
+  const modeConfig = resolveEvalModeConfig(config.mode);
+  const evalsetPaths = await expandEvalsetPaths(
+    resolveEvalsetPaths(config, rootDir),
+  );
+
+  const hostConfig = getBuiltinHostConfig(config.clientHost ?? 'claude-cli', {
+    model: config.model,
+    maxToolCalls: config.maxToolCalls,
+    timeout: config.timeout,
+    provider: config.provider,
+    mcpUrl: config.mcpUrl,
+    pluginDir: process.env.PLUGIN_DIR,
+    pluginMcpUrl: process.env.GLEAN_PLUGIN_MCP_URL,
+  });
+
+  const outputDir =
+    options.outputDir ??
+    path.join(rootDir, '.mcp-test-results', config.name);
+
+  if (options.dryRun) {
+    return {
+      config,
+      outputDir,
+      datasets: evalsetPaths.map((evalsetPath) => ({
+        path: evalsetPath,
+        name: path.basename(evalsetPath, '.json'),
+      })),
+      merged: {
+        timestamp: new Date().toISOString(),
+        durationMs: 0,
+        configName: config.name,
+        evalMode: config.mode,
+        mcpUrl: config.mcpUrl,
+        evalsetFilePaths: config.evalsetFilePaths,
+        metrics: {
+          total: 0,
+          passed: 0,
+          failed: 0,
+          passRate: 0,
+          datasetBreakdown: {},
+        },
+        results: [],
+      },
+    };
+  }
+
+  if (modeConfig.isServerComparison) {
+    throw new Error(
+      'sxs mode is not yet supported by runEvalSuite — use runServerComparison directly',
+    );
+  }
+
+  const mcpConfig = resolveMcpConfig(config, options.mcpConfig);
+  const client = await createMCPClientForConfig(mcpConfig);
+  const mcp = createMCPFixture(client, undefined, { authType: 'api-token' });
+
+  const datasetResults: Array<{ path: string; name: string; result: EvalRunnerResult }> =
+    [];
+
+  try {
+    for (const evalsetPath of evalsetPaths) {
+      const raw = JSON.parse(await fs.readFile(evalsetPath, 'utf8')) as unknown;
+      const dataset = buildEvalDataset(
+        raw,
+        config.mode,
+        hostConfig,
+        config,
+      );
+      const result = await runEvalDataset(
+        {
+          dataset,
+          filterTags:
+            modeConfig.filterTags.length > 0
+              ? modeConfig.filterTags
+              : undefined,
+          concurrency: config.concurrency ?? 1,
+          defaultLlmIterations: config.iterations || undefined,
+        },
+        { mcp },
+      );
+      datasetResults.push({
+        path: evalsetPath,
+        name: dataset.name,
+        result,
+      });
+    }
+  } finally {
+    await closeMCPClient(client);
+  }
+
+  const merged = mergeResults(
+    config,
+    datasetResults.map(({ name, result }) => ({ name, result })),
+  );
+
+  await fs.mkdir(outputDir, { recursive: true });
+  await fs.writeFile(
+    path.join(outputDir, 'results.json'),
+    `${JSON.stringify(merged, null, 2)}\n`,
+  );
+
+  for (const { name, result } of datasetResults) {
+    await fs.writeFile(
+      path.join(outputDir, `run-${name}.json`),
+      `${JSON.stringify(
+        {
+          timestamp: merged.timestamp,
+          durationMs: result.durationMs,
+          metrics: {
+            total: result.total,
+            passed: result.passed,
+            failed: result.failed,
+            passRate: result.total > 0 ? result.passed / result.total : 0,
+            totalHostUsage: result.totalHostUsage,
+          },
+          results: result.caseResults,
+        },
+        null,
+        2,
+      )}\n`,
+    );
+  }
+
+  return {
+    config,
+    outputDir,
+    datasets: datasetResults,
+    merged,
+  };
+}

--- a/src/evals/runEvalSuite.ts
+++ b/src/evals/runEvalSuite.ts
@@ -55,6 +55,10 @@ export interface ScioCompatibleResults {
 }
 
 function applyConfigEnv(config: EvalConfig): void {
+  // Match scio run-eval.ts — required for scio-prod in corp TLS environments.
+  process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
+  process.env.CLAUDE_CODE_DISABLE_AUTO_MEMORY = '1';
+  process.env.CLAUDE_CODE_DISABLE_CLAUDE_MDS = '1';
   if (config.mcpUrl) {
     process.env.GLEAN_MCP_URL = config.mcpUrl;
   }

--- a/src/evals/runEvalSuite.ts
+++ b/src/evals/runEvalSuite.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto';
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import {
@@ -43,6 +44,18 @@ export interface RunEvalSuiteResult {
     result?: EvalRunnerResult;
   }>;
   summary: EvaluationSummary;
+}
+
+function manifestIdentity(manifest: EvalManifest): {
+  manifestId: string;
+  contentHash: string;
+} {
+  return {
+    manifestId: manifest.name,
+    contentHash: createHash('sha256')
+      .update(JSON.stringify(manifest))
+      .digest('hex'),
+  };
 }
 
 function applyManifestEnv(manifest: EvalManifest): void {
@@ -169,6 +182,7 @@ export async function runEvalSuite(
   const outputDir =
     options.outputDir ?? path.join(rootDir, '.mcp-test-results', manifest.name);
   const arms = selectedArms(manifest, options.arm);
+  const identity = manifestIdentity(manifest);
   const datasets = manifest.datasets.flatMap((source) => {
     if (source.type !== 'file' && source.type !== 'dir') return [source];
     return [source];
@@ -180,11 +194,14 @@ export async function runEvalSuite(
       outputDir,
       datasets: datasets.map((source) => ({ source })),
       summary: {
+        schemaVersion: 1,
+        ...identity,
         timestamp: new Date().toISOString(),
         durationMs: 0,
         manifestName: manifest.name,
         arms: [],
         metrics: {},
+        armDeltas: {},
         results: [],
       },
     };
@@ -256,6 +273,8 @@ export async function runEvalSuite(
     0
   );
   const summary: EvaluationSummary = {
+    schemaVersion: 1,
+    ...identity,
     timestamp: new Date().toISOString(),
     durationMs,
     manifestName: manifest.name,
@@ -270,6 +289,7 @@ export async function runEvalSuite(
             allResults.length
           : 0,
     },
+    armDeltas: {},
     results: allResults,
   };
 

--- a/src/evals/runEvalSuite.ts
+++ b/src/evals/runEvalSuite.ts
@@ -6,12 +6,16 @@ import {
 } from '../mcp/clientFactory.js';
 import { createMCPFixture } from '../mcp/fixtures/mcpFixture.js';
 import type { MCPConfig } from '../config/mcpConfig.js';
-import type { EvalConfig } from './evalConfigSchema.js';
 import {
-  loadEvalConfig,
-  resolveEvalModeConfig,
-  resolveEvalsetPaths,
-} from './evalConfigSchema.js';
+  loadEvalManifest,
+  type DatasetConfig,
+  type EvalArm,
+  type EvalManifest,
+} from './evalManifest.js';
+import type {
+  EvaluationArmResult,
+  EvaluationSummary,
+} from './evalFrameworkTypes.js';
 import { buildEvalDataset } from './buildEvalDataset.js';
 import { getBuiltinHostConfig } from './builtinHosts.js';
 import { runEvalDataset } from './evalRunner.js';
@@ -21,163 +25,79 @@ import type { UsageMetrics } from '../types/index.js';
 import { loadPlugins } from '../plugins/loadPlugins.js';
 
 export interface RunEvalSuiteOptions {
-  configPath: string;
+  manifestPath: string;
   rootDir?: string;
   pluginPaths?: string[];
   outputDir?: string;
   mcpConfig?: MCPConfig;
   dryRun?: boolean;
+  arm?: string;
 }
 
 export interface RunEvalSuiteResult {
-  config: EvalConfig;
+  manifest: EvalManifest;
   outputDir: string;
-  datasets: Array<{ path: string; name: string; result?: EvalRunnerResult }>;
-  merged: ScioCompatibleResults;
+  datasets: Array<{
+    source: DatasetConfig;
+    dataset?: ReturnType<typeof buildEvalDataset>;
+    result?: EvalRunnerResult;
+  }>;
+  summary: EvaluationSummary;
 }
 
-export interface ScioCompatibleResults {
-  timestamp: string;
-  durationMs: number;
-  configName: string;
-  evalMode: string;
-  mcpUrl?: string;
-  evalsetFilePaths?: string[];
-  metrics: {
-    total: number;
-    passed: number;
-    failed: number;
-    passRate: number;
-    datasetBreakdown: Record<string, number>;
-    totalHostUsage?: Partial<UsageMetrics>;
-  };
-  results: EvalCaseResult[];
-}
-
-function applyConfigEnv(config: EvalConfig): void {
-  // Match scio run-eval.ts — required for scio-prod in corp TLS environments.
+function applyManifestEnv(manifest: EvalManifest): void {
   process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
   process.env.CLAUDE_CODE_DISABLE_AUTO_MEMORY = '1';
   process.env.CLAUDE_CODE_DISABLE_CLAUDE_MDS = '1';
-  if (config.mcpUrl) {
-    process.env.GLEAN_MCP_URL = config.mcpUrl;
+  if (manifest.model) process.env.EVAL_MODEL = manifest.model;
+  if (manifest.timeout)
+    process.env.EVAL_HOST_TIMEOUT = String(manifest.timeout);
+  if (manifest.iterations) {
+    process.env.EVAL_ITERATIONS = String(manifest.iterations);
   }
-  if (config.model) {
-    process.env.EVAL_MODEL = config.model;
+  if (manifest.maxToolCalls) {
+    process.env.EVAL_MAX_TOOL_CALLS = String(manifest.maxToolCalls);
   }
-  if (config.timeout) {
-    process.env.EVAL_HOST_TIMEOUT = String(config.timeout);
-  }
-  if (config.iterations) {
-    process.env.EVAL_ITERATIONS = String(config.iterations);
-  }
-  if (config.maxToolCalls) {
-    process.env.EVAL_MAX_TOOL_CALLS = String(config.maxToolCalls);
-  }
-  if (config.provider) {
-    process.env.EVAL_PROVIDER = config.provider;
-  }
-  if (config.judges?.length) {
-    process.env.EVAL_JUDGES = config.judges.join(',');
-  }
-  if (config.plugins?.[0]) {
-    const plugin = config.plugins[0];
-    process.env.PLUGIN_DIR = plugin.dir.replace(/^~/, process.env.HOME ?? '');
-    if (plugin.mcpUrl) {
-      process.env.GLEAN_PLUGIN_MCP_URL = plugin.mcpUrl;
-    }
-  }
-  if (config.env) {
-    for (const [key, value] of Object.entries(config.env)) {
-      process.env[key] = value;
-    }
-  }
+  if (manifest.provider) process.env.EVAL_PROVIDER = manifest.provider;
 }
 
-function resolveMcpConfig(
-  config: EvalConfig,
-  override?: MCPConfig,
+async function expandDatasetPath(datasetPath: string): Promise<string[]> {
+  const stat = await fs.stat(datasetPath);
+  if (!stat.isDirectory()) return [datasetPath];
+  return (await fs.readdir(datasetPath))
+    .filter((name) => name.endsWith('.json'))
+    .sort()
+    .map((name) => path.join(datasetPath, name));
+}
+
+function selectedArms(manifest: EvalManifest, name?: string): EvalArm[] {
+  const arms = manifest.arms?.length
+    ? manifest.arms
+    : [{ name: 'default' } satisfies EvalArm];
+  if (!name) return arms;
+  const arm = arms.find((candidate) => candidate.name === name);
+  if (!arm) throw new Error(`Evaluation arm "${name}" was not found.`);
+  return [arm];
+}
+
+function resolveServer(
+  manifest: EvalManifest,
+  arm: EvalArm,
+  override?: MCPConfig
 ): MCPConfig {
-  if (override) {
-    return override;
-  }
-  const serverUrl =
-    config.mcpUrl ??
-    process.env.GLEAN_MCP_URL ??
-    'https://scio-prod-be.glean.com/mcp/default';
-  const accessToken = process.env.GLEAN_API_TOKEN;
-  if (!accessToken) {
+  if (override) return override;
+  const servers = arm.servers ?? manifest.servers ?? [];
+  if (servers.length !== 1) {
     throw new Error(
-      'GLEAN_API_TOKEN is required to run evals against the MCP server',
+      `The current runner requires exactly one MCPConfig per arm; arm "${arm.name}" has ${servers.length}.`
     );
   }
-  return {
-    transport: 'http',
-    serverUrl,
-    auth: { accessToken },
-  };
-}
-
-async function expandEvalsetPaths(paths: string[]): Promise<string[]> {
-  const files: string[] = [];
-  for (const evalsetPath of paths) {
-    const stat = await fs.stat(evalsetPath);
-    if (stat.isDirectory()) {
-      const dirFiles = (await fs.readdir(evalsetPath))
-        .filter((name) => name.endsWith('.json'))
-        .sort()
-        .map((name) => path.join(evalsetPath, name));
-      files.push(...dirFiles);
-    } else {
-      files.push(evalsetPath);
-    }
-  }
-  return files;
-}
-
-function mergeResults(
-  config: EvalConfig,
-  datasetResults: Array<{ name: string; result: EvalRunnerResult }>,
-): ScioCompatibleResults {
-  const allResults: EvalCaseResult[] = [];
-  const datasetBreakdown: Record<string, number> = {};
-  let durationMs = 0;
-  let totalHostUsage: Partial<UsageMetrics> | undefined;
-
-  for (const { name, result } of datasetResults) {
-    allResults.push(...result.caseResults);
-    datasetBreakdown[name] = result.total;
-    durationMs += result.durationMs;
-    if (result.totalHostUsage) {
-      totalHostUsage = sumUsage(totalHostUsage, result.totalHostUsage);
-    }
-  }
-
-  const passed = allResults.filter((r) => r.pass).length;
-  const total = allResults.length;
-
-  return {
-    timestamp: new Date().toISOString(),
-    durationMs,
-    configName: config.name,
-    evalMode: config.mode,
-    mcpUrl: config.mcpUrl,
-    evalsetFilePaths: config.evalsetFilePaths,
-    metrics: {
-      total,
-      passed,
-      failed: total - passed,
-      passRate: total > 0 ? passed / total : 0,
-      datasetBreakdown,
-      totalHostUsage,
-    },
-    results: allResults,
-  };
+  return servers[0]!;
 }
 
 function sumUsage(
   a: Partial<UsageMetrics> | undefined,
-  b: Partial<UsageMetrics>,
+  b: Partial<UsageMetrics>
 ): Partial<UsageMetrics> {
   const keys = [
     'inputTokens',
@@ -198,153 +118,165 @@ function sumUsage(
   return result;
 }
 
+function summarizeArm(
+  arm: EvalArm,
+  server: MCPConfig,
+  results: Array<{ name: string; result: EvalRunnerResult }>
+): EvaluationArmResult {
+  const caseResults: EvalCaseResult[] = [];
+  let totalHostUsage: Partial<UsageMetrics> | undefined;
+  for (const { result } of results) {
+    caseResults.push(...result.caseResults);
+    if (result.totalHostUsage) {
+      totalHostUsage = sumUsage(totalHostUsage, result.totalHostUsage);
+    }
+  }
+  return {
+    name: arm.name,
+    servers: [server],
+    result: {
+      caseResults,
+      total: caseResults.length,
+      passed: caseResults.filter((result) => result.pass).length,
+      failed: caseResults.filter((result) => !result.pass).length,
+      durationMs: results.reduce(
+        (sum, item) => sum + item.result.durationMs,
+        0
+      ),
+      totalHostUsage,
+    },
+  };
+}
+
 export async function runEvalSuite(
-  options: RunEvalSuiteOptions,
+  options: RunEvalSuiteOptions
 ): Promise<RunEvalSuiteResult> {
   const rootDir = options.rootDir ?? process.cwd();
-  const config = loadEvalConfig(options.configPath, { rootDir });
-  applyConfigEnv(config);
+  const manifest = loadEvalManifest(options.manifestPath, { rootDir });
+  applyManifestEnv(manifest);
 
-  const pluginPaths =
-    options.pluginPaths ??
-    config.plugins?.map((plugin) =>
-      path.isAbsolute(plugin.dir)
-        ? plugin.dir
-        : path.resolve(rootDir, plugin.dir),
-    ) ??
-    [];
-
+  const pluginPaths = options.pluginPaths ?? manifest.plugins ?? [];
   if (pluginPaths.length > 0) {
-    await loadPlugins(pluginPaths);
+    await loadPlugins(
+      pluginPaths.map((pluginPath) =>
+        path.isAbsolute(pluginPath)
+          ? pluginPath
+          : path.resolve(rootDir, pluginPath)
+      )
+    );
   }
 
-  const modeConfig = resolveEvalModeConfig(config.mode);
-  const evalsetPaths = await expandEvalsetPaths(
-    resolveEvalsetPaths(config, rootDir),
-  );
-
-  const hostConfig = getBuiltinHostConfig(config.clientHost ?? 'claude-cli', {
-    model: config.model,
-    maxToolCalls: config.maxToolCalls,
-    timeout: config.timeout,
-    provider: config.provider,
-    mcpUrl: config.mcpUrl,
-    pluginDir: process.env.PLUGIN_DIR,
-    pluginMcpUrl: process.env.GLEAN_PLUGIN_MCP_URL,
-  });
-
   const outputDir =
-    options.outputDir ??
-    path.join(rootDir, '.mcp-test-results', config.name);
+    options.outputDir ?? path.join(rootDir, '.mcp-test-results', manifest.name);
+  const arms = selectedArms(manifest, options.arm);
+  const datasets = manifest.datasets.flatMap((source) => {
+    if (source.type !== 'file' && source.type !== 'dir') return [source];
+    return [source];
+  });
 
   if (options.dryRun) {
     return {
-      config,
+      manifest,
       outputDir,
-      datasets: evalsetPaths.map((evalsetPath) => ({
-        path: evalsetPath,
-        name: path.basename(evalsetPath, '.json'),
-      })),
-      merged: {
+      datasets: datasets.map((source) => ({ source })),
+      summary: {
         timestamp: new Date().toISOString(),
         durationMs: 0,
-        configName: config.name,
-        evalMode: config.mode,
-        mcpUrl: config.mcpUrl,
-        evalsetFilePaths: config.evalsetFilePaths,
-        metrics: {
-          total: 0,
-          passed: 0,
-          failed: 0,
-          passRate: 0,
-          datasetBreakdown: {},
-        },
+        manifestName: manifest.name,
+        arms: [],
+        metrics: {},
         results: [],
       },
     };
   }
 
-  if (modeConfig.isServerComparison) {
-    throw new Error(
-      'sxs mode is not yet supported by runEvalSuite — use runServerComparison directly',
-    );
-  }
+  const armResults: EvaluationArmResult[] = [];
+  const allDatasets: RunEvalSuiteResult['datasets'] = [];
+  const allResults: EvalCaseResult[] = [];
 
-  const mcpConfig = resolveMcpConfig(config, options.mcpConfig);
-  const client = await createMCPClientForConfig(mcpConfig);
-  const mcp = createMCPFixture(client, undefined, { authType: 'api-token' });
+  for (const arm of arms) {
+    const server = resolveServer(manifest, arm, options.mcpConfig);
+    const client = await createMCPClientForConfig(server);
+    const mcp = createMCPFixture(client, undefined, { authType: 'api-token' });
+    const hostType = arm.host?.type ?? manifest.host?.type ?? 'claude-cli';
+    const hostConfig = getBuiltinHostConfig(hostType, {
+      model: manifest.model,
+      maxToolCalls: manifest.maxToolCalls,
+      timeout: manifest.timeout,
+      provider: manifest.provider,
+      server,
+    });
+    const armDatasetResults: Array<{
+      name: string;
+      result: EvalRunnerResult;
+    }> = [];
 
-  const datasetResults: Array<{ path: string; name: string; result: EvalRunnerResult }> =
-    [];
-
-  try {
-    for (const evalsetPath of evalsetPaths) {
-      const raw = JSON.parse(await fs.readFile(evalsetPath, 'utf8')) as unknown;
-      const dataset = buildEvalDataset(
-        raw,
-        config.mode,
-        hostConfig,
-        config,
-      );
-      const result = await runEvalDataset(
-        {
-          dataset,
-          filterTags:
-            modeConfig.filterTags.length > 0
-              ? modeConfig.filterTags
-              : undefined,
-          concurrency: config.concurrency ?? 1,
-          defaultLlmIterations: config.iterations || undefined,
-        },
-        { mcp },
-      );
-      datasetResults.push({
-        path: evalsetPath,
-        name: dataset.name,
-        result,
-      });
+    try {
+      for (const source of datasets) {
+        if (source.type !== 'file' && source.type !== 'dir') {
+          throw new Error(
+            `Dataset source "${source.type}" is not registered in the built-in runner.`
+          );
+        }
+        const datasetPath = source.path;
+        if (typeof datasetPath !== 'string') {
+          throw new Error(`Dataset source "${source.type}" requires a path.`);
+        }
+        for (const filePath of await expandDatasetPath(
+          path.isAbsolute(datasetPath)
+            ? datasetPath
+            : path.resolve(rootDir, datasetPath)
+        )) {
+          const raw = JSON.parse(
+            await fs.readFile(filePath, 'utf8')
+          ) as unknown;
+          const dataset = buildEvalDataset(raw, hostConfig, manifest);
+          const result = await runEvalDataset(
+            {
+              dataset,
+              concurrency: manifest.concurrency ?? 1,
+              defaultLlmIterations: manifest.iterations || undefined,
+            },
+            { mcp }
+          );
+          allDatasets.push({ source, dataset, result });
+          armDatasetResults.push({ name: dataset.name, result });
+          allResults.push(...result.caseResults);
+        }
+      }
+    } finally {
+      await closeMCPClient(client);
     }
-  } finally {
-    await closeMCPClient(client);
+
+    armResults.push(summarizeArm(arm, server, armDatasetResults));
   }
 
-  const merged = mergeResults(
-    config,
-    datasetResults.map(({ name, result }) => ({ name, result })),
+  const durationMs = armResults.reduce(
+    (sum, arm) => sum + (arm.result?.durationMs ?? 0),
+    0
   );
+  const summary: EvaluationSummary = {
+    timestamp: new Date().toISOString(),
+    durationMs,
+    manifestName: manifest.name,
+    arms: armResults,
+    metrics: {
+      total: allResults.length,
+      passed: allResults.filter((result) => result.pass).length,
+      failed: allResults.filter((result) => !result.pass).length,
+      passRate:
+        allResults.length > 0
+          ? allResults.filter((result) => result.pass).length /
+            allResults.length
+          : 0,
+    },
+    results: allResults,
+  };
 
   await fs.mkdir(outputDir, { recursive: true });
   await fs.writeFile(
     path.join(outputDir, 'results.json'),
-    `${JSON.stringify(merged, null, 2)}\n`,
+    `${JSON.stringify(summary, null, 2)}\n`
   );
-
-  for (const { name, result } of datasetResults) {
-    await fs.writeFile(
-      path.join(outputDir, `run-${name}.json`),
-      `${JSON.stringify(
-        {
-          timestamp: merged.timestamp,
-          durationMs: result.durationMs,
-          metrics: {
-            total: result.total,
-            passed: result.passed,
-            failed: result.failed,
-            passRate: result.total > 0 ? result.passed / result.total : 0,
-            totalHostUsage: result.totalHostUsage,
-          },
-          results: result.caseResults,
-        },
-        null,
-        2,
-      )}\n`,
-    );
-  }
-
-  return {
-    config,
-    outputDir,
-    datasets: datasetResults,
-    merged,
-  };
+  return { manifest, outputDir, datasets: allDatasets, summary };
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -298,6 +298,16 @@ export {
   validateManifestRegistrations,
 } from './evals/frameworkRegistries.js';
 
+// Eval dataset building and suite runner
+export { buildEvalDataset } from './evals/buildEvalDataset.js';
+export { getBuiltinHostConfig } from './evals/builtinHosts.js';
+export { runEvalSuite } from './evals/runEvalSuite.js';
+export type {
+  RunEvalSuiteOptions,
+  RunEvalSuiteResult,
+  ScioCompatibleResults,
+} from './evals/runEvalSuite.js';
+
 // Plugin loading
 export { loadPluginModule, loadPlugins } from './plugins/loadPlugins.js';
 export type {

--- a/src/index.ts
+++ b/src/index.ts
@@ -305,7 +305,6 @@ export { runEvalSuite } from './evals/runEvalSuite.js';
 export type {
   RunEvalSuiteOptions,
   RunEvalSuiteResult,
-  ScioCompatibleResults,
 } from './evals/runEvalSuite.js';
 
 // Plugin loading

--- a/src/judge/judgeRegistry.ts
+++ b/src/judge/judgeRegistry.ts
@@ -121,7 +121,7 @@ export function registerJudge(
 export function getRegisteredJudge(name: string): CustomJudgeExecutor {
   try {
     const judge = getJudge(name);
-    return (candidate, reference) => judge.evaluate(candidate, reference);
+    return judge.evaluate;
   } catch (error) {
     if (error instanceof Error && !error.message.includes('Available:')) {
       throw new Error(`${error.message} No judges are registered.`);

--- a/src/judge/judgeRegistry.ts
+++ b/src/judge/judgeRegistry.ts
@@ -1,3 +1,4 @@
+import { z } from 'zod';
 import {
   clearJudges,
   getJudge,
@@ -107,7 +108,11 @@ export function registerJudge(
     ) {
       throw error;
     }
-    registerFrameworkJudge({ name, evaluate: executor });
+    registerFrameworkJudge({
+      name,
+      schema: z.object({}).passthrough(),
+      evaluate: executor,
+    });
   }
 }
 

--- a/src/judge/judgeRegistry.ts
+++ b/src/judge/judgeRegistry.ts
@@ -120,7 +120,8 @@ export function registerJudge(
  */
 export function getRegisteredJudge(name: string): CustomJudgeExecutor {
   try {
-    return getJudge(name).evaluate;
+    const judge = getJudge(name);
+    return (candidate, reference) => judge.evaluate(candidate, reference);
   } catch (error) {
     if (error instanceof Error && !error.message.includes('Available:')) {
       throw new Error(`${error.message} No judges are registered.`);

--- a/src/judge/judgeRegistry.ts
+++ b/src/judge/judgeRegistry.ts
@@ -1,3 +1,9 @@
+import {
+  clearJudges,
+  getJudge,
+  registerJudge as registerFrameworkJudge,
+} from '../evals/frameworkRegistries.js';
+
 /**
  * Custom Judge Registry
  *
@@ -52,8 +58,6 @@ export type CustomJudgeExecutor = (
   reference?: unknown
 ) => Promise<CustomJudgeResult>;
 
-const registry = new Map<string, CustomJudgeExecutor>();
-
 /**
  * Registers a named custom judge executor.
  *
@@ -89,17 +93,22 @@ export function registerJudge(
   name: string,
   executor: CustomJudgeExecutor
 ): void {
-  const existing = registry.get(name);
-  if (existing !== undefined) {
-    if (existing === executor) {
-      return; // same function re-registered (e.g., shared setup imported by multiple files)
-    }
+  try {
+    const existing = getJudge(name);
+    if (existing.evaluate === executor) return;
     throw new Error(
       `Judge "${name}" is already registered with a different executor. ` +
         `Use clearJudgeRegistry() first if you need to replace it.`
     );
+  } catch (error) {
+    if (
+      error instanceof Error &&
+      !error.message.includes(`Judge "${name}" is not registered`)
+    ) {
+      throw error;
+    }
+    registerFrameworkJudge({ name, evaluate: executor });
   }
-  registry.set(name, executor);
 }
 
 /**
@@ -110,23 +119,19 @@ export function registerJudge(
  * @throws {Error} If no judge with the given name is registered
  */
 export function getRegisteredJudge(name: string): CustomJudgeExecutor {
-  const executor = registry.get(name);
-  if (!executor) {
-    const available =
-      registry.size > 0
-        ? ` Available judges: ${[...registry.keys()].join(', ')}`
-        : ' No judges are registered.';
-    throw new Error(
-      `Judge "${name}" is not registered.${available} ` +
-        `Register it with registerJudge() before tests run.`
-    );
+  try {
+    return getJudge(name).evaluate;
+  } catch (error) {
+    if (error instanceof Error && !error.message.includes('Available:')) {
+      throw new Error(`${error.message} No judges are registered.`);
+    }
+    throw error;
   }
-  return executor;
 }
 
 /**
  * Clears all registered judges. Intended for test teardown.
  */
 export function clearJudgeRegistry(): void {
-  registry.clear();
+  clearJudges();
 }


### PR DESCRIPTION
## Stack\n\nStacked on `chenhao/mcp-tester-01-scaffold` / PR #248.\n\n## Scope\n\n- Add manifest-driven eval dataset construction and suite execution.\n- Route built-in hosts and judges through the registry layer.\n- Preserve provider-neutral framework types and Scio-compatible result shaping.\n\n## Validation\n\n- Draft stack; full validation will run after the stack is assembled.