### PR TITLE
[Evals] Finish quality and type-cleanup pass

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,36 +209,53 @@ The `examples/` directory contains complete working examples:
 - [sqlite-server/](./examples/sqlite-server) — Test suite for a SQLite MCP server: 11 Playwright tests, 14 eval dataset cases.
 - [basic-playwright-usage/](./examples/basic-playwright-usage) — Minimal Playwright patterns.
 
-## Campaign runner
+## Evaluation manifests
 
-For projects with multiple evalsets, the campaign runner converts minimal JSON
-(evalsets containing `expected_tool`, `tool`, or `scenario`) into tester-native
-cases and writes self-contained results:
+For projects with multiple datasets, use an evaluation manifest. Dataset
+paths are shorthand for tagged file sources, while hosts, metrics, judges,
+result stores, and other extensions resolve through public registries:
+
+```json
+{
+  "name": "tool-selection-search",
+  "datasets": [{ "type": "file", "path": "evalsets/search.json" }],
+  "servers": [
+    {
+      "transport": "http",
+      "serverUrl": "https://example.com/mcp",
+      "label": "prod"
+    }
+  ],
+  "host": { "type": "sdk" },
+  "metrics": ["passed"],
+  "results": { "store": { "type": "file", "directory": ".mcp-test-results" } }
+}
+```
+
+Run one manifest or a bounded batch:
 
 ```bash
 npx mcp-server-tester run \
-  --config configs/eval.json \
-  --root-dir . \
-  --mode tool-selection \
-  --max-cases 10 \
-  --concurrency 4
+  --manifest eval-manifest.json \
+  --plugins ./plugins \
+  --dry-run
 
 npx mcp-server-tester batch \
-  --config-dir configs/weekly \
-  --parallel 4
+  --manifest-dir manifests \
+  --workers 4 \
+  --skip-existing \
+  --dry-run
 ```
 
-Campaign configs support `direct`, `tool-selection`, `tool-call`,
-`e2e-quality`, `mcp-host`, `sxs`, and `all` modes, plus local evalset paths,
-custom judge plugins, metrics, baselines, and host overrides. The public
-metric registry includes token/cost/duration, response/tool, pass/no-action,
-and judge metrics; applications can add a metric with `registerMetric()`.
+Use `arms` to compare server sets or host configurations. An arm can override
+servers, host options, tool maps, scenario templates, metrics, and judges.
+The canonical execution primitives remain `EvalDataset`, `EvalCase`,
+`EvalMode`, `MCPConfig`, and `runEvalDataset`.
 
-Native MCP servers can be attached safely by supplying definitions with
-`buildNativeMcpServers()`. The tester validates HTTPS (or loopback HTTP),
-preflights credentials and `tools/list`, and gives CLI hosts a stdio dry-run
-proxy. Non-read-only calls are returned as planned writes and are never sent
-to the upstream server.
+Applications can register extensions with `registerDatasetSource`,
+`registerHost`, `registerJudge`, `registerMetric`, and `registerResultStore`.
+Secrets remain environment-variable or plugin-owned runtime inputs and do not
+belong in committed manifests.
 
 ## Known Limitations
 

