### PR TITLE
[Evals] Add runtime dispatch, secrets, and direct Anthropic host

### DIFF
--- a/schema/eval-manifest.schema.json
+++ b/schema/eval-manifest.schema.json
@@ -97,7 +97,8 @@
     "maxCases": { "type": "integer", "minimum": 1 },
     "timeout": { "type": "integer", "minimum": 1 },
     "maxToolCalls": { "type": "integer", "minimum": 0 },
-    "tools": { "type": "string" }
+    "tools": { "type": "string" },
+    "requireEvalEndpoint": { "type": "boolean" }
   },
   "definitions": {
     "extension": {

--- a/src/cli/commands/run/index.ts
+++ b/src/cli/commands/run/index.ts
@@ -11,6 +11,7 @@ export interface RunOptions {
   dryRun?: boolean;
   arm?: string;
   outputDir?: string;
+  secretsFile?: string;
 }
 
 export async function run(options: RunOptions): Promise<void> {
@@ -19,6 +20,7 @@ export async function run(options: RunOptions): Promise<void> {
     rootDir: options.rootDir,
     pluginPaths: options.plugins,
     outputDir: options.outputDir,
+    secretsFile: options.secretsFile,
     dryRun: options.dryRun,
     arm: options.arm,
   };

--- a/src/cli/commands/run/index.ts
+++ b/src/cli/commands/run/index.ts
@@ -44,6 +44,7 @@ export async function run(options: RunOptions): Promise<void> {
 
   const metrics = result.summary.metrics as {
     passed?: number;
+    failed?: number;
     total?: number;
     passRate?: number;
   };
@@ -52,4 +53,5 @@ export async function run(options: RunOptions): Promise<void> {
     `Results: ${metrics.passed ?? 0}/${metrics.total ?? 0} passed (${((metrics.passRate ?? 0) * 100).toFixed(1)}%)`
   );
   console.log(`Output: ${path.join(result.outputDir, 'results.json')}`);
+  if ((metrics.failed ?? 0) > 0) process.exitCode = 1;
 }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -73,6 +73,8 @@ program
   )
   .option('--plugins <paths...>', 'Plugin modules to load before the run')
   .option('--arm <name>', 'Run one named manifest arm')
+  .option('--output-dir <dir>', 'Directory for run artifacts')
+  .option('--secrets-file <path>', 'JSON or dotenv-style runtime secrets file')
   .option(
     '--root-dir <dir>',
     'Base directory for resolving relative paths',

--- a/src/config/mcpConfig.ts
+++ b/src/config/mcpConfig.ts
@@ -77,6 +77,9 @@ export interface MCPAuthConfig {
    */
   accessToken?: string;
 
+  /** Environment variable containing the access token; resolved at runtime. */
+  accessTokenEnv?: string;
+
   /**
    * Full OAuth configuration for browser-based authentication
    */
@@ -311,9 +314,14 @@ const MCPClientCredentialsConfigSchema = z.object({
 const MCPAuthConfigSchema = z
   .object({
     accessToken: z.string().optional(),
+    accessTokenEnv: z.string().min(1).optional(),
     oauth: MCPOAuthConfigSchema.optional(),
     clientCredentials: MCPClientCredentialsConfigSchema.optional(),
   })
+  .refine(
+    (data) => !(data.accessToken && data.accessTokenEnv),
+    'Cannot specify both accessToken and accessTokenEnv'
+  )
   .refine(
     (data) => !(data.accessToken && data.oauth),
     'Cannot specify both accessToken and oauth configuration'

--- a/src/evals/anthropicApiHost.ts
+++ b/src/evals/anthropicApiHost.ts
@@ -1,0 +1,258 @@
+import {
+  closeMCPClient,
+  createMCPClientForConfig,
+} from '../mcp/clientFactory.js';
+import { z } from 'zod';
+import type { EvalCase } from './datasetTypes.js';
+import type { HostRunOptions, HostDefinition } from './evalFrameworkTypes.js';
+import type { EvalRunnerResult } from './evalRunner.js';
+import type { EvalCaseResult } from '../types/reporter.js';
+import type { MCPHostConfig } from './mcpHost/mcpHostTypes.js';
+import type { UsageMetrics } from '../types/index.js';
+
+interface AnthropicContentBlock {
+  type: string;
+  [key: string]: unknown;
+}
+
+interface AnthropicResponse {
+  content?: AnthropicContentBlock[];
+  stop_reason?: string;
+  usage?: {
+    input_tokens?: number;
+    output_tokens?: number;
+  };
+  error?: { message?: string };
+}
+
+interface AnthropicMessage {
+  role: 'user' | 'assistant';
+  content: string | AnthropicContentBlock[];
+}
+
+function hostConfig(options: Record<string, unknown>): MCPHostConfig {
+  return {
+    hostType: 'sdk',
+    provider: 'anthropic',
+    model:
+      typeof options.model === 'string' ? options.model : 'claude-sonnet-4-6',
+    maxToolCalls:
+      typeof options.maxToolCalls === 'number' ? options.maxToolCalls : 20,
+  };
+}
+
+function scenarioForCase(case_: EvalCase): string {
+  const value = (case_ as unknown as Record<string, unknown>).scenario;
+  if (typeof value !== 'string' || !value) {
+    throw new Error(
+      `Anthropic API host requires a scenario for case ${case_.id}.`
+    );
+  }
+  return value;
+}
+
+function expectedToolsForCase(case_: EvalCase): string[] {
+  const expect = (case_ as unknown as Record<string, unknown>).expect;
+  if (!expect || typeof expect !== 'object') return [];
+  const toolsTriggered = (expect as Record<string, unknown>).toolsTriggered;
+  if (!toolsTriggered || typeof toolsTriggered !== 'object') return [];
+  const calls = (toolsTriggered as Record<string, unknown>).calls;
+  if (!Array.isArray(calls)) return [];
+  return calls.flatMap((call) => {
+    if (!call || typeof call !== 'object') return [];
+    const name = (call as Record<string, unknown>).name;
+    return typeof name === 'string' ? [name] : [];
+  });
+}
+
+function textFromResponse(content: AnthropicContentBlock[]): string {
+  return content
+    .map((block) =>
+      block.type === 'text' && typeof block.text === 'string' ? block.text : ''
+    )
+    .filter(Boolean)
+    .join('\n');
+}
+
+async function postAnthropic(
+  apiKey: string,
+  model: string,
+  messages: AnthropicMessage[],
+  tools: Array<Record<string, unknown>>
+): Promise<AnthropicResponse> {
+  const response = await fetch('https://api.anthropic.com/v1/messages', {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      'anthropic-version': '2023-06-01',
+      'x-api-key': apiKey,
+    },
+    body: JSON.stringify({
+      model,
+      max_tokens: 4096,
+      messages,
+      tools,
+    }),
+  });
+  const body = (await response.json()) as AnthropicResponse;
+  if (!response.ok) {
+    throw new Error(
+      body.error?.message ?? `Anthropic API returned ${response.status}.`
+    );
+  }
+  return body;
+}
+
+async function runCase(
+  client: Awaited<ReturnType<typeof createMCPClientForConfig>>,
+  apiKey: string,
+  model: string,
+  maxToolCalls: number,
+  case_: EvalCase,
+  tools: Array<Record<string, unknown>>,
+  datasetName: string
+): Promise<EvalCaseResult> {
+  const startedAt = Date.now();
+  const messages: AnthropicMessage[] = [
+    { role: 'user', content: scenarioForCase(case_) },
+  ];
+  const toolCalls: Array<Record<string, unknown>> = [];
+  let finalContent: AnthropicContentBlock[] = [];
+  let inputTokens = 0;
+  let outputTokens = 0;
+
+  for (let iteration = 0; iteration <= maxToolCalls; iteration += 1) {
+    const response = await postAnthropic(apiKey, model, messages, tools);
+    finalContent = response.content ?? [];
+    inputTokens += response.usage?.input_tokens ?? 0;
+    outputTokens += response.usage?.output_tokens ?? 0;
+    const toolUses = finalContent.filter((block) => block.type === 'tool_use');
+    if (toolUses.length === 0 || response.stop_reason !== 'tool_use') break;
+
+    messages.push({ role: 'assistant', content: finalContent });
+    const toolResults: AnthropicContentBlock[] = [];
+    for (const toolUse of toolUses) {
+      const name = typeof toolUse.name === 'string' ? toolUse.name : '';
+      const id = typeof toolUse.id === 'string' ? toolUse.id : '';
+      const input =
+        toolUse.input && typeof toolUse.input === 'object'
+          ? (toolUse.input as Record<string, unknown>)
+          : {};
+      if (!name || !id) continue;
+      const result = await client.callTool({ name, arguments: input });
+      toolCalls.push({ name, arguments: input, result });
+      toolResults.push({
+        type: 'tool_result',
+        tool_use_id: id,
+        content: [{ type: 'text', text: JSON.stringify(result) }],
+        is_error: Boolean((result as { isError?: boolean }).isError),
+      });
+    }
+    messages.push({ role: 'user', content: toolResults });
+  }
+
+  const expectedTools = expectedToolsForCase(case_);
+  const calledNames = toolCalls.map((call) => String(call.name));
+  const pass = expectedTools.every((name) => calledNames.includes(name));
+  return {
+    id: case_.id,
+    datasetName,
+    toolName: case_.toolName ?? '',
+    source: 'eval',
+    pass,
+    durationMs: Date.now() - startedAt,
+    response: {
+      success: true,
+      response: textFromResponse(finalContent),
+      toolCalls,
+    },
+    hostUsage: {
+      inputTokens,
+      outputTokens,
+      totalCostUsd: 0,
+      durationMs: Date.now() - startedAt,
+    },
+    expectations: {
+      toolsTriggered: {
+        expected: expectedTools,
+        actual: calledNames,
+        pass,
+      },
+    },
+  } as EvalCaseResult;
+}
+
+async function runAnthropicApiHost(
+  options: HostRunOptions
+): Promise<EvalRunnerResult> {
+  const apiKeyEnv =
+    typeof options.host.apiKeyEnv === 'string'
+      ? options.host.apiKeyEnv
+      : 'ANTHROPIC_API_KEY';
+  const apiKey = process.env[apiKeyEnv];
+  if (!apiKey) throw new Error(`Anthropic API key ${apiKeyEnv} is not set.`);
+  const model =
+    typeof options.host.model === 'string'
+      ? options.host.model
+      : (options.manifest.model ?? 'claude-sonnet-4-6');
+  const maxToolCalls = options.manifest.maxToolCalls ?? 20;
+  const server = options.servers[0];
+  if (!server) throw new Error('Anthropic API host requires one MCP server.');
+
+  const client = await createMCPClientForConfig(server);
+  try {
+    const listed = await client.listTools();
+    const tools = listed.tools.map((tool) => ({
+      name: tool.name,
+      description: tool.description,
+      input_schema: tool.inputSchema,
+    }));
+    const caseResults: EvalCaseResult[] = [];
+    for (const case_ of options.cases) {
+      caseResults.push(
+        await runCase(
+          client,
+          apiKey,
+          model,
+          maxToolCalls,
+          case_,
+          tools,
+          options.dataset.name
+        )
+      );
+    }
+    const durationMs = caseResults.reduce(
+      (sum, result) => sum + result.durationMs,
+      0
+    );
+    return {
+      total: caseResults.length,
+      passed: caseResults.filter((result) => result.pass).length,
+      failed: caseResults.filter((result) => !result.pass).length,
+      caseResults,
+      durationMs,
+      totalHostUsage: caseResults.reduce<UsageMetrics>(
+        (usage, result) => ({
+          inputTokens:
+            (usage.inputTokens ?? 0) + (result.hostUsage?.inputTokens ?? 0),
+          outputTokens:
+            (usage.outputTokens ?? 0) + (result.hostUsage?.outputTokens ?? 0),
+          totalCostUsd:
+            (usage.totalCostUsd ?? 0) + (result.hostUsage?.totalCostUsd ?? 0),
+          durationMs:
+            (usage.durationMs ?? 0) + (result.hostUsage?.durationMs ?? 0),
+        }),
+        { inputTokens: 0, outputTokens: 0, totalCostUsd: 0, durationMs: 0 }
+      ),
+    };
+  } finally {
+    await closeMCPClient(client);
+  }
+}
+
+export const ANTHROPIC_API_HOST: HostDefinition = {
+  name: 'anthropic-api',
+  schema: z.object({ type: z.literal('anthropic-api') }).passthrough(),
+  createConfig: hostConfig,
+  run: runAnthropicApiHost,
+};

--- a/src/evals/buildEvalDataset.ts
+++ b/src/evals/buildEvalDataset.ts
@@ -75,11 +75,24 @@ function buildJudges(
   return result;
 }
 
+function requireHostConfig(
+  hostConfig: MCPHostConfig | undefined,
+  source: string
+): MCPHostConfig {
+  if (!hostConfig) {
+    throw new Error(
+      `Dataset source "${source}" requires a resolved host configuration.`
+    );
+  }
+  return hostConfig;
+}
+
 function buildToolSelectionDataset(
   evalset: RawEvalset,
-  hostConfig: MCPHostConfig,
+  hostConfig: MCPHostConfig | undefined,
   manifest: EvalManifest
 ): EvalDataset {
+  const resolvedHostConfig = requireHostConfig(hostConfig, 'tool-selection');
   const iterations = fixtureIterations(manifest);
   const cases = evalset.cases.map((case_) => {
     const expectedTool = String(case_.expected_tool);
@@ -94,7 +107,7 @@ function buildToolSelectionDataset(
       toolName: expectedTool,
       mode: 'mcp_host' as const,
       scenario,
-      mcpHostConfig: hostConfig,
+      mcpHostConfig: resolvedHostConfig,
       tags: ['mcp_host', 'tool_selection', ...tags],
       iterations,
       accuracyThreshold: iterations === 1 ? 1.0 : 0.8,
@@ -115,8 +128,9 @@ function buildToolSelectionDataset(
 
 function buildToolCallDataset(
   evalset: RawEvalset,
-  hostConfig: MCPHostConfig
+  hostConfig: MCPHostConfig | undefined
 ): EvalDataset {
+  const resolvedHostConfig = requireHostConfig(hostConfig, 'tool-call');
   const cases = evalset.cases.map((case_) => {
     const tool = String(case_.tool);
     const tags = Array.isArray(case_.tags) ? (case_.tags as string[]) : [];
@@ -142,7 +156,8 @@ function buildToolCallDataset(
     ] as const) {
       if (case_[key] !== undefined) fixtureCase[key] = case_[key];
     }
-    if (case_.mode === 'mcp_host') fixtureCase.mcpHostConfig = hostConfig;
+    if (case_.mode === 'mcp_host')
+      fixtureCase.mcpHostConfig = resolvedHostConfig;
     return fixtureCase;
   });
 
@@ -155,9 +170,10 @@ function buildToolCallDataset(
 
 function buildE2eQualityDataset(
   evalset: RawEvalset,
-  hostConfig: MCPHostConfig,
+  hostConfig: MCPHostConfig | undefined,
   manifest: EvalManifest
 ): EvalDataset {
+  const resolvedHostConfig = requireHostConfig(hostConfig, 'e2e-quality');
   const judges = enabledJudges(manifest);
   const cases = evalset.cases.map((case_) => {
     const scenario = String(case_.scenario);
@@ -172,7 +188,7 @@ function buildE2eQualityDataset(
           : `E2E quality: ${scenario.slice(0, 80)}`,
       mode: 'mcp_host',
       scenario,
-      mcpHostConfig: hostConfig,
+      mcpHostConfig: resolvedHostConfig,
       tags: ['e2e_quality', ...tags],
       iterations: 1,
     };
@@ -198,7 +214,7 @@ function buildE2eQualityDataset(
  */
 export function buildEvalDataset(
   raw: unknown,
-  hostConfig: MCPHostConfig,
+  hostConfig: MCPHostConfig | undefined,
   manifest: EvalManifest
 ): EvalDataset {
   if (isPrebuiltDataset(raw)) {

--- a/src/evals/builtinDatasetSources.ts
+++ b/src/evals/builtinDatasetSources.ts
@@ -1,0 +1,45 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { z } from 'zod';
+import { registerDatasetSource } from './frameworkRegistries.js';
+import type { DatasetConfig } from './evalManifest.js';
+import type { DatasetSourceContext } from './evalFrameworkTypes.js';
+import { buildEvalDataset } from './buildEvalDataset.js';
+import type { EvalDataset } from './datasetTypes.js';
+
+const FileDatasetSchema = z
+  .object({
+    type: z.enum(['file', 'dir']),
+    path: z.string().min(1),
+    recursive: z.boolean().optional(),
+  })
+  .passthrough();
+
+async function loadFileDataset(
+  config: DatasetConfig,
+  context: DatasetSourceContext
+): Promise<EvalDataset> {
+  if (typeof config.path !== 'string') {
+    throw new Error(`Dataset source "${config.type}" requires a path.`);
+  }
+  const filePath = path.isAbsolute(config.path)
+    ? config.path
+    : path.resolve(context.rootDir, config.path);
+  const raw = JSON.parse(await fs.readFile(filePath, 'utf8')) as unknown;
+  return buildEvalDataset(raw, context.hostConfig, context.manifest);
+}
+
+let registered = false;
+
+/** Register the provider-neutral file and directory dataset sources. */
+export function registerBuiltinDatasetSources(): void {
+  if (registered) return;
+  for (const name of ['file', 'dir'] as const) {
+    registerDatasetSource({
+      name,
+      schema: FileDatasetSchema,
+      load: loadFileDataset,
+    });
+  }
+  registered = true;
+}

--- a/src/evals/builtinHosts.ts
+++ b/src/evals/builtinHosts.ts
@@ -5,6 +5,7 @@ import { z } from 'zod';
 import type { MCPConfig } from '../config/mcpConfig.js';
 import { getHost, registerHost } from './frameworkRegistries.js';
 import type { MCPHostConfig } from './mcpHost/mcpHostTypes.js';
+import { ANTHROPIC_API_HOST } from './anthropicApiHost.js';
 
 export interface BuiltinHostOptions {
   model?: string;
@@ -34,6 +35,7 @@ export function registerBuiltinHosts(): void {
       createConfig: (options) => factory(options ?? {}),
     });
   }
+  registerHost(ANTHROPIC_API_HOST);
   builtinsRegistered = true;
 }
 

--- a/src/evals/builtinHosts.ts
+++ b/src/evals/builtinHosts.ts
@@ -67,6 +67,9 @@ function vercelSdkHost(options: BuiltinHostOptions): MCPHostConfig {
 function claudeCliHost(options: BuiltinHostOptions): MCPHostConfig {
   const provider = options.provider ?? 'anthropic';
   if (provider === 'vertex') {
+    // Claude Code prefers ANTHROPIC_API_KEY even when Vertex is selected.
+    // Remove the conflicting direct key so the explicit provider wins.
+    delete process.env.ANTHROPIC_API_KEY;
     process.env.CLAUDE_CODE_USE_VERTEX = '1';
     if (process.env.GOOGLE_VERTEX_PROJECT) {
       process.env.ANTHROPIC_VERTEX_PROJECT_ID ??=
@@ -171,7 +174,9 @@ function claudeCliHost(options: BuiltinHostOptions): MCPHostConfig {
 
   return {
     hostType: 'cli',
-    provider: provider as MCPHostConfig['provider'],
+    provider: (provider === 'vertex'
+      ? 'vertex-anthropic'
+      : provider) as MCPHostConfig['provider'],
     mcpServers: mcpServers as Record<string, Record<string, unknown>>,
     model,
     cli: {

--- a/src/evals/evalFrameworkTypes.ts
+++ b/src/evals/evalFrameworkTypes.ts
@@ -17,6 +17,8 @@ import type { EvalResultStore } from './resultStore.js';
 export interface DatasetSourceContext {
   rootDir: string;
   manifest: EvalManifest;
+  /** Resolved built-in host config for legacy dataset normalization. */
+  hostConfig?: MCPHostConfig;
 }
 
 /** Public dataset-source extension point. */
@@ -89,6 +91,7 @@ export interface EvaluationSuiteOptions {
   rootDir?: string;
   pluginPaths?: string[];
   outputDir?: string;
+  secretsFile?: string;
   dryRun?: boolean;
   arm?: string;
 }
@@ -109,6 +112,13 @@ export interface EvaluationArmResult {
 }
 
 /** Stable summary shape written by a completed evaluation suite. */
+export interface RunTelemetry {
+  cases: number;
+  toolCalls: number;
+  failedCases: number;
+  totalHostUsage?: Partial<UsageMetrics>;
+}
+
 export interface RunSummary {
   schemaVersion: 1;
   manifestId: string;
@@ -118,6 +128,7 @@ export interface RunSummary {
   manifestName: string;
   arms: EvaluationArmResult[];
   metrics: Record<string, unknown>;
+  telemetry?: RunTelemetry;
   armDeltas: Record<string, Record<string, unknown>>;
   caseArtifactPointers?: Record<string, string[]>;
   results: EvalCaseResult[];

--- a/src/evals/evalManifest.ts
+++ b/src/evals/evalManifest.ts
@@ -55,6 +55,8 @@ export interface EvalManifest {
   timeout?: number;
   maxToolCalls?: number;
   tools?: string;
+  /** Require HTTP server URLs to use an explicit /eval endpoint. */
+  requireEvalEndpoint?: boolean;
   [key: string]: unknown;
 }
 
@@ -101,6 +103,7 @@ export const EvalManifestSchema = z
     timeout: z.number().int().positive().optional(),
     maxToolCalls: z.number().int().nonnegative().optional(),
     tools: z.string().optional(),
+    requireEvalEndpoint: z.boolean().optional(),
   })
   .passthrough();
 

--- a/src/evals/frameworkRegistries.ts
+++ b/src/evals/frameworkRegistries.ts
@@ -18,24 +18,48 @@ interface Registry<T extends NamedImplementation> {
   clear(): void;
 }
 
+interface RegistryState {
+  datasets: Map<string, NamedImplementation>;
+  hosts: Map<string, NamedImplementation>;
+  judges: Map<string, NamedImplementation>;
+  metrics: Map<string, NamedImplementation>;
+  resultStores: Map<string, NamedImplementation>;
+}
+
+const REGISTRY_STATE_KEY = Symbol.for(
+  'mcp-server-tester.framework-registry-state'
+);
+const globalRegistry = globalThis as unknown as Record<symbol, unknown>;
+const existingRegistryState = globalRegistry[REGISTRY_STATE_KEY] as
+  RegistryState | undefined;
+const registryState: RegistryState = existingRegistryState ?? {
+  datasets: new Map<string, NamedImplementation>(),
+  hosts: new Map<string, NamedImplementation>(),
+  judges: new Map<string, NamedImplementation>(),
+  metrics: new Map<string, NamedImplementation>(),
+  resultStores: new Map<string, NamedImplementation>(),
+};
+if (!existingRegistryState) globalRegistry[REGISTRY_STATE_KEY] = registryState;
+
 function createRegistry<T extends NamedImplementation>(
-  kind: string
+  kind: string,
+  implementations: Map<string, NamedImplementation>
 ): Registry<T> {
-  const implementations = new Map<string, T>();
+  const typedImplementations = implementations as Map<string, T>;
   return {
     register(implementation) {
-      const existing = implementations.get(implementation.name);
+      const existing = typedImplementations.get(implementation.name);
       if (existing && existing !== implementation) {
         throw new Error(
           `${kind} "${implementation.name}" is already registered.`
         );
       }
-      implementations.set(implementation.name, implementation);
+      typedImplementations.set(implementation.name, implementation);
     },
     get(name) {
-      const implementation = implementations.get(name);
+      const implementation = typedImplementations.get(name);
       if (!implementation) {
-        const available = [...implementations.keys()].sort().join(', ');
+        const available = [...typedImplementations.keys()].sort().join(', ');
         throw new Error(
           `${kind} "${name}" is not registered.${
             available ? ` Available: ${available}.` : ''
@@ -45,21 +69,30 @@ function createRegistry<T extends NamedImplementation>(
       return implementation;
     },
     list() {
-      return [...implementations.values()].sort((a, b) =>
+      return [...typedImplementations.values()].sort((a, b) =>
         a.name.localeCompare(b.name)
       );
     },
     clear() {
-      implementations.clear();
+      typedImplementations.clear();
     },
   };
 }
 
-const datasetSources = createRegistry<DatasetSource>('Dataset source');
-const hosts = createRegistry<HostDefinition>('Host');
-const judges = createRegistry<JudgeDefinition>('Judge');
-const metrics = createRegistry<MetricDefinition>('Metric');
-const resultStores = createRegistry<ResultStoreDefinition>('Result store');
+const datasetSources = createRegistry<DatasetSource>(
+  'Dataset source',
+  registryState.datasets
+);
+const hosts = createRegistry<HostDefinition>('Host', registryState.hosts);
+const judges = createRegistry<JudgeDefinition>('Judge', registryState.judges);
+const metrics = createRegistry<MetricDefinition>(
+  'Metric',
+  registryState.metrics
+);
+const resultStores = createRegistry<ResultStoreDefinition>(
+  'Result store',
+  registryState.resultStores
+);
 
 export const registerDatasetSource = (source: DatasetSource): void =>
   datasetSources.register(source);

--- a/src/evals/metrics.ts
+++ b/src/evals/metrics.ts
@@ -312,7 +312,21 @@ export const METRIC_REGISTRY: Record<string, MetricDefinition> = {
 };
 
 for (const definition of Object.values(BUILT_IN_METRICS)) {
-  registerFrameworkMetric(definition);
+  try {
+    registerFrameworkMetric(definition);
+  } catch (error) {
+    // A packaged CLI and a dynamically loaded plugin can each load this
+    // module. Built-ins are identical by name in that case, so keep the
+    // process-wide registry's first definition.
+    if (
+      !(error instanceof Error) ||
+      !error.message.includes(
+        `Metric "${definition.name}" is already registered`
+      )
+    ) {
+      throw error;
+    }
+  }
 }
 
 /** Register or replace a named metric for subsequent runs. */

--- a/src/evals/runEvalSuite.ts
+++ b/src/evals/runEvalSuite.ts
@@ -7,29 +7,41 @@ import {
 } from '../mcp/clientFactory.js';
 import { createMCPFixture } from '../mcp/fixtures/mcpFixture.js';
 import type { MCPConfig } from '../config/mcpConfig.js';
+import { isHttpConfig } from '../config/mcpConfig.js';
 import {
   loadEvalManifest,
   type DatasetConfig,
   type EvalArm,
   type EvalManifest,
+  type HostConfig,
 } from './evalManifest.js';
 import type {
   EvaluationArmResult,
   EvaluationSummary,
+  HostDefinition,
+  RunTelemetry,
 } from './evalFrameworkTypes.js';
-import { buildEvalDataset } from './buildEvalDataset.js';
-import { getBuiltinHostConfig } from './builtinHosts.js';
+import { registerBuiltinDatasetSources } from './builtinDatasetSources.js';
+import { registerBuiltinHosts } from './builtinHosts.js';
 import { runEvalDataset } from './evalRunner.js';
 import type { EvalRunnerResult } from './evalRunner.js';
+import type { EvalDataset } from './datasetTypes.js';
 import type { EvalCaseResult } from '../types/reporter.js';
 import type { UsageMetrics } from '../types/index.js';
 import { loadPlugins } from '../plugins/loadPlugins.js';
+import {
+  getDatasetSource,
+  getHost,
+  validateManifestRegistrations,
+} from './frameworkRegistries.js';
+import { computeMetrics, type MetricSpec } from './metrics.js';
 
 export interface RunEvalSuiteOptions {
   manifestPath: string;
   rootDir?: string;
   pluginPaths?: string[];
   outputDir?: string;
+  secretsFile?: string;
   mcpConfig?: MCPConfig;
   dryRun?: boolean;
   arm?: string;
@@ -40,10 +52,64 @@ export interface RunEvalSuiteResult {
   outputDir: string;
   datasets: Array<{
     source: DatasetConfig;
-    dataset?: ReturnType<typeof buildEvalDataset>;
+    dataset?: EvalDataset;
     result?: EvalRunnerResult;
   }>;
   summary: EvaluationSummary;
+}
+
+async function loadSecretsFile(secretsFile: string): Promise<void> {
+  const raw = await fs.readFile(secretsFile, 'utf8');
+  let entries: Record<string, unknown>;
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      throw new Error('Secrets JSON must contain an object.');
+    }
+    entries = parsed as Record<string, unknown>;
+  } catch {
+    entries = {};
+    for (const rawLine of raw.split(/\r?\n/)) {
+      const line = rawLine.trim();
+      if (!line || line.startsWith('#')) continue;
+      const equals = line.indexOf('=');
+      if (equals < 1) continue;
+      const key = line.slice(0, equals).trim();
+      const value = line
+        .slice(equals + 1)
+        .trim()
+        .replace(/^['"]|['"]$/g, '');
+      entries[key] = value;
+    }
+  }
+  for (const [key, value] of Object.entries(entries)) {
+    if (typeof value === 'string' && process.env[key] === undefined) {
+      process.env[key] = value;
+    }
+  }
+}
+
+function resolveServerSecrets(server: MCPConfig): MCPConfig {
+  if (!isHttpConfig(server) || !server.auth?.accessTokenEnv) return server;
+  const envName = server.auth.accessTokenEnv;
+  const token = process.env[envName];
+  if (!token) {
+    throw new Error(
+      `MCP access token environment variable "${envName}" is not set.`
+    );
+  }
+  const { accessTokenEnv: _accessTokenEnv, ...auth } = server.auth;
+  return { ...server, auth: { ...auth, accessToken: token } };
+}
+
+function assertEvalEndpoint(server: MCPConfig, manifest: EvalManifest): void {
+  if (!manifest.requireEvalEndpoint || !isHttpConfig(server)) return;
+  const pathname = new URL(server.serverUrl).pathname;
+  if (!/\/eval(?:\/|$)/.test(pathname)) {
+    throw new Error(
+      `Evaluation requires an /eval MCP endpoint; received "${server.serverUrl}".`
+    );
+  }
 }
 
 function manifestIdentity(manifest: EvalManifest): {
@@ -108,6 +174,28 @@ function resolveServer(
   return servers[0]!;
 }
 
+function resolveHost(
+  manifest: EvalManifest,
+  arm: EvalArm,
+  server: MCPConfig
+): {
+  definition: HostDefinition;
+  declaration: HostConfig;
+  config: ReturnType<HostDefinition['createConfig']>;
+} {
+  const declaration = arm.host ?? manifest.host ?? { type: 'claude-cli' };
+  const definition = getHost(declaration.type);
+  const config = definition.createConfig({
+    ...declaration,
+    model: manifest.model,
+    maxToolCalls: manifest.maxToolCalls,
+    timeout: manifest.timeout,
+    provider: manifest.provider,
+    server,
+  });
+  return { definition, declaration, config };
+}
+
 function sumUsage(
   a: Partial<UsageMetrics> | undefined,
   b: Partial<UsageMetrics>
@@ -129,6 +217,38 @@ function sumUsage(
     }
   }
   return result;
+}
+
+function countToolCalls(results: EvalCaseResult[]): number {
+  return results.reduce((count, result) => {
+    const response = result.response;
+    if (!response || typeof response !== 'object') return count;
+    const calls = (response as { toolCalls?: unknown }).toolCalls;
+    return count + (Array.isArray(calls) ? calls.length : 0);
+  }, 0);
+}
+
+function buildArmDeltas(
+  arms: EvaluationArmResult[]
+): Record<string, Record<string, unknown>> {
+  const baseline = arms[0]?.result;
+  if (!baseline || baseline.total === 0) return {};
+  const baselineRate = baseline.passed / baseline.total;
+  return Object.fromEntries(
+    arms.slice(1).map((arm) => {
+      const result = arm.result;
+      const passRate =
+        result && result.total > 0 ? result.passed / result.total : 0;
+      return [
+        arm.name,
+        {
+          passRate,
+          passRateDelta: passRate - baselineRate,
+          baseline: arms[0]?.name,
+        },
+      ];
+    })
+  );
 }
 
 function summarizeArm(
@@ -166,8 +286,17 @@ export async function runEvalSuite(
 ): Promise<RunEvalSuiteResult> {
   const rootDir = options.rootDir ?? process.cwd();
   const manifest = loadEvalManifest(options.manifestPath, { rootDir });
+  if (options.secretsFile) {
+    await loadSecretsFile(
+      path.isAbsolute(options.secretsFile)
+        ? options.secretsFile
+        : path.resolve(rootDir, options.secretsFile)
+    );
+  }
   applyManifestEnv(manifest);
 
+  registerBuiltinDatasetSources();
+  registerBuiltinHosts();
   const pluginPaths = options.pluginPaths ?? manifest.plugins ?? [];
   if (pluginPaths.length > 0) {
     await loadPlugins(
@@ -179,6 +308,7 @@ export async function runEvalSuite(
     );
   }
 
+  validateManifestRegistrations(manifest);
   const outputDir =
     options.outputDir ?? path.join(rootDir, '.mcp-test-results', manifest.name);
   const arms = selectedArms(manifest, options.arm);
@@ -213,65 +343,90 @@ export async function runEvalSuite(
 
   for (const arm of arms) {
     const server = resolveServer(manifest, arm, options.mcpConfig);
-    const client = await createMCPClientForConfig(server);
-    const mcp = createMCPFixture(client, undefined, { authType: 'api-token' });
-    const hostType = arm.host?.type ?? manifest.host?.type ?? 'claude-cli';
-    const hostConfig = getBuiltinHostConfig(hostType, {
-      model: manifest.model,
-      maxToolCalls: manifest.maxToolCalls,
-      timeout: manifest.timeout,
-      provider: manifest.provider,
-      server,
-    });
-    const armDatasetResults: Array<{
+    const resolvedServer = resolveServerSecrets(server);
+    assertEvalEndpoint(resolvedServer, manifest);
+    const host = resolveHost(manifest, arm, resolvedServer);
+    const sourceResults: Array<{
       name: string;
       result: EvalRunnerResult;
     }> = [];
+    const client = host.definition.run
+      ? undefined
+      : await createMCPClientForConfig(resolvedServer);
+    const mcp = client
+      ? createMCPFixture(client, undefined, { authType: 'api-token' })
+      : undefined;
 
     try {
       for (const source of datasets) {
-        if (source.type !== 'file' && source.type !== 'dir') {
-          throw new Error(
-            `Dataset source "${source.type}" is not registered in the built-in runner.`
-          );
-        }
-        const datasetPath = source.path;
-        if (typeof datasetPath !== 'string') {
-          throw new Error(`Dataset source "${source.type}" requires a path.`);
-        }
-        for (const filePath of await expandDatasetPath(
-          path.isAbsolute(datasetPath)
-            ? datasetPath
-            : path.resolve(rootDir, datasetPath)
-        )) {
-          const raw = JSON.parse(
-            await fs.readFile(filePath, 'utf8')
-          ) as unknown;
-          const dataset = buildEvalDataset(raw, hostConfig, manifest);
-          const result = await runEvalDataset(
-            {
-              dataset,
-              concurrency: manifest.concurrency ?? 1,
-              defaultLlmIterations: manifest.iterations || undefined,
-            },
-            { mcp }
-          );
-          allDatasets.push({ source, dataset, result });
-          armDatasetResults.push({ name: dataset.name, result });
+        const datasetPaths =
+          source.type === 'file' || source.type === 'dir'
+            ? await expandDatasetPath(
+                path.isAbsolute(String(source.path))
+                  ? String(source.path)
+                  : path.resolve(rootDir, String(source.path))
+              )
+            : [undefined];
+        for (const filePath of datasetPaths) {
+          const sourceConfig = filePath
+            ? { ...source, type: 'file', path: filePath }
+            : source;
+          const datasetSource = getDatasetSource(sourceConfig.type);
+          const dataset = await datasetSource.load(sourceConfig, {
+            rootDir,
+            manifest,
+            hostConfig: host.config,
+          });
+          const result = host.definition.run
+            ? await host.definition.run({
+                dataset,
+                cases: dataset.cases,
+                servers: [resolvedServer],
+                host: host.declaration,
+                manifest,
+                arm,
+              })
+            : await runEvalDataset(
+                {
+                  dataset,
+                  concurrency: manifest.concurrency ?? 1,
+                  defaultLlmIterations: manifest.iterations || undefined,
+                },
+                { mcp: mcp! }
+              );
+          allDatasets.push({ source: sourceConfig, dataset, result });
+          sourceResults.push({ name: dataset.name, result });
           allResults.push(...result.caseResults);
         }
       }
     } finally {
-      await closeMCPClient(client);
+      if (client) await closeMCPClient(client);
     }
 
-    armResults.push(summarizeArm(arm, server, armDatasetResults));
+    armResults.push(summarizeArm(arm, resolvedServer, sourceResults));
   }
 
   const durationMs = armResults.reduce(
     (sum, arm) => sum + (arm.result?.durationMs ?? 0),
     0
   );
+  const metricSpecs = [
+    ...(manifest.metrics ?? []),
+    ...arms.flatMap((arm) => arm.metrics ?? []),
+  ] as MetricSpec[];
+  const computedMetrics = metricSpecs.length
+    ? computeMetrics(metricSpecs, allResults).aggregated
+    : {};
+  let totalHostUsage: Partial<UsageMetrics> | undefined;
+  for (const arm of armResults) {
+    totalHostUsage = sumUsage(totalHostUsage, arm.result?.totalHostUsage ?? {});
+  }
+  const telemetry: RunTelemetry = {
+    cases: allResults.length,
+    toolCalls: countToolCalls(allResults),
+    failedCases: allResults.filter((result) => !result.pass).length,
+    totalHostUsage,
+  };
   const summary: EvaluationSummary = {
     schemaVersion: 1,
     ...identity,
@@ -288,8 +443,10 @@ export async function runEvalSuite(
           ? allResults.filter((result) => result.pass).length /
             allResults.length
           : 0,
+      ...computedMetrics,
     },
-    armDeltas: {},
+    telemetry,
+    armDeltas: buildArmDeltas(armResults),
     results: allResults,
   };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -272,6 +272,7 @@ export type {
   MetricValue,
   ResultStoreDefinition,
   RunSummary,
+  RunTelemetry,
   EvalSummaryGenerator,
 } from './evals/evalFrameworkTypes.js';
 export {


### PR DESCRIPTION
## Stack\n\nStacked on `chenhao/mcp-tester-06-quality`.\n\n## Scope\n\n- Dispatch manifests to runtime hosts.\n- Load runtime secrets for local and CI execution.\n- Add the direct Anthropic API host and endpoint enforcement.\n- Preserve CLI failure semantics for failed evaluations.\n\n## Validation\n\n- Validated locally against the Scio eval endpoint.