### PR TITLE
[Evals] Add execution metrics and result summaries

### DIFF
--- a/src/evals/datasetTypes.ts
+++ b/src/evals/datasetTypes.ts
@@ -348,6 +348,33 @@ const MCPHostConfigSchema = z.object({
       timeout: z.number().optional(),
     })
     .optional(),
+  mcpServers: z
+    .record(z.string(), z.record(z.string(), z.unknown()))
+    .optional(),
+  browser: z
+    .object({
+      script: z.string(),
+      timeout: z.number().optional(),
+      headless: z.boolean().optional(),
+      storageState: z.string().optional(),
+      cookies: z
+        .array(
+          z.object({
+            name: z.string(),
+            value: z.string(),
+            url: z.string().optional(),
+            domain: z.string().optional(),
+            path: z.string().optional(),
+            expires: z.number().optional(),
+            httpOnly: z.boolean().optional(),
+            secure: z.boolean().optional(),
+            sameSite: z.enum(['Strict', 'Lax', 'None']).optional(),
+            partitionKey: z.string().optional(),
+          })
+        )
+        .optional(),
+    })
+    .optional(),
 });
 
 /**

--- a/src/evals/evalFrameworkTypes.ts
+++ b/src/evals/evalFrameworkTypes.ts
@@ -61,7 +61,6 @@ export interface MetricDefinition {
   readonly kind: MetricKind;
   readonly unit?: string;
   compute(caseResult: EvalCaseResult): MetricValue;
-  aggregate?(values: MetricValue[], metricName: string): unknown;
 }
 
 /** Public judge extension point. */

--- a/src/evals/evalRunner.ts
+++ b/src/evals/evalRunner.ts
@@ -683,8 +683,7 @@ async function runExpectBlockValidations(
           reasoning: validation.details?.reasoning as string | undefined,
           judgeName,
           judgeProvider: validation.details?.judgeProvider as
-            | string
-            | undefined,
+            string | undefined,
           judgeModel: validation.details?.judgeModel as string | undefined,
         } satisfies EvalExpectationResult;
       })