--- a/src/assertions/matchers/toPassToolJudge.ts
+++ b/src/assertions/matchers/toPassToolJudge.ts
@@ -105,7 +105,7 @@ export async function toPassToolJudge(
       rubricOrOptions !== null &&
       'text' in rubricOrOptions)
   ) {
-    rubric = rubricOrOptions as RubricSpec;
+    rubric = rubricOrOptions;
     options = maybeOptions ?? {};
   } else {
     options = rubricOrOptions;

--- a/src/assertions/validators/types.ts
+++ b/src/assertions/validators/types.ts
@@ -121,9 +121,7 @@ export interface FieldRemovalSanitizer {
  * - A field removal sanitizer: { remove: ['field1', 'nested.field'] }
  */
 export type SnapshotSanitizer =
-  | BuiltInSanitizer
-  | RegexSanitizer
-  | FieldRemovalSanitizer;
+  BuiltInSanitizer | RegexSanitizer | FieldRemovalSanitizer;
 
 /**
  * Schema registry for named schemas in datasets

--- a/src/auth/oauthFlow.test.ts
+++ b/src/auth/oauthFlow.test.ts
@@ -60,7 +60,7 @@ function mockAuthServer(
       authorization_endpoint: 'https://auth.example.com/authorize',
       token_endpoint: 'https://auth.example.com/token',
       ...overrides,
-    } as oauth.AuthorizationServer,
+    },
   };
 }
 

--- a/src/auth/setupOAuth.test.ts
+++ b/src/auth/setupOAuth.test.ts
@@ -80,7 +80,7 @@ function makeConfig(overrides: Record<string, unknown> = {}): OAuthSetupConfig {
     },
     outputPath: 'playwright/.auth/oauth-state.json',
     ...overrides,
-  } as OAuthSetupConfig;
+  };
 }
 
 const mockMetadata = {

--- a/src/evals/evalRunner.test.ts
+++ b/src/evals/evalRunner.test.ts
@@ -765,26 +765,35 @@ describe('runEvalDataset concurrency', () => {
   }
 
   it('should run cases concurrently when concurrency > 1', async () => {
-    const startTimes: number[] = [];
-    const mcp = createMockMCP();
-    vi.mocked(mcp.callTool).mockImplementation(async () => {
-      startTimes.push(Date.now());
-      await new Promise((r) => setTimeout(r, 30)); // simulate latency
-      return { content: [{ type: 'text', text: 'ok' }], isError: false };
-    });
+    vi.useFakeTimers();
+    try {
+      const startTimes: number[] = [];
+      const mcp = createMockMCP();
+      vi.mocked(mcp.callTool).mockImplementation(async () => {
+        startTimes.push(Date.now());
+        await new Promise((r) => setTimeout(r, 30)); // simulate latency
+        return { content: [{ type: 'text', text: 'ok' }], isError: false };
+      });
 
-    const dataset = createDataset([
-      createEvalCase({ id: 'c1' }),
-      createEvalCase({ id: 'c2' }),
-      createEvalCase({ id: 'c3' }),
-    ]);
+      const dataset = createDataset([
+        createEvalCase({ id: 'c1' }),
+        createEvalCase({ id: 'c2' }),
+        createEvalCase({ id: 'c3' }),
+      ]);
 
-    const start = Date.now();
-    await runEvalDataset({ dataset, concurrency: 3 }, createContext(mcp));
-    const elapsed = Date.now() - start;
+      const result = runEvalDataset(
+        { dataset, concurrency: 3 },
+        createContext(mcp)
+      );
+      await vi.runAllTimersAsync();
+      await result;
 
-    // 3 cases with 30ms each, run in parallel → should complete well under 90ms (sequential)
-    expect(elapsed).toBeLessThan(150);
+      // All three calls start at the same virtual time when concurrency is 3.
+      expect(startTimes).toHaveLength(3);
+      expect(new Set(startTimes).size).toBe(1);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it('should default to sequential execution (concurrency: 1)', async () => {

--- a/src/evals/externalHost/builtins/anthropicClaude.ts
+++ b/src/evals/externalHost/builtins/anthropicClaude.ts
@@ -282,8 +282,7 @@ async function captureClaudeCoworkAgentTraceCapability({
       ? state.data.claudeDataDir
       : getClaudeDataDir(config, binding);
   const snapshot = state.data.claudeSessionSnapshot as
-    | ClaudeSessionSnapshot
-    | undefined;
+    ClaudeSessionSnapshot | undefined;
 
   if (!snapshot) {
     return failureResult({

--- a/src/evals/externalHost/capabilityRuntime.ts
+++ b/src/evals/externalHost/capabilityRuntime.ts
@@ -265,9 +265,7 @@ function mergeCapabilities(
 
 function normalizeCapabilityBindings(
   binding:
-    | ExternalHostCapabilityBinding
-    | ExternalHostCapabilityBinding[]
-    | undefined
+    ExternalHostCapabilityBinding | ExternalHostCapabilityBinding[] | undefined
 ): ExternalHostCapabilityBinding[] {
   if (!binding) {
     return [];

--- a/src/evals/externalHost/types.ts
+++ b/src/evals/externalHost/types.ts
@@ -7,11 +7,7 @@ import type { UsageMetrics } from '../../types/index.js';
 export type ExternalHostType = 'cli' | 'browser' | 'desktop' | 'custom';
 
 export type HostCapability =
-  | 'control'
-  | 'input'
-  | 'completion'
-  | 'trace'
-  | 'normalize';
+  'control' | 'input' | 'completion' | 'trace' | 'normalize';
 
 export type TraceSource =
   | 'mcp-proxy'
@@ -29,9 +25,7 @@ export type TraceSource =
 export type ObservationConfidence = 'high' | 'medium' | 'low' | 'unknown';
 
 export type ExternalHostCorrelationStrategy =
-  | 'prompt_marker'
-  | 'host_session_metadata'
-  | 'none';
+  'prompt_marker' | 'host_session_metadata' | 'none';
 
 export interface HostDriverId {
   provider: string;
@@ -210,8 +204,7 @@ export interface ExternalHostRunFailure {
 }
 
 export type ExternalHostRunResult =
-  | ExternalHostRunSuccess
-  | ExternalHostRunFailure;
+  ExternalHostRunSuccess | ExternalHostRunFailure;
 
 export type ExternalHostCapabilitiesConfig = Partial<
   Record<

--- a/src/evals/resultStore.ts
+++ b/src/evals/resultStore.ts
@@ -68,8 +68,7 @@ export interface GCSEvalResultStoreConfig {
 }
 
 export type EvalResultStoreConfig =
-  | FileEvalResultStoreConfig
-  | GCSEvalResultStoreConfig;
+  FileEvalResultStoreConfig | GCSEvalResultStoreConfig;
 
 export type EvalResultStoreLike = EvalResultStore | EvalResultStoreConfig;
 

--- a/src/evals/variantExperiment.ts
+++ b/src/evals/variantExperiment.ts
@@ -21,10 +21,7 @@ import type { ZodType } from 'zod';
  *   error rather than silently ranking on nothing.
  */
 export type ExperimentMetric =
-  | 'passRate'
-  | 'toolF1'
-  | 'toolPrecision'
-  | 'toolRecall';
+  'passRate' | 'toolF1' | 'toolPrecision' | 'toolRecall';
 
 /**
  * Why a variant experiment stopped.
@@ -38,10 +35,7 @@ export type ExperimentMetric =
  *   emitted by the current delta-based logic.
  */
 export type VariantExperimentReason =
-  | 'threshold-met'
-  | 'no-improvement'
-  | 'max-rounds'
-  | 'no-variants';
+  'threshold-met' | 'no-improvement' | 'max-rounds' | 'no-variants';
 
 /** Whether a winning variant should be applied, rejected, or is inconclusive. */
 export type VariantRecommendation = 'apply' | 'reject' | 'inconclusive';

--- a/src/judge/claudeAgentJudge.ts
+++ b/src/judge/claudeAgentJudge.ts
@@ -90,7 +90,7 @@ export function createClaudeAgentJudge(config: JudgeConfig): Judge {
         })) {
           // The final message will be the SDKResultMessage
           if (message.type === 'result') {
-            resultMessage = message as unknown as typeof resultMessage;
+            resultMessage = message;
           }
         }
 

