### PR TITLE
[Evals] Add host and browser integrations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
       "devDependencies": {
         "@ai-sdk/provider-utils": "^4.0.15",
         "@playwright/test": "^1.49.0",
+        "playwright": "^1.57.0",
         "@release-it-plugins/lerna-changelog": "^8.0.1",
         "@types/debug": "^4.1.12",
         "@types/ndjson": "^2.0.4",

--- a/package.json
+++ b/package.json
@@ -97,6 +97,7 @@
   "devDependencies": {
     "@ai-sdk/provider-utils": "^4.0.15",
     "@playwright/test": "^1.49.0",
+    "playwright": "^1.57.0",
     "@release-it-plugins/lerna-changelog": "^8.0.1",
     "@types/debug": "^4.1.12",
     "@types/ndjson": "^2.0.4",

--- a/src/evals/builtinHosts.test.ts
+++ b/src/evals/builtinHosts.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest';
+import { getBuiltinHostConfig } from './builtinHosts.js';
+
+describe('getBuiltinHostConfig', () => {
+  it('passes the configured model to the Claude CLI', () => {
+    const config = getBuiltinHostConfig('claude-cli', {
+      model: 'claude-sonnet-4-6',
+      mcpUrl: 'https://example.com/mcp',
+    });
+
+    expect(config.cli?.args).toContain('--model');
+    expect(config.cli?.args).toContain('claude-sonnet-4-6');
+  });
+});

--- a/src/evals/builtinHosts.test.ts
+++ b/src/evals/builtinHosts.test.ts
@@ -5,7 +5,10 @@ describe('getBuiltinHostConfig', () => {
   it('passes the configured model to the Claude CLI', () => {
     const config = getBuiltinHostConfig('claude-cli', {
       model: 'claude-sonnet-4-6',
-      mcpUrl: 'https://example.com/mcp',
+      server: {
+        transport: 'http',
+        serverUrl: 'https://example.com/mcp',
+      },
     });
 
     expect(config.cli?.args).toContain('--model');

--- a/src/evals/builtinHosts.ts
+++ b/src/evals/builtinHosts.ts
@@ -153,9 +153,12 @@ function claudeCliHost(options: BuiltinHostOptions): MCPHostConfig {
     `${JSON.stringify({ mcpServers }, null, 2)}\n`
   );
 
+  const model = options.model ?? 'claude-sonnet-4-20250514';
   const baseArgs = [
     '-p',
     '{{scenario}}',
+    '--model',
+    model,
     '--output-format',
     'stream-json',
     '--verbose',
@@ -169,7 +172,8 @@ function claudeCliHost(options: BuiltinHostOptions): MCPHostConfig {
   return {
     hostType: 'cli',
     provider: provider as MCPHostConfig['provider'],
-    model: options.model ?? 'claude-sonnet-4-20250514',
+    mcpServers: mcpServers as Record<string, Record<string, unknown>>,
+    model,
     cli: {
       command: 'claude',
       args: baseArgs,

--- a/src/evals/mcpHost/adapters/browser/index.ts
+++ b/src/evals/mcpHost/adapters/browser/index.ts
@@ -1,0 +1,1 @@
+export { runBrowserHost } from './runner.js';

--- a/src/evals/mcpHost/adapters/browser/runner.test.ts
+++ b/src/evals/mcpHost/adapters/browser/runner.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from 'vitest';
+import { validateSimulationResult } from './runner.js';
+
+describe('browser runner', () => {
+  describe('validateSimulationResult', () => {
+    it('returns null for a valid result', () => {
+      expect(
+        validateSimulationResult({
+          success: true,
+          toolCalls: [{ name: 'search', arguments: { q: 'test' } }],
+          response: 'hello',
+        })
+      ).toBeNull();
+    });
+
+    it('returns null for an empty toolCalls array', () => {
+      expect(
+        validateSimulationResult({ success: false, toolCalls: [], error: 'x' })
+      ).toBeNull();
+    });
+
+    it('rejects null', () => {
+      expect(validateSimulationResult(null)).toMatch(/Expected object/);
+    });
+
+    it('rejects non-object', () => {
+      expect(validateSimulationResult('string')).toMatch(/Expected object/);
+    });
+
+    it('rejects missing success', () => {
+      expect(validateSimulationResult({ toolCalls: [] })).toMatch(
+        /"success" must be a boolean/
+      );
+    });
+
+    it('rejects non-boolean success', () => {
+      expect(validateSimulationResult({ success: 1, toolCalls: [] })).toMatch(
+        /"success" must be a boolean/
+      );
+    });
+
+    it('rejects missing toolCalls', () => {
+      expect(validateSimulationResult({ success: true })).toMatch(
+        /"toolCalls" must be an array/
+      );
+    });
+
+    it('rejects non-array toolCalls', () => {
+      expect(
+        validateSimulationResult({ success: true, toolCalls: 'bad' })
+      ).toMatch(/"toolCalls" must be an array/);
+    });
+
+    it('rejects toolCall with non-string name', () => {
+      expect(
+        validateSimulationResult({
+          success: true,
+          toolCalls: [{ name: 123, arguments: {} }],
+        })
+      ).toMatch(/toolCalls\[0\]\.name must be a string/);
+    });
+
+    it('rejects toolCall with null arguments', () => {
+      expect(
+        validateSimulationResult({
+          success: true,
+          toolCalls: [{ name: 'x', arguments: null }],
+        })
+      ).toMatch(/toolCalls\[0\]\.arguments must be an object/);
+    });
+  });
+});

--- a/src/evals/mcpHost/adapters/browser/runner.ts
+++ b/src/evals/mcpHost/adapters/browser/runner.ts
@@ -1,0 +1,167 @@
+import { resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import type { Page, BrowserType } from 'playwright';
+import type {
+  BrowserConfig,
+  LLMToolCall,
+  MCPHostSimulationResult,
+} from '../../mcpHostTypes.js';
+
+const DEFAULT_TIMEOUT = 120_000;
+
+/**
+ * The signature a browser script must export as its default export.
+ */
+type BrowserScriptFn = (
+  page: Page,
+  scenario: string
+) => Promise<MCPHostSimulationResult>;
+
+/**
+ * Runs a browser host: launches Chromium, injects auth, executes
+ * the user-provided script, and returns the simulation result.
+ *
+ * Playwright is dynamically imported so the framework doesn't
+ * hard-depend on it at the package level — it's already a peer
+ * dependency via @playwright/test.
+ */
+export async function runBrowserHost(
+  browserConfig: BrowserConfig,
+  scenario: string
+): Promise<MCPHostSimulationResult> {
+  const timeout = browserConfig.timeout ?? DEFAULT_TIMEOUT;
+
+  // Dynamic import — playwright is an optional peer dependency. Keeping the
+  // package name indirect prevents tsup from bundling Chromium's optional
+  // bidi implementation into every tester installation.
+  let chromium: BrowserType;
+  try {
+    const playwrightPackage = 'playwright';
+    const pw = (await import(playwrightPackage)) as unknown as {
+      chromium: BrowserType;
+    };
+    chromium = pw.chromium;
+  } catch {
+    return {
+      success: false,
+      toolCalls: [],
+      error:
+        'Browser host requires the "playwright" package. Install it with: npm install playwright',
+    };
+  }
+
+  // Resolve and import the user's script
+  const scriptPath = resolve(process.cwd(), browserConfig.script);
+  let scriptFn: BrowserScriptFn;
+  try {
+    const scriptModule = (await import(
+      pathToFileURL(scriptPath).href
+    )) as Record<string, unknown>;
+    scriptFn = scriptModule.default as BrowserScriptFn;
+    if (typeof scriptFn !== 'function') {
+      return {
+        success: false,
+        toolCalls: [],
+        error: `Browser script "${browserConfig.script}" must export a default function. Got ${typeof scriptFn}.`,
+      };
+    }
+  } catch (err) {
+    return {
+      success: false,
+      toolCalls: [],
+      error: `Failed to import browser script "${browserConfig.script}": ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
+
+  const browser = await chromium.launch({
+    headless: browserConfig.headless ?? true,
+  });
+
+  try {
+    // Create context with optional storageState
+    const contextOptions: Record<string, unknown> = {};
+    if (browserConfig.storageState) {
+      contextOptions.storageState = resolve(
+        process.cwd(),
+        browserConfig.storageState
+      );
+    }
+
+    const context = await browser.newContext(contextOptions);
+
+    // Inject extra cookies if provided
+    if (browserConfig.cookies && browserConfig.cookies.length > 0) {
+      await context.addCookies(browserConfig.cookies);
+    }
+
+    const page = await context.newPage();
+
+    // Run the script with a timeout
+    let result: MCPHostSimulationResult;
+    try {
+      result = await Promise.race([
+        scriptFn(page, scenario),
+        new Promise<never>((_, reject) =>
+          setTimeout(
+            () =>
+              reject(
+                new Error(
+                  `Browser script timed out after ${timeout}ms. ` +
+                    `Increase timeout via mcpHostConfig.browser.timeout.`
+                )
+              ),
+            timeout
+          )
+        ),
+      ]);
+    } catch (err) {
+      return {
+        success: false,
+        toolCalls: [],
+        error: `Browser script failed: ${err instanceof Error ? err.message : String(err)}`,
+      };
+    }
+
+    // Validate the result
+    const validationError = validateSimulationResult(result);
+    if (validationError) {
+      return {
+        success: false,
+        toolCalls: [],
+        error: `Browser script returned invalid result: ${validationError}`,
+      };
+    }
+
+    return result;
+  } finally {
+    await browser.close();
+  }
+}
+
+export function validateSimulationResult(result: unknown): string | null {
+  if (result === null || typeof result !== 'object') {
+    return `Expected object, got ${typeof result}`;
+  }
+
+  const obj = result as Record<string, unknown>;
+
+  if (typeof obj.success !== 'boolean') {
+    return `"success" must be a boolean, got ${typeof obj.success}`;
+  }
+
+  if (!Array.isArray(obj.toolCalls)) {
+    return `"toolCalls" must be an array, got ${typeof obj.toolCalls}`;
+  }
+
+  for (let i = 0; i < obj.toolCalls.length; i++) {
+    const tc = obj.toolCalls[i] as LLMToolCall;
+    if (typeof tc.name !== 'string') {
+      return `toolCalls[${i}].name must be a string, got ${typeof tc.name}`;
+    }
+    if (typeof tc.arguments !== 'object' || tc.arguments === null) {
+      return `toolCalls[${i}].arguments must be an object, got ${typeof tc.arguments}`;
+    }
+  }
+
+  return null;
+}

--- a/src/evals/mcpHost/mcpHostSimulation.ts
+++ b/src/evals/mcpHost/mcpHostSimulation.ts
@@ -26,6 +26,7 @@ import type {
 } from './mcpHostTypes.js';
 import { createVercelOrchestrator } from './adapters/vercel.js';
 import { runCLIHost } from './adapters/cli/index.js';
+import { runBrowserHost } from './adapters/browser/runner.js';
 
 // Single orchestrator instance shared across all providers.
 // Each provider is dynamically imported inside the orchestrator on first use.
@@ -99,10 +100,12 @@ export async function simulateMCPHost(
   }
 
   if (hostType === 'browser' || hostType === 'desktop') {
-    throw new Error(
-      `Host type '${hostType}' is not yet implemented. ` +
-        `Supported host types: 'sdk', 'cli'.`
-    );
+    if (!config.browser) {
+      throw new Error(
+        `mcpHostConfig.browser is required when hostType is '${hostType}'.`
+      );
+    }
+    return runBrowserHost(config.browser, scenario);
   }
 
   // Default: SDK host via Vercel AI SDK

--- a/src/evals/mcpHost/mcpHostTypes.ts
+++ b/src/evals/mcpHost/mcpHostTypes.ts
@@ -231,9 +231,6 @@ export interface MCPHostConfig {
    * Browser host configuration (required for 'browser' host type).
    */
   browser?: BrowserConfig;
-
-  /** Named MCP servers exposed to a host adapter. */
-  mcpServers?: Record<string, Record<string, unknown>>;
 }
 
 /**

--- a/src/evals/mcpHost/mcpHostTypes.ts
+++ b/src/evals/mcpHost/mcpHostTypes.ts
@@ -13,8 +13,8 @@ import type { UsageMetrics } from '../../types/index.js';
  *
  * - 'sdk': Programmatic via Vercel AI SDK (default). The framework's MCP connection is reused.
  * - 'cli': CLI-based hosts (e.g., Claude Code, Codex). Spawns a process with its own MCP connection.
- * - 'browser': Web-based hosts (e.g., claude.ai). Uses Playwright/CDP. (Not yet implemented.)
- * - 'desktop': Desktop app hosts (e.g., Claude Desktop). Uses computer use. (Not yet implemented.)
+ * - 'browser': Web-based hosts (e.g., claude.ai). Uses Playwright and a user script.
+ * - 'desktop': Desktop-style hosts driven through the browser adapter.
  */
 export type HostType = 'sdk' | 'cli' | 'browser' | 'desktop';
 
@@ -177,8 +177,8 @@ export interface MCPHostConfig {
    *
    * - 'sdk': Programmatic via Vercel AI SDK (default). The framework's MCP connection is reused.
    * - 'cli': CLI-based hosts (e.g., Claude Code, Codex). Spawns a process with its own MCP connection.
-   * - 'browser': Web-based hosts (not yet implemented).
-   * - 'desktop': Desktop app hosts (not yet implemented).
+   * - 'browser': Web-based hosts driven by a Playwright script.
+   * - 'desktop': Desktop-style hosts driven through the browser adapter.
    *
    * @default 'sdk'
    */
@@ -220,6 +220,12 @@ export interface MCPHostConfig {
    * CLI host configuration (required for 'cli' host type).
    */
   cli?: CLIConfig;
+
+  /**
+   * Additional MCP server entries for CLI hosts. Values follow the Claude
+   * mcpServers JSON shape and may point at safe local proxies.
+   */
+  mcpServers?: Record<string, Record<string, unknown>>;
 
   /**
    * Browser host configuration (required for 'browser' host type).

--- a/src/mcp/dryRunProxy.ts
+++ b/src/mcp/dryRunProxy.ts
@@ -1,0 +1,231 @@
+import readline from 'node:readline';
+
+export const DEFAULT_PLANNED_WRITE_KEY = '_mcp_eval_planned_write';
+
+export interface DryRunProxyOptions {
+  name: string;
+  upstreamUrl: string;
+  token: string;
+  headers?: Record<string, string>;
+  alwaysWriteTools?: string[];
+  readOnlyTools?: string[];
+  plannedWriteKey?: string;
+  timeoutMs?: number;
+}
+
+interface JsonRpcResponse {
+  result?: Record<string, unknown>;
+  error?: { message?: string };
+  [key: string]: unknown;
+}
+
+function isReadOnly(tool: Record<string, unknown> | undefined): boolean {
+  if (!tool) return false;
+  const annotations = tool.annotations;
+  if (!annotations || typeof annotations !== 'object') return false;
+  const values = annotations as Record<string, unknown>;
+  return values.readOnlyHint === true && values.destructiveHint !== true;
+}
+
+function plannedWriteResult(
+  options: DryRunProxyOptions,
+  toolName: string,
+  arguments_: unknown
+): Record<string, unknown> {
+  const key = options.plannedWriteKey ?? DEFAULT_PLANNED_WRITE_KEY;
+  const envelope = {
+    [key]: {
+      server: options.name,
+      tool_name: toolName,
+      arguments: arguments_,
+    },
+  };
+  return {
+    content: [{ type: 'text', text: JSON.stringify(envelope) }],
+    structuredContent: envelope,
+  };
+}
+
+function parseResponse(text: string, contentType: string): JsonRpcResponse {
+  if (contentType.includes('text/event-stream')) {
+    for (const line of text.split(/\r?\n/)) {
+      if (!line.startsWith('data:')) continue;
+      const payload = line.slice('data:'.length).trim();
+      if (payload && payload !== '[DONE]')
+        return JSON.parse(payload) as JsonRpcResponse;
+    }
+    throw new Error('upstream returned an empty SSE body');
+  }
+  const parsed: unknown = JSON.parse(text);
+  if (!parsed || typeof parsed !== 'object') {
+    throw new Error('upstream response is not a JSON object');
+  }
+  return parsed as JsonRpcResponse;
+}
+
+class UpstreamClient {
+  private sessionId: string | undefined;
+
+  public constructor(private readonly options: DryRunProxyOptions) {}
+
+  public async rpc(
+    method: string,
+    params: unknown,
+    id: number,
+    notification = false
+  ): Promise<JsonRpcResponse | undefined> {
+    const controller = new AbortController();
+    const timer = setTimeout(
+      () => controller.abort(),
+      this.options.timeoutMs ?? 60_000
+    );
+    try {
+      const headers: Record<string, string> = {
+        Accept: 'application/json, text/event-stream',
+        'Content-Type': 'application/json',
+        ...(this.options.headers ?? {}),
+      };
+      if (this.options.token)
+        headers.Authorization = `Bearer ${this.options.token}`;
+      if (this.sessionId) headers['Mcp-Session-Id'] = this.sessionId;
+      const response = await fetch(this.options.upstreamUrl, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({ jsonrpc: '2.0', id, method, params }),
+        signal: controller.signal,
+      });
+      if (method === 'initialize') {
+        this.sessionId = response.headers.get('mcp-session-id') ?? undefined;
+      }
+      if (notification) return undefined;
+      const text = await response.text();
+      return parseResponse(text, response.headers.get('content-type') ?? '');
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+}
+
+function toolMap(
+  result: JsonRpcResponse | undefined
+): Map<string, Record<string, unknown>> {
+  const inner = result?.result ?? result;
+  const tools = inner?.tools;
+  const map = new Map<string, Record<string, unknown>>();
+  if (!Array.isArray(tools)) return map;
+  for (const value of tools as unknown[]) {
+    if (!value || typeof value !== 'object') continue;
+    const tool = value as Record<string, unknown>;
+    const name = tool.name;
+    if (typeof name === 'string') map.set(name, tool);
+  }
+  return map;
+}
+
+/** Run the stdio JSON-RPC dry-run proxy used by native MCP servers. */
+export async function runDryRunProxy(
+  options: DryRunProxyOptions
+): Promise<void> {
+  if (!options.token)
+    throw new Error('dry-run proxy requires a non-empty token');
+  const client = new UpstreamClient(options);
+  const tools = new Map<string, Record<string, unknown>>();
+  const alwaysWrite = new Set(options.alwaysWriteTools ?? []);
+  const readOnly = new Set(options.readOnlyTools ?? []);
+  const input = readline.createInterface({ input: process.stdin });
+
+  for await (const line of input) {
+    if (!line.trim()) continue;
+    let message: Record<string, unknown>;
+    try {
+      const parsed: unknown = JSON.parse(line);
+      if (!parsed || typeof parsed !== 'object') continue;
+      message = parsed as Record<string, unknown>;
+    } catch {
+      continue;
+    }
+
+    const method = typeof message.method === 'string' ? message.method : '';
+    const id = typeof message.id === 'number' ? message.id : 1;
+    const notification =
+      message.id === undefined || method.startsWith('notifications/');
+    const params = message.params;
+
+    if (!notification && method === 'tools/call') {
+      const callParams =
+        params && typeof params === 'object'
+          ? (params as Record<string, unknown>)
+          : {};
+      const toolName =
+        typeof callParams.name === 'string' ? callParams.name : '';
+      let tool = tools.get(toolName);
+      if (!tool) {
+        const listed = await client.rpc('tools/list', {}, 1);
+        for (const [name, value] of toolMap(listed)) tools.set(name, value);
+        tool = tools.get(toolName);
+      }
+      const write =
+        alwaysWrite.has(toolName) ||
+        (!readOnly.has(toolName) && !isReadOnly(tool));
+      if (write) {
+        process.stdout.write(
+          `${JSON.stringify({
+            jsonrpc: '2.0',
+            id,
+            result: plannedWriteResult(options, toolName, callParams.arguments),
+          })}\n`
+        );
+        continue;
+      }
+    }
+
+    const upstream = await client.rpc(method, params, id, notification);
+    if (upstream && method === 'tools/list') {
+      for (const [name, value] of toolMap(upstream)) tools.set(name, value);
+    }
+    if (!notification) {
+      process.stdout.write(
+        `${JSON.stringify({
+          ...(upstream ?? {
+            error: { code: -32000, message: 'empty upstream response' },
+          }),
+          jsonrpc: '2.0',
+          id,
+        })}\n`
+      );
+    }
+  }
+}
+
+/** Probe an upstream server before attaching it to a host configuration. */
+export async function preflightMcpServer(
+  options: DryRunProxyOptions,
+  expectedMinTools = 1
+): Promise<void> {
+  const client = new UpstreamClient(options);
+  const initialized = await client.rpc(
+    'initialize',
+    {
+      protocolVersion: '2024-11-05',
+      capabilities: {},
+      clientInfo: { name: 'mcp-server-tester-preflight', version: '1.0' },
+    },
+    1
+  );
+  if (initialized?.error)
+    throw new Error(
+      `initialize failed: ${initialized.error.message ?? 'unknown error'}`
+    );
+  await client.rpc('notifications/initialized', {}, 0, true);
+  const listed = await client.rpc('tools/list', {}, 2);
+  if (listed?.error)
+    throw new Error(
+      `tools/list failed: ${listed.error.message ?? 'unknown error'}`
+    );
+  const tools = listed?.result?.tools;
+  if (!Array.isArray(tools) || tools.length < expectedMinTools) {
+    throw new Error(
+      `tools/list returned ${Array.isArray(tools) ? tools.length : 0} tools; expected at least ${expectedMinTools}`
+    );
+  }
+}


### PR DESCRIPTION
## Stack\n\nStacked on `chenhao/mcp-tester-03-execution-metrics`.\n\n## Scope\n\n- Add native and browser host integrations.\n- Add MCP host simulation and dry-run support.\n- Declare the direct Playwright dependency required by the browser runner.\n\n## Validation\n\n- Typecheck passes on a clean pnpm installation.