@@ -771,6 +770,9 @@ function buildRequest(
 
   if (evalCase.mode === 'mcp_host') {
     if (evalCase.scenario) request.scenario = evalCase.scenario;
+    if (evalCase.canonicalAnswer !== undefined) {
+      request.reference = evalCase.canonicalAnswer;
+    }
     if (evalCase.mcpHostConfig) {
       request.mcpHostConfig = {
         provider: evalCase.mcpHostConfig.provider,

--- a/src/evals/metrics.test.ts
+++ b/src/evals/metrics.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from 'vitest';
+import type { EvalCaseResult } from '../types/reporter.js';
+import { computeMetrics } from './metrics.js';
+
+function result(
+  id: string,
+  pass: boolean,
+  options: {
+    calls?: string[];
+    usage?: EvalCaseResult['hostUsage'];
+    judge?: { name: string; pass: boolean; score: number };
+  } = {}
+): EvalCaseResult {
+  return {
+    id,
+    datasetName: 'metrics',
+    toolName: 'test',
+    source: 'eval',
+    pass,
+    response: {
+      toolCalls: (options.calls ?? []).map((name) => ({ name })),
+      response: 'one two three',
+    },
+    expectations: options.judge
+      ? {
+          judge: {
+            pass: options.judge.pass,
+            score: options.judge.score,
+            judgeName: options.judge.name,
+          },
+        }
+      : {},
+    authType: 'none',
+    durationMs: 1000,
+    hostUsage: options.usage,
+  };
+}
+
+describe('computeMetrics', () => {
+  it('computes Scio-compatible metrics and aggregates nulls correctly', () => {
+    const cases = [
+      result('one', true, {
+        calls: ['search', 'read'],
+        usage: {
+          inputTokens: 10,
+          outputTokens: 20,
+          totalCostUsd: 0.2,
+          durationMs: 100,
+          durationApiMs: 50,
+          cacheReadInputTokens: 3,
+          cacheCreationInputTokens: 4,
+        },
+        judge: { name: 'quality', pass: true, score: 0.9 },
+      }),
+      result('two', false),
+    ];
+
+    const metrics = computeMetrics(
+      [
+        'passed',
+        'input_tokens',
+        'input_tokens_uncached',
+        'cost_usd',
+        'duration_api_s',
+        'tool_count',
+        'response_words',
+        'judge_score',
+        {
+          metric: 'judge_score_for',
+          name: 'quality_score',
+          params: { judge: 'quality' },
+        },
+      ],
+      cases
+    );
+
+    expect(metrics.perCase.one!.input_tokens).toBe(17);
+    expect(metrics.perCase.one!.input_tokens_uncached).toBe(10);
+    expect(metrics.perCase.one!.duration_api_s).toBe(0.05);
+    expect(metrics.perCase.one!.tool_count).toBe(2);
+    expect(metrics.perCase.one!.response_words).toBe(3);
+    expect(metrics.perCase.one!.judge_score).toEqual({ quality: 0.9 });
+    expect(metrics.perCase.two!.cost_usd).toBeNull();
+    expect(metrics.aggregated.passed_rate).toBe(0.5);
+    expect(metrics.aggregated.input_tokens_mean).toBe(8.5);
+    expect(metrics.aggregated.cost_usd_mean).toBe(0.2);
+    expect(metrics.aggregated.quality_score_mean).toBe(0.9);
+    expect(metrics.aggregated.judge_score).toEqual({ quality: 0.9 });
+  });
+
+  it('rejects unknown metric names instead of silently dropping them', () => {
+    expect(() => computeMetrics(['not-a-metric'], [])).toThrow(
+      'Unknown metric "not-a-metric"'
+    );
+  });
+});

--- a/src/evals/metrics.test.ts
+++ b/src/evals/metrics.test.ts
@@ -9,6 +9,7 @@ function result(
     calls?: string[];
     usage?: EvalCaseResult['hostUsage'];
     judge?: { name: string; pass: boolean; score: number };
+    response?: EvalCaseResult['response'];
   } = {}
 ): EvalCaseResult {
   return {
@@ -17,7 +18,7 @@ function result(
     toolName: 'test',
     source: 'eval',
     pass,
-    response: {
+    response: options.response ?? {
       toolCalls: (options.calls ?? []).map((name) => ({ name })),
       response: 'one two three',
     },
@@ -86,6 +87,22 @@ describe('computeMetrics', () => {
     expect(metrics.aggregated.cost_usd_mean).toBe(0.2);
     expect(metrics.aggregated.quality_score_mean).toBe(0.9);
     expect(metrics.aggregated.judge_score).toEqual({ quality: 0.9 });
+  });
+
+  it('extracts text from direct MCP content responses', () => {
+    const metrics = computeMetrics(
+      ['response_len', 'response_words'],
+      [
+        result('direct', true, {
+          response: {
+            content: [{ type: 'text', text: 'one two three' }],
+          },
+        }),
+      ]
+    );
+
+    expect(metrics.perCase.direct!.response_len).toBe(13);
+    expect(metrics.perCase.direct!.response_words).toBe(3);
   });
 
   it('rejects unknown metric names instead of silently dropping them', () => {

--- a/src/evals/metrics.ts
+++ b/src/evals/metrics.ts
@@ -47,8 +47,17 @@ function toolCalls(caseResult: EvalCaseResult): unknown[] {
 }
 
 function responseText(caseResult: EvalCaseResult): string {
-  const response = responseObject(caseResult).response;
-  return typeof response === 'string' ? response : '';
+  const response = responseObject(caseResult);
+  if (typeof response.response === 'string') return response.response;
+  if (!Array.isArray(response.content)) return '';
+  return response.content
+    .map((item) => {
+      if (!item || typeof item !== 'object') return '';
+      const text = (item as Record<string, unknown>).text;
+      return typeof text === 'string' ? text : '';
+    })
+    .filter(Boolean)
+    .join('\n');
 }
 
 function judgeEntries(

--- a/src/evals/metrics.ts
+++ b/src/evals/metrics.ts
@@ -1,0 +1,372 @@
+import type { EvalCaseResult } from '../types/reporter.js';
+import type { UsageMetrics } from '../types/index.js';
+import type { MetricSpec } from './evalConfigSchema.js';
+
+/** Values emitted by a metric for one eval case. */
+export type MetricValue =
+  boolean | number | string | Record<string, number> | null;
+
+export type MetricKind = 'binary' | 'continuous' | 'categorical' | 'object';
+
+export interface MetricDefinition {
+  readonly name: string;
+  readonly kind: MetricKind;
+  readonly unit?: string;
+  compute(caseResult: EvalCaseResult): MetricValue;
+  aggregate?(
+    values: MetricValue[],
+    metric: ResolvedMetric
+  ): { key: string; value: unknown } | undefined;
+}
+
+export interface ResolvedMetric {
+  readonly metric: MetricDefinition;
+  readonly outName: string;
+  readonly params: Record<string, unknown>;
+}
+
+export interface MetricResult {
+  perCase: Record<string, Record<string, MetricValue>>;
+  aggregated: Record<string, unknown>;
+}
+
+function hostUsage(caseResult: EvalCaseResult): UsageMetrics | undefined {
+  return caseResult.hostUsage;
+}
+
+function responseObject(caseResult: EvalCaseResult): Record<string, unknown> {
+  const response = caseResult.response;
+  return response && typeof response === 'object'
+    ? (response as Record<string, unknown>)
+    : {};
+}
+
+function toolCalls(caseResult: EvalCaseResult): unknown[] {
+  const calls = responseObject(caseResult).toolCalls;
+  return Array.isArray(calls) ? calls : [];
+}
+
+function responseText(caseResult: EvalCaseResult): string {
+  const response = responseObject(caseResult).response;
+  return typeof response === 'string' ? response : '';
+}
+
+function judgeEntries(
+  caseResult: EvalCaseResult
+): Array<Record<string, unknown>> {
+  const judge = caseResult.expectations?.judge as
+    Record<string, unknown> | undefined;
+  if (!judge) return [];
+  const nested = judge.judgeResults;
+  if (Array.isArray(nested)) {
+    return nested.filter(
+      (entry): entry is Record<string, unknown> =>
+        Boolean(entry) && typeof entry === 'object'
+    );
+  }
+  return [judge];
+}
+
+function scoreFromJudge(entry: Record<string, unknown>): number | null {
+  if (typeof entry.score === 'number') return entry.score;
+  if (typeof entry.details !== 'string') return null;
+  const match = entry.details.match(/score\s+([0-9]*\.?[0-9]+)/i);
+  return match ? Number(match[1]) : null;
+}
+
+function judgeName(entry: Record<string, unknown>): string {
+  return typeof entry.judgeName === 'string' && entry.judgeName
+    ? entry.judgeName
+    : 'judge';
+}
+
+function judgeScores(caseResult: EvalCaseResult): Record<string, number> {
+  const scores: Record<string, number> = {};
+  for (const entry of judgeEntries(caseResult)) {
+    const score = scoreFromJudge(entry);
+    if (score !== null) scores[judgeName(entry)] = score;
+  }
+  return scores;
+}
+
+function judgePass(caseResult: EvalCaseResult): boolean | null {
+  const entries = judgeEntries(caseResult);
+  if (entries.length === 0) return null;
+  const verdicts = entries
+    .map((entry) => entry.pass)
+    .filter((value): value is boolean => typeof value === 'boolean');
+  return verdicts.length > 0 ? verdicts.every(Boolean) : null;
+}
+
+function meanAggregation(
+  values: MetricValue[],
+  metric: ResolvedMetric
+): { key: string; value: unknown } | undefined {
+  const numbers = values.filter(
+    (value): value is number => typeof value === 'number'
+  );
+  return numbers.length > 0
+    ? {
+        key: `${metric.outName}_mean`,
+        value: numbers.reduce((sum, value) => sum + value, 0) / numbers.length,
+      }
+    : undefined;
+}
+
+function rateAggregation(
+  values: MetricValue[],
+  metric: ResolvedMetric
+): { key: string; value: unknown } | undefined {
+  const booleans = values.filter(
+    (value): value is boolean => typeof value === 'boolean'
+  );
+  return booleans.length > 0
+    ? {
+        key: `${metric.outName}_rate`,
+        value: booleans.filter(Boolean).length / booleans.length,
+      }
+    : undefined;
+}
+
+function judgeScoreAggregation(
+  values: MetricValue[],
+  metric: ResolvedMetric
+): { key: string; value: unknown } | undefined {
+  const byJudge: Record<string, number[]> = {};
+  for (const value of values) {
+    if (!value || typeof value !== 'object' || Array.isArray(value)) continue;
+    for (const [name, score] of Object.entries(value)) {
+      if (typeof score === 'number') (byJudge[name] ??= []).push(score);
+    }
+  }
+  const averaged: Record<string, number> = {};
+  for (const [name, scores] of Object.entries(byJudge)) {
+    averaged[name] =
+      scores.reduce((sum, score) => sum + score, 0) / scores.length;
+  }
+  return Object.keys(averaged).length > 0
+    ? { key: metric.outName, value: averaged }
+    : undefined;
+}
+
+function metric(
+  name: string,
+  kind: MetricKind,
+  compute: (caseResult: EvalCaseResult) => MetricValue,
+  aggregate?: MetricDefinition['aggregate'],
+  unit?: string
+): MetricDefinition {
+  return { name, kind, compute, aggregate, unit };
+}
+
+/** Built-in metrics, including the metrics used by Scio's eval campaigns. */
+export const BUILT_IN_METRICS: Record<string, MetricDefinition> = {
+  passed: metric('passed', 'binary', (result) => result.pass, rateAggregation),
+  response_success: metric(
+    'response_success',
+    'binary',
+    (result) => responseObject(result).success !== false,
+    rateAggregation
+  ),
+  is_no_action: metric(
+    'is_no_action',
+    'binary',
+    (result) => toolCalls(result).length === 0,
+    rateAggregation
+  ),
+  cost_usd: metric(
+    'cost_usd',
+    'continuous',
+    (result) => hostUsage(result)?.totalCostUsd ?? null,
+    meanAggregation,
+    'USD'
+  ),
+  input_tokens: metric(
+    'input_tokens',
+    'continuous',
+    (result) => {
+      const usage = hostUsage(result);
+      return usage
+        ? usage.inputTokens +
+            (usage.cacheReadInputTokens ?? 0) +
+            (usage.cacheCreationInputTokens ?? 0)
+        : 0;
+    },
+    meanAggregation,
+    'tokens'
+  ),
+  input_tokens_uncached: metric(
+    'input_tokens_uncached',
+    'continuous',
+    (result) => hostUsage(result)?.inputTokens ?? null,
+    meanAggregation,
+    'tokens'
+  ),
+  cache_read_tokens: metric(
+    'cache_read_tokens',
+    'continuous',
+    (result) => hostUsage(result)?.cacheReadInputTokens ?? null,
+    meanAggregation,
+    'tokens'
+  ),
+  cache_creation_tokens: metric(
+    'cache_creation_tokens',
+    'continuous',
+    (result) => hostUsage(result)?.cacheCreationInputTokens ?? null,
+    meanAggregation,
+    'tokens'
+  ),
+  output_tokens: metric(
+    'output_tokens',
+    'continuous',
+    (result) => hostUsage(result)?.outputTokens ?? null,
+    meanAggregation,
+    'tokens'
+  ),
+  duration_s: metric(
+    'duration_s',
+    'continuous',
+    (result) => result.durationMs / 1000,
+    meanAggregation,
+    'seconds'
+  ),
+  duration_api_s: metric(
+    'duration_api_s',
+    'continuous',
+    (result) => {
+      const durationMs = hostUsage(result)?.durationApiMs;
+      return durationMs === undefined ? null : durationMs / 1000;
+    },
+    meanAggregation,
+    'seconds'
+  ),
+  tool_count: metric(
+    'tool_count',
+    'continuous',
+    (result) => toolCalls(result).length,
+    meanAggregation,
+    'calls'
+  ),
+  first_tool: metric('first_tool', 'categorical', (result) => {
+    const first = toolCalls(result)[0];
+    return first && typeof first === 'object' && 'name' in first
+      ? String(first.name)
+      : null;
+  }),
+  response_len: metric(
+    'response_len',
+    'continuous',
+    (result) => responseText(result).length,
+    meanAggregation,
+    'chars'
+  ),
+  response_words: metric(
+    'response_words',
+    'continuous',
+    (result) => responseText(result).trim().split(/\s+/).filter(Boolean).length,
+    meanAggregation,
+    'words'
+  ),
+  judge_pass: metric('judge_pass', 'binary', judgePass, rateAggregation),
+  judge_score: metric(
+    'judge_score',
+    'object',
+    (result) => judgeScores(result),
+    judgeScoreAggregation
+  ),
+  judge_name: metric('judge_name', 'categorical', (result) => {
+    const first = judgeEntries(result)[0];
+    return first ? judgeName(first) : null;
+  }),
+};
+
+/** Registry used by suite runs and available for application-specific metrics. */
+export const METRIC_REGISTRY: Record<string, MetricDefinition> = {
+  ...BUILT_IN_METRICS,
+};
+
+/** Register or replace a named metric for subsequent runs. */
+export function registerMetric(definition: MetricDefinition): void {
+  METRIC_REGISTRY[definition.name] = definition;
+}
+
+function slug(value: string): string {
+  return value.replace(/-/g, '_');
+}
+
+/** Resolve one config metric, including parameterized judge metrics. */
+export function resolveMetric(
+  spec: MetricSpec,
+  registry: Record<string, MetricDefinition> = METRIC_REGISTRY
+): ResolvedMetric {
+  const name = typeof spec === 'string' ? spec : spec.metric;
+  const params = typeof spec === 'string' ? {} : (spec.params ?? {});
+  const base = registry[name];
+  if (base) {
+    return {
+      metric: base,
+      outName: typeof spec === 'string' ? name : (spec.name ?? name),
+      params,
+    };
+  }
+
+  if (name === 'judge_pass_for' || name === 'judge_score_for') {
+    const judge = typeof params.judge === 'string' ? params.judge : '';
+    const defaultName = `judge_${slug(judge || 'unknown')}_${
+      name === 'judge_pass_for' ? 'pass' : 'score'
+    }`;
+    const definition = metric(
+      name,
+      name === 'judge_pass_for' ? 'binary' : 'continuous',
+      (result) => {
+        const entry = judgeEntries(result).find(
+          (item) => judgeName(item) === judge
+        );
+        if (!entry) return null;
+        return name === 'judge_pass_for'
+          ? typeof entry.pass === 'boolean'
+            ? entry.pass
+            : null
+          : scoreFromJudge(entry);
+      },
+      name === 'judge_pass_for' ? rateAggregation : meanAggregation
+    );
+    return {
+      metric: definition,
+      outName:
+        typeof spec === 'string' ? defaultName : (spec.name ?? defaultName),
+      params,
+    };
+  }
+
+  throw new Error(
+    `Unknown metric "${name}". Available metrics: ${Object.keys(registry)
+      .sort()
+      .join(', ')}, judge_pass_for, judge_score_for`
+  );
+}
+
+export function computeMetrics(
+  specs: MetricSpec[],
+  cases: EvalCaseResult[],
+  registry: Record<string, MetricDefinition> = METRIC_REGISTRY
+): MetricResult {
+  const resolved = specs.map((spec) => resolveMetric(spec, registry));
+  const perCase: MetricResult['perCase'] = {};
+  for (const caseResult of cases) {
+    const values: Record<string, MetricValue> = {};
+    for (const item of resolved)
+      values[item.outName] = item.metric.compute(caseResult);
+    perCase[caseResult.id] = values;
+  }
+
+  const aggregated: Record<string, unknown> = {};
+  for (const item of resolved) {
+    const values = cases.map(
+      (caseResult) => perCase[caseResult.id]?.[item.outName] ?? null
+    );
+    const aggregate = item.metric.aggregate?.(values, item);
+    if (aggregate) aggregated[aggregate.key] = aggregate.value;
+  }
+  return { perCase, aggregated };
+}

--- a/src/evals/metrics.ts
+++ b/src/evals/metrics.ts
@@ -168,7 +168,7 @@ function metric(
   return { name, kind, compute, aggregate, unit };
 }
 
-/** Built-in metrics, including the metrics used by Scio's eval campaigns. */
+/** Built-in metrics, including the metrics used by Scio's evaluations. */
 export const BUILT_IN_METRICS: Record<string, MetricDefinition> = {
   passed: metric('passed', 'binary', (result) => result.pass, rateAggregation),
   response_success: metric(

--- a/src/evals/metrics.ts
+++ b/src/evals/metrics.ts
@@ -1,3 +1,4 @@
+import { z } from 'zod';
 import type { EvalCaseResult } from '../types/reporter.js';
 import type { UsageMetrics } from '../types/index.js';
 import { registerMetric as registerFrameworkMetric } from './frameworkRegistries.js';
@@ -18,6 +19,7 @@ export type MetricKind = 'binary' | 'continuous' | 'categorical' | 'object';
 
 export interface MetricDefinition {
   readonly name: string;
+  readonly schema: z.ZodType;
   readonly kind: MetricKind;
   readonly unit?: string;
   compute(caseResult: EvalCaseResult): MetricValue;
@@ -173,7 +175,14 @@ function metric(
   aggregate?: MetricDefinition['aggregate'],
   unit?: string
 ): MetricDefinition {
-  return { name, kind, compute, aggregate, unit };
+  return {
+    name,
+    schema: z.object({}).passthrough(),
+    kind,
+    compute,
+    aggregate,
+    unit,
+  };
 }
 
 /** Built-in metrics, including the metrics used by Scio's evaluations. */

--- a/src/evals/metrics.ts
+++ b/src/evals/metrics.ts
@@ -1,6 +1,14 @@
 import type { EvalCaseResult } from '../types/reporter.js';
 import type { UsageMetrics } from '../types/index.js';
-import type { MetricSpec } from './evalConfigSchema.js';
+import { registerMetric as registerFrameworkMetric } from './frameworkRegistries.js';
+export type MetricSpec =
+  | string
+  | {
+      metric?: string;
+      type?: string;
+      name?: string;
+      params?: Record<string, unknown>;
+    };
 
 /** Values emitted by a metric for one eval case. */
 export type MetricValue =
@@ -294,9 +302,14 @@ export const METRIC_REGISTRY: Record<string, MetricDefinition> = {
   ...BUILT_IN_METRICS,
 };
 
+for (const definition of Object.values(BUILT_IN_METRICS)) {
+  registerFrameworkMetric(definition);
+}
+
 /** Register or replace a named metric for subsequent runs. */
 export function registerMetric(definition: MetricDefinition): void {
   METRIC_REGISTRY[definition.name] = definition;
+  registerFrameworkMetric(definition);
 }
 
 function slug(value: string): string {
@@ -308,8 +321,10 @@ export function resolveMetric(
   spec: MetricSpec,
   registry: Record<string, MetricDefinition> = METRIC_REGISTRY
 ): ResolvedMetric {
-  const name = typeof spec === 'string' ? spec : spec.metric;
+  const name =
+    typeof spec === 'string' ? spec : (spec.metric ?? spec.type ?? spec.name);
   const params = typeof spec === 'string' ? {} : (spec.params ?? {});
+  if (!name) throw new Error('Metric configuration requires a type or name.');
   const base = registry[name];
   if (base) {
     return {

--- a/src/evals/resultSummary.test.ts
+++ b/src/evals/resultSummary.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  buildEvalSummaryPrompt,
+  summarizeEvalResults,
+} from './resultSummary.js';
+import type { EvalCaseResult } from '../types/reporter.js';
+
+const caseResult: EvalCaseResult = {
+  id: 'case-1',
+  datasetName: 'demo',
+  toolName: 'search',
+  source: 'eval',
+  pass: false,
+  request: { scenario: 'Find the design doc' },
+  response: { response: 'I could not find it' },
+  expectations: {
+    judge: { pass: false, score: 0.2, details: 'score 0.2: incomplete' },
+  },
+  authType: 'none',
+  durationMs: 10,
+};
+
+describe('result summary', () => {
+  it('builds a compact analysis prompt with metrics and case context', () => {
+    const prompt = buildEvalSummaryPrompt({
+      metrics: { total: 1, passed: 0 },
+      results: [caseResult],
+    });
+    expect(prompt).toContain('Find the design doc');
+    expect(prompt).toContain('score 0.2');
+    expect(prompt).toContain('total');
+  });
+
+  it('delegates summary generation to the supplied caller', async () => {
+    const callLLM = vi
+      .fn()
+      .mockResolvedValue('One failure: incomplete answer.');
+    const summary = await summarizeEvalResults(
+      { metrics: {}, results: [caseResult] },
+      callLLM
+    );
+    expect(summary).toBe('One failure: incomplete answer.');
+    expect(callLLM).toHaveBeenCalledOnce();
+  });
+
+  it('does not call the LLM for an empty run', async () => {
+    const callLLM = vi.fn();
+    expect(
+      await summarizeEvalResults({ metrics: {}, results: [] }, callLLM)
+    ).toBeNull();
+    expect(callLLM).not.toHaveBeenCalled();
+  });
+});

--- a/src/evals/resultSummary.ts
+++ b/src/evals/resultSummary.ts
@@ -1,0 +1,64 @@
+import type { EvalCaseResult } from '../types/reporter.js';
+
+export interface EvalSummaryResult {
+  metrics: Record<string, unknown>;
+  results: EvalCaseResult[];
+  aggregatedMetrics?: Record<string, unknown>;
+}
+
+export type EvalSummaryCaller = (prompt: string) => Promise<string>;
+
+function compactCase(result: EvalCaseResult): Record<string, unknown> {
+  const response = result.response;
+  const responseValue =
+    response && typeof response === 'object' && 'response' in response
+      ? (response as { response?: unknown }).response
+      : undefined;
+  const responseText = typeof responseValue === 'string' ? responseValue : '';
+  const judge = result.expectations?.judge;
+  return {
+    id: result.id,
+    dataset: result.datasetName,
+    pass: result.pass,
+    error: result.error,
+    scenario: result.request?.scenario ?? '',
+    judges: judge
+      ? {
+          pass: judge.pass,
+          score: judge.score,
+          details: judge.details,
+          judgeResults: judge.judgeResults,
+        }
+      : undefined,
+    response: responseText.slice(0, 500),
+  };
+}
+
+/** Build the stable, compact prompt used for post-run eval analysis. */
+export function buildEvalSummaryPrompt(result: EvalSummaryResult): string {
+  const metrics = result.aggregatedMetrics ?? result.metrics;
+  return `You are an eval analysis assistant. Analyze these MCP evaluation results and provide a concise summary.
+
+METRICS:
+${JSON.stringify(metrics, null, 2)}
+
+CASES:
+${JSON.stringify(result.results.map(compactCase), null, 2)}
+
+Cover:
+1. Overall quality assessment in 1-2 sentences.
+2. If there are failures, group them by pattern and explain what went wrong.
+3. Note passes with low judge scores.
+4. Give actionable recommendations when appropriate.
+
+Keep it concise and use plain text without markdown headers.`;
+}
+
+/** Generate an optional natural-language analysis through an application-supplied LLM. */
+export async function summarizeEvalResults(
+  result: EvalSummaryResult,
+  callLLM: EvalSummaryCaller
+): Promise<string | null> {
+  if (result.results.length === 0) return null;
+  return callLLM(buildEvalSummaryPrompt(result));
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -293,10 +293,16 @@ export {
   registerDatasetSource,
   registerHost,
   registerJudge,
-  registerMetric,
   registerResultStore,
   validateManifestRegistrations,
 } from './evals/frameworkRegistries.js';
+export {
+  BUILT_IN_METRICS,
+  METRIC_REGISTRY,
+  computeMetrics,
+  registerMetric,
+  resolveMetric,
+} from './evals/metrics.js';
 
 // Eval dataset building and suite runner
 export { buildEvalDataset } from './evals/buildEvalDataset.js';

--- a/src/types/reporter.ts
+++ b/src/types/reporter.ts
@@ -268,6 +268,8 @@ export interface EvalCaseRequest {
   // mcp_host mode fields
   /** Natural language scenario sent to the LLM (mcp_host mode) */
   scenario?: string;
+  /** Golden/reference answer associated with the case, when supplied. */
+  reference?: string;
   /** LLM provider/model configuration (mcp_host mode) */
   mcpHostConfig?: {
     provider?: string;


### PR DESCRIPTION
## Stack\n\nStacked on `chenhao/mcp-tester-02-eval-config`.\n\n## Scope\n\n- Add shared execution metrics and result summaries.\n- Adapt runner output to manifest contracts.\n- Add metric and summary coverage.\n\n## Validation\n\n- Draft stack; full validation will run after the stack is assembled.