--- a/src/judge/googleJudge.ts
+++ b/src/judge/googleJudge.ts
@@ -93,12 +93,10 @@ export function createGoogleJudge(config: JudgeConfig = {}): Judge {
         usage: {
           inputTokens:
             (result.response.usageMetadata?.promptTokenCount as
-              | number
-              | undefined) ?? 0,
+              number | undefined) ?? 0,
           outputTokens:
             (result.response.usageMetadata?.candidatesTokenCount as
-              | number
-              | undefined) ?? 0,
+              number | undefined) ?? 0,
           totalCostUsd: 0,
           durationMs,
         },

--- a/src/judge/openaiJudge.test.ts
+++ b/src/judge/openaiJudge.test.ts
@@ -25,7 +25,7 @@ import { createOpenAIJudge } from './openaiJudge.js';
 
 // Retrieve the mocked create function for configuring in tests
 async function getMockCreate() {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unnecessary-type-assertion
   const openai = await import('openai' as any);
   // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unnecessary-type-assertion
   return (openai as any).__mockCreate;

--- a/src/mcp/clientFactory.ts
+++ b/src/mcp/clientFactory.ts
@@ -21,8 +21,7 @@ import { performClientCredentialsFlow } from '../auth/oauthFlow.js';
  */
 function getRetryAfterDelayMs(err: unknown): number | null {
   const response = (err as Record<string, unknown>)?.response as
-    | Response
-    | undefined;
+    Response | undefined;
   const retryAfter = response?.headers?.get?.('Retry-After');
   if (retryAfter) {
     const seconds = parseInt(retryAfter, 10);
@@ -36,8 +35,7 @@ function getRetryAfterDelayMs(err: unknown): number | null {
  */
 function isRateLimitError(err: unknown): boolean {
   const response = (err as Record<string, unknown>)?.response as
-    | Response
-    | undefined;
+    Response | undefined;
   return response?.status === 429;
 }
 

--- a/src/mcp/fixtures/mcpFixture.ts
+++ b/src/mcp/fixtures/mcpFixture.ts
@@ -35,8 +35,8 @@ function withCallTimeout<T>(
 // Dynamic import of test for conditional step tracking
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 let testStep:
-  | ((name: string, fn: () => Promise<unknown>) => Promise<unknown>)
-  | null = null;
+  ((name: string, fn: () => Promise<unknown>) => Promise<unknown>) | null =
+  null;
 
 // Try to load test.step() dynamically
 try {

--- a/src/plugins/loadPlugins.test.ts
+++ b/src/plugins/loadPlugins.test.ts
@@ -32,7 +32,9 @@ describe('loadPluginModule', () => {
     `);
 
     await loadPluginModule(pluginDir);
-    const mod = await import(new URL('./index.mjs', `file://${pluginDir}/`).href);
+    const mod = await import(
+      new URL('./index.mjs', `file://${pluginDir}/`).href
+    );
     expect(mod.wasCalled()).toBe(true);
   });
 
@@ -49,6 +51,8 @@ describe('loadPluginModule', () => {
       export const noop = () => {};
     `);
 
-    await expect(loadPluginModule(pluginDir)).rejects.toThrow(/does not export a register function/);
+    await expect(loadPluginModule(pluginDir)).rejects.toThrow(
+      /does not export a register function/
+    );
   });
 });


### PR DESCRIPTION
## Stack\n\nStacked on `chenhao/mcp-tester-05-operations`.\n\n## Scope\n\n- Restore type-aware lint cleanup across the eval framework.\n- Align public types and result-store interfaces.\n- Make the concurrency test deterministic under CI timing.\n\n## Validation\n\n- Focused eval-runner tests pass.\n- Full top-of-stack typecheck and test suite pass.