### PR TITLE
[Evals] Add core manifest-driven evaluation execution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,13 +18,14 @@ jobs:
 
       - run: npm run format:check
 
+      # Legacy examples resolve package self-imports through dist.
+      - run: npm run build
+
       - run: npm run typecheck
 
       - run: npm run lint
 
       - run: npm run docs:check
-
-      - run: npm run build
 
       - name: Public evaluation foundation contracts
         run: npm run test:eval-foundation

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -253,15 +253,18 @@ authType?: 'oauth' | 'api-token' | 'none';  // Don't do this!
 
 ## Pre-Push Checklist
 
-Before pushing commits or creating a PR, run all CI checks locally and fix any failures. These mirror the CI pipeline (`.github/workflows/ci.yml`) exactly:
+Before pushing commits or creating a PR, run all CI checks locally and fix any failures. These mirror the CI pipeline (`.github/workflows/ci.yml`) exactly. Build before typecheck and lint: legacy examples resolve package self-imports through `dist`.
 
 ```bash
 npm run format:check        # Prettier (run `npm run format` to auto-fix)
+npm run build               # Full build including UI reporter
 npm run typecheck           # TypeScript validation
 npm run lint                # ESLint (run `npm run lint:fix` to auto-fix)
 npm run docs:check          # Docs snippet sync
-npm run build               # Full build including UI reporter
+npm run test:eval-foundation # Public evaluation foundation contracts
 npm test                    # Unit tests (Vitest)
+npx playwright install --with-deps
+npm run test:playwright     # Integration tests (Playwright)
 ```
 
 If `format:check` or `lint` fails, run `npm run format` or `npm run lint:fix` to auto-fix, then re-check. If `docs:check` fails with "content-mismatch", update the snippet line range in the markdown file to match the current source.

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1159,7 +1159,7 @@ interface MCPConformanceResult {
 
 ### `EvalExpectBlock`
 
-```typescript snippet=src/evals/datasetTypes.ts#L198-L299
+```typescript snippet=src/evals/datasetTypes.ts#L199-L300
 /**
  * Unified expectation block for eval cases
  *
@@ -1266,7 +1266,7 @@ export interface EvalExpectBlock {
 
 ### `EvalCase`
 
-````typescript snippet=src/evals/datasetTypes.ts#L25-L152
+````typescript snippet=src/evals/datasetTypes.ts#L26-L153
 /**
  * A single eval test case
  *

--- a/docs/migrations/dataset-sources.md
+++ b/docs/migrations/dataset-sources.md
@@ -1,0 +1,117 @@
+# Migrating dataset sources to canonical EvalDataset
+
+Built-in `file`, `dir`, and `gcs` sources now accept **canonical EvalDataset JSON only**. They no longer infer tool-selection, tool-call, or quality evaluations from a first case, attach host configurations, or manufacture Glean judge assertions. `buildEvalDataset(raw, hostConfig, manifest)` retains its public signature, but the host argument is unused: it validates canonical data and applies `maxCases` after validating every case.
+
+## Preferred migration: canonical data
+
+A minimal direct dataset needs a name, a case ID, and a tool name. A mode, arguments, expectations, and a resolved host are not required for loading:
+
+```json
+{
+  "name": "search-regression",
+  "cases": [{ "id": "search", "toolName": "search" }]
+}
+```
+
+Keep assertions explicit when they matter. For example, translate a legacy `tool` field to `toolName` and retain `args` and `expect`. Translate `expected_tool` into an explicit host case with `expect.toolsTriggered`. Translate quality scenarios into host cases with `expect.passesJudge` and the correct reference and threshold for each judge.
+
+```json
+{
+  "name": "policy-quality",
+  "cases": [
+    {
+      "id": "policy",
+      "mode": "host",
+      "host": { "type": "my-host", "model": "case-model" },
+      "scenario": "What is our leave policy?",
+      "iterations": 3,
+      "accuracyThreshold": 0.8,
+      "expect": {
+        "passesJudge": {
+          "judge": "my-quality-judge",
+          "reference": "The expected policy answer",
+          "threshold": 0.75
+        }
+      }
+    }
+  ]
+}
+```
+
+Register `my-host` and `my-quality-judge` in your own plugin. Canonical ingestion preserves `direct`, `host`, `mcp_host`, and `external_host` modes, per-case host overrides, iterations, accuracy thresholds, and explicit assertions. Registered-host resolution and any manifest-wide judge policy belong to the suite, not the JSON reader.
+
+Use canonical data with any built-in source:
+
+```json
+{
+  "name": "canonical-sources",
+  "datasets": [
+    { "type": "file", "path": "datasets/search.json" },
+    { "type": "dir", "path": "datasets/canonical" },
+    { "type": "gcs", "uri": "gs://my-eval-bucket/datasets/quality.json" }
+  ]
+}
+```
+
+Directory declarations are expanded by the suite; each JSON entry undergoes the same canonical validation. GCS reads require the optional `@google-cloud/storage` package and Application Default Credentials with object-read access. Reading a dataset does not require a result store, uploader, or bucket-write permission.
+
+Noncanonical fields are rejected instead of silently discarded, including on later cases and cases beyond `maxCases`. A scenario without a host mode is not implicitly a quality evaluation. Fix the JSON or select an explicit source adapter when the error says `Expected a canonical EvalDataset`.
+
+## Transitional migration: opt-in `glean-legacy` plugin
+
+The copyable source adapter is in [examples/plugins/legacy-glean-datasets.ts](../../examples/plugins/legacy-glean-datasets.ts). It imports only the public `@gleanwork/mcp-server-tester` API, Node APIs, and Zod; it does not import internal files or the result uploader. The example is repository source, not a new package export or an automatically loaded built-in.
+
+1. Copy the module into your consumer repository, for example `plugins/legacy-glean-datasets.ts`.
+2. Compile it to ESM JavaScript with your existing TypeScript build (or run with a TypeScript-aware loader). Keep the package import external so the plugin uses the runner's installed framework.
+3. Load the compiled module using `manifest.plugins` or the CLI `--plugins` option. The loader calls the exported `register()` hook. Merely importing the module does not register it.
+4. Replace legacy built-in source declarations with `type: "glean-legacy"` and explicitly select both a format and a transport. Each source is one JSON object/file; expand a legacy directory into individual source declarations in the consumer.
+
+```json
+{
+  "name": "legacy-search",
+  "plugins": ["./plugins/legacy-glean-datasets.js"],
+  "host": { "type": "vercel-sdk", "provider": "anthropic" },
+  "iterations": 3,
+  "datasets": [
+    {
+      "type": "glean-legacy",
+      "format": "tool-selection",
+      "transport": { "type": "file", "path": "datasets/tool-selection.json" }
+    },
+    {
+      "type": "glean-legacy",
+      "format": "tool-call",
+      "transport": {
+        "type": "gcs",
+        "uri": "gs://my-eval-bucket/tool-call.json"
+      }
+    }
+  ]
+}
+```
+
+For quality datasets, use `format: "e2e-quality"`, load the organization judge implementation plugin as well, and list the selected judges in the manifest. The source adapter creates assertions; it does **not** implement or register the judges.
+
+### Preserved legacy policy
+
+- `tool-selection` requires `expected_tool` and `scenario` on every case. It produces MCP-host tool-trigger assertions and `mcp_host` / `tool_selection` tags. Iterations resolve as case override, manifest override, then 5; accuracy defaults to 1 for one iteration and 0.8 otherwise. Explicit case accuracy thresholds win.
+- `tool-call` requires `tool` on every case, renames it to `toolName`, preserves arguments and explicit expectations, and adds `tool_call` tags. With no expectations, it retains `isError: false` and `responseSize.minBytes: 50`. Explicit host-mode cases use the resolved host configuration and case/manifest iterations.
+- `e2e-quality` requires `scenario`, adds `e2e_quality` tags, and uses case/manifest iterations with a default of 1. Explicit accuracy thresholds are preserved.
+- Quality judge mappings remain `glean-completeness`, `glean-correctness`, `task-completion`, `glean-rate-limit`, and `glean-timeout`. Their default threshold is 0.5; an explicit manifest judge threshold overrides it. Completeness/completion/signal judges reference the scenario. Correctness requires a nonempty reference answer and receives the JSON string `{ "question": scenario, "answer": reference }`.
+- No judges are enabled implicitly. Unmapped manifest judges fail explicitly, including custom quality judges, rather than silently creating unjudged cases. Tool-selection and tool-call formats reject manifest judges whose policy they cannot map. Quality/selection cases carrying an `expect` block fail explicitly rather than lose those assertions: migrate them to canonical data. Tool-call cases preserve explicit custom `expect.passesJudge` assertions.
+- Scenario conversions require a resolved MCP host configuration. A custom host can expose `createConfig()` if it supports that contract; otherwise migrate to canonical `mode: "host"` cases rather than fabricating an SDK configuration.
+- No environment variable is read for iterations, and no cloud storage operation is an upload. GCS is optional and dynamically loaded only when selected.
+
+These defaults are organization policy owned by the adapter. Other organizations should supply their own `DatasetSource`, not add policy to core readers.
+
+## Scio integration checklist
+
+No Scio repository changes are included in this migration. In Scio's main integration:
+
+- Copy/build the example beside existing consumer-owned plugins and add its compiled path to the plugin list without dropping the judge implementation plugin.
+- Replace each legacy file/GCS declaration with `glean-legacy`, its known `format`, and a nested `transport`. Leave canonical sources on the built-in types. Expand directories before creating legacy source declarations.
+- Keep quality formats in manifests whose judges match the adapter policy. For custom judge semantics, prefer canonical assertions or extend the consumer's copy of the adapter explicitly; do not silently ignore a custom judge.
+- Retain existing GCS read credentials and install the optional storage dependency only where GCS input is used. Do not wire dataset reads through the result uploader.
+- Run local-file smoke evaluations with stub hosts/judges before enabling real host or cloud calls. Verify selection accuracy thresholds and quality judge references against the old fixtures.
+
+The focused tests in `src/evals/buildEvalDataset.test.ts`, `src/evals/builtinDatasetSources.test.ts`, and `src/evals/legacyGleanDatasetSource.test.ts` cover canonical loading, explicit rejection, file/GCS adaptation, thresholds, and quality judge execution. All GCS operations in these tests are mocked.

--- a/examples/plugins/legacy-glean-datasets.ts
+++ b/examples/plugins/legacy-glean-datasets.ts
@@ -1,0 +1,369 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { z } from 'zod';
+import {
+  loadEvalDatasetFromObject,
+  registerDatasetSource,
+  type DatasetSourceContext,
+  type EvalDataset,
+  type EvalManifest,
+  type ExtensionConfig,
+  type MCPHostConfig,
+} from '@gleanwork/mcp-server-tester';
+
+const LegacyCaseSchema = z
+  .object({
+    id: z.string().min(1),
+    description: z.string().optional(),
+    tags: z.array(z.string()).optional(),
+    scenario: z.string().min(1).optional(),
+    expected_tool: z.string().min(1).optional(),
+    tool: z.string().min(1).optional(),
+    reference: z.string().optional(),
+    iterations: z.number().int().positive().optional(),
+    accuracyThreshold: z.number().min(0).max(1).optional(),
+  })
+  .passthrough();
+const LegacyDatasetSchema = z.object({
+  name: z.string().min(1).optional(),
+  description: z.string().optional(),
+  cases: z.array(LegacyCaseSchema).min(1),
+});
+type RawEvalset = z.infer<typeof LegacyDatasetSchema>;
+export type LegacyFormat = 'tool-selection' | 'tool-call' | 'e2e-quality';
+
+// Transport and legacy policy are explicitly selected, never inferred from the
+// first case. This module can be copied to an organization's plugin directory.
+const LegacySourceSchema = z
+  .object({
+    type: z.literal('glean-legacy'),
+    format: z.enum(['tool-selection', 'tool-call', 'e2e-quality']),
+    transport: z.discriminatedUnion('type', [
+      z.object({ type: z.literal('file'), path: z.string().min(1) }).strict(),
+      z
+        .object({
+          type: z.literal('gcs'),
+          uri: z.string().regex(/^gs:\/\/[^/]+\/.+/),
+        })
+        .strict(),
+    ]),
+  })
+  .strict();
+
+function extensionName(extension: ExtensionConfig): string {
+  return extension.name ?? extension.type;
+}
+
+const LEGACY_QUALITY_JUDGES = new Set([
+  'glean-completeness',
+  'glean-correctness',
+  'task-completion',
+  'glean-rate-limit',
+  'glean-timeout',
+]);
+
+function enabledJudges(
+  manifest: EvalManifest,
+  source: string
+): Map<string, number> {
+  const judges = new Map(
+    (manifest.judges ?? []).map((judge) => [
+      extensionName(judge),
+      z
+        .number()
+        .min(0)
+        .max(1)
+        .parse(judge.threshold ?? 0.5),
+    ])
+  );
+  const unsupported = [...judges.keys()].filter(
+    (name) => source !== 'e2e-quality' || !LEGACY_QUALITY_JUDGES.has(name)
+  );
+  if (unsupported.length > 0) {
+    throw new Error(
+      `Legacy ${source} datasets cannot apply manifest judges: ${unsupported.join(', ')}. ` +
+        'Use canonical EvalDataset cases with expect.passesJudge or a custom dataset source.'
+    );
+  }
+  return judges;
+}
+
+function buildJudges(
+  scenario: string,
+  reference: string | undefined,
+  judges: Map<string, number>
+): Array<Record<string, unknown>> {
+  const result: Array<Record<string, unknown>> = [];
+  if (judges.has('glean-completeness')) {
+    result.push({
+      judge: 'glean-completeness',
+      reference: scenario,
+      threshold: 0.5,
+    });
+  }
+  if (judges.has('glean-correctness') && !reference) {
+    throw new Error(
+      'Legacy e2e-quality datasets require a reference for glean-correctness. ' +
+        'Use canonical EvalDataset cases with explicit expect.passesJudge to select judges per case.'
+    );
+  }
+  if (judges.has('glean-correctness')) {
+    result.push({
+      judge: 'glean-correctness',
+      reference: JSON.stringify({ question: scenario, answer: reference }),
+      threshold: 0.5,
+    });
+  }
+  if (judges.has('task-completion')) {
+    result.push({
+      judge: 'task-completion',
+      reference: scenario,
+      threshold: 0.5,
+    });
+  }
+  for (const signalJudge of ['glean-rate-limit', 'glean-timeout'] as const) {
+    if (judges.has(signalJudge)) {
+      result.push({ judge: signalJudge, reference: scenario, threshold: 0.5 });
+    }
+  }
+  return result.map((assertion) => ({
+    ...assertion,
+    threshold: judges.get(String(assertion.judge)),
+  }));
+}
+
+function requireHostConfig(
+  hostConfig: MCPHostConfig | undefined,
+  source: string
+): MCPHostConfig {
+  if (!hostConfig) {
+    throw new Error(
+      `Dataset source "${source}" requires a resolved host configuration.`
+    );
+  }
+  return hostConfig;
+}
+
+function buildToolSelectionDataset(
+  evalset: RawEvalset,
+  hostConfig: MCPHostConfig | undefined,
+  manifest: EvalManifest
+): EvalDataset {
+  enabledJudges(manifest, 'tool-selection');
+  const resolvedHostConfig = requireHostConfig(hostConfig, 'tool-selection');
+  const cases = evalset.cases.map((case_) => {
+    const iterations = case_.iterations ?? manifest.iterations ?? 5;
+    const expectedTool = String(case_.expected_tool);
+    const scenario = String(case_.scenario);
+    const tags = case_.tags ?? [];
+    return {
+      id: String(case_.id),
+      description:
+        typeof case_.description === 'string'
+          ? case_.description
+          : `Tool selection: should trigger ${expectedTool}`,
+      toolName: expectedTool,
+      mode: 'mcp_host' as const,
+      scenario,
+      mcpHostConfig: resolvedHostConfig,
+      tags: ['mcp_host', 'tool_selection', ...tags],
+      iterations,
+      accuracyThreshold:
+        case_.accuracyThreshold ?? (iterations === 1 ? 1.0 : 0.8),
+      expect: {
+        toolsTriggered: {
+          calls: [{ name: expectedTool, required: true }],
+        },
+      },
+    };
+  });
+
+  return loadEvalDatasetFromObject({
+    name: evalset.name ?? 'tool-selection',
+    description: evalset.description ?? 'Tool selection evaluation.',
+    cases,
+  });
+}
+
+function buildToolCallDataset(
+  evalset: RawEvalset,
+  hostConfig: MCPHostConfig | undefined,
+  manifest: EvalManifest
+): EvalDataset {
+  enabledJudges(manifest, 'tool-call');
+  const cases = evalset.cases.map((case_) => {
+    const tool = String(case_.tool);
+    const tags = case_.tags ?? [];
+    const fixtureCase: Record<string, unknown> = {
+      id: String(case_.id),
+      description:
+        typeof case_.description === 'string'
+          ? case_.description
+          : `Tool call: ${tool}`,
+      toolName: tool,
+      tags: ['tool_call', ...tags],
+      expect: case_.expect ?? {
+        isError: false,
+        responseSize: { minBytes: 50 },
+      },
+    };
+    if (case_.args !== undefined) fixtureCase.args = case_.args;
+    for (const key of [
+      'mode',
+      'scenario',
+      'iterations',
+      'accuracyThreshold',
+    ] as const) {
+      if (case_[key] !== undefined) fixtureCase[key] = case_[key];
+    }
+    if (case_.mode === 'mcp_host') {
+      fixtureCase.mcpHostConfig = requireHostConfig(hostConfig, 'tool-call');
+      fixtureCase.iterations = case_.iterations ?? manifest.iterations;
+    }
+    return fixtureCase;
+  });
+
+  return loadEvalDatasetFromObject({
+    name: evalset.name ?? 'tool-call',
+    description: evalset.description ?? 'Tool call evaluation.',
+    cases,
+  });
+}
+
+function buildE2eQualityDataset(
+  evalset: RawEvalset,
+  hostConfig: MCPHostConfig | undefined,
+  manifest: EvalManifest
+): EvalDataset {
+  const judges = enabledJudges(manifest, 'e2e-quality');
+  const resolvedHostConfig = requireHostConfig(hostConfig, 'e2e-quality');
+  const cases = evalset.cases.map((case_) => {
+    const scenario = String(case_.scenario);
+    const reference =
+      typeof case_.reference === 'string' ? case_.reference : undefined;
+    const tags = case_.tags ?? [];
+    const fixtureCase: Record<string, unknown> = {
+      id: String(case_.id),
+      description:
+        typeof case_.description === 'string'
+          ? case_.description
+          : `E2E quality: ${scenario.slice(0, 80)}`,
+      mode: 'mcp_host',
+      scenario,
+      mcpHostConfig: resolvedHostConfig,
+      tags: ['e2e_quality', ...tags],
+      iterations: case_.iterations ?? manifest.iterations ?? 1,
+      accuracyThreshold: case_.accuracyThreshold,
+    };
+    const judgeList = buildJudges(scenario, reference, judges);
+    if (judgeList.length > 0) fixtureCase.expect = { passesJudge: judgeList };
+    return fixtureCase;
+  });
+
+  const withRef = evalset.cases.filter((c) => c.reference).length;
+  return loadEvalDatasetFromObject({
+    name: evalset.name ?? 'e2e-quality',
+    description:
+      evalset.description ??
+      `E2E quality evaluation. ${cases.length} cases (${withRef} with correctness judge).`,
+    cases,
+  });
+}
+
+/** Explicit migration entry point; all organization policy lives in this adapter. */
+export function convertLegacyGleanDataset(
+  raw: unknown,
+  format: LegacyFormat,
+  hostConfig: MCPHostConfig | undefined,
+  manifest: EvalManifest
+): EvalDataset {
+  const evalset = LegacyDatasetSchema.parse(raw);
+  for (const case_ of evalset.cases) {
+    if (format !== 'tool-call' && case_.expect !== undefined) {
+      throw new Error(
+        `Legacy ${format} cannot apply case expect assertions. Use canonical EvalDataset with explicit expect.passesJudge instead.`
+      );
+    }
+    const required =
+      format === 'tool-selection'
+        ? ['expected_tool', 'scenario']
+        : format === 'tool-call'
+          ? ['tool']
+          : ['scenario'];
+    for (const key of required) {
+      if (typeof case_[key] !== 'string' || !case_[key]) {
+        throw new Error(`Legacy ${format} case "${case_.id}" requires ${key}.`);
+      }
+    }
+  }
+  let dataset: EvalDataset;
+  switch (format) {
+    case 'tool-selection':
+      dataset = buildToolSelectionDataset(evalset, hostConfig, manifest);
+      break;
+    case 'tool-call':
+      dataset = buildToolCallDataset(evalset, hostConfig, manifest);
+      break;
+    case 'e2e-quality':
+      dataset = buildE2eQualityDataset(evalset, hostConfig, manifest);
+      break;
+  }
+  return manifest.maxCases && dataset.cases.length > manifest.maxCases
+    ? { ...dataset, cases: dataset.cases.slice(0, manifest.maxCases) }
+    : dataset;
+}
+
+interface GCSStorage {
+  bucket(name: string): {
+    file(name: string): { download(): Promise<[Buffer]> };
+  };
+}
+
+/** Source-only JSON transport; deliberately unrelated to result upload/storage. */
+async function readLegacyJSON(
+  transport: z.infer<typeof LegacySourceSchema>['transport'],
+  context: DatasetSourceContext
+): Promise<unknown> {
+  if (transport.type === 'file') {
+    return JSON.parse(
+      await fs.readFile(path.resolve(context.rootDir, transport.path), 'utf8')
+    ) as unknown;
+  }
+  const match = /^gs:\/\/([^/]+)\/(.+)$/.exec(transport.uri)!;
+  let Storage: new () => GCSStorage;
+  try {
+    // Variable import keeps this copyable plugin independent of the optional
+    // package's type declarations. Only GCS users need to install it.
+    const packageName = '@google-cloud/storage';
+    ({ Storage } = (await import(packageName)) as {
+      Storage: new () => GCSStorage;
+    });
+  } catch (error) {
+    throw new Error(
+      'glean-legacy GCS transport requires the optional @google-cloud/storage package.',
+      { cause: error }
+    );
+  }
+  const [buffer] = await new Storage()
+    .bucket(match[1]!)
+    .file(match[2]!)
+    .download();
+  return JSON.parse(buffer.toString('utf8')) as unknown;
+}
+
+/** Plugin loader hook. Merely importing this example does not register it. */
+export function register(): void {
+  registerDatasetSource({
+    name: 'glean-legacy',
+    schema: LegacySourceSchema,
+    async load(config, context) {
+      const source = LegacySourceSchema.parse(config);
+      return convertLegacyGleanDataset(
+        await readLegacyJSON(source.transport, context),
+        source.format,
+        context.hostConfig,
+        context.manifest
+      );
+    },
+  });
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gleanwork/mcp-server-tester",
-  "version": "1.1.1",
+  "version": "1.2.0-dev.0",
   "description": "Playwright-based testing and evaluation framework for MCP servers",
   "keywords": [
     "playwright",

--- a/schema/eval-manifest.schema.json
+++ b/schema/eval-manifest.schema.json
@@ -173,6 +173,7 @@
               "type": "object",
               "properties": {
                 "accessToken": { "type": "string" },
+                "accessTokenEnv": { "type": "string", "minLength": 1 },
                 "oauth": {
                   "type": "object",
                   "properties": {

--- a/src/config/mcpConfig.ts
+++ b/src/config/mcpConfig.ts
@@ -77,6 +77,9 @@ export interface MCPAuthConfig {
    */
   accessToken?: string;
 
+  /** Environment variable containing the access token; resolved at runtime. */
+  accessTokenEnv?: string;
+
   /**
    * Full OAuth configuration for browser-based authentication
    */
@@ -311,9 +314,14 @@ const MCPClientCredentialsConfigSchema = z.object({
 const MCPAuthConfigSchema = z
   .object({
     accessToken: z.string().optional(),
+    accessTokenEnv: z.string().min(1).optional(),
     oauth: MCPOAuthConfigSchema.optional(),
     clientCredentials: MCPClientCredentialsConfigSchema.optional(),
   })
+  .refine(
+    (data) => !(data.accessToken && data.accessTokenEnv),
+    'Cannot specify both accessToken and accessTokenEnv'
+  )
   .refine(
     (data) => !(data.accessToken && data.oauth),
     'Cannot specify both accessToken and oauth configuration'

--- a/src/evals/buildEvalDataset.test.ts
+++ b/src/evals/buildEvalDataset.test.ts
@@ -117,6 +117,25 @@ describe('buildEvalDataset canonical ingestion', () => {
     ).toThrow(/at least one case/);
   });
 
+  it('applies tag selection before nested run.maxCases without changing source data', () => {
+    const raw = {
+      name: 'tagged',
+      cases: [
+        { id: 'skip', toolName: 'search', tags: ['other'] },
+        { id: 'keep', toolName: 'search', tags: ['wanted'] },
+        { id: 'limit', toolName: 'search', tags: ['wanted'] },
+      ],
+    };
+    expect(
+      buildEvalDataset(raw, undefined, {
+        ...manifest,
+        filterTags: ['wanted'],
+        run: { maxCases: 1 },
+      }).cases.map((entry) => entry.id)
+    ).toEqual(['keep']);
+    expect(raw.cases).toHaveLength(3);
+  });
+
   it('truncates validated canonical datasets to maxCases', () => {
     expect(
       buildEvalDataset(

--- a/src/evals/buildEvalDataset.test.ts
+++ b/src/evals/buildEvalDataset.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it } from 'vitest';
+import { buildEvalDataset } from './buildEvalDataset.js';
+import type { EvalManifest } from './evalManifest.js';
+
+const manifest: EvalManifest = {
+  name: 'test',
+  datasets: [{ type: 'file', path: 'x.json' }],
+};
+
+describe('buildEvalDataset canonical ingestion', () => {
+  it('accepts minimal direct cases without mode, args, expectations, or a host', () => {
+    const raw = { name: 'canonical', cases: [{ id: 'a', toolName: 'search' }] };
+    expect(buildEvalDataset(raw, undefined, manifest).cases).toEqual(raw.cases);
+  });
+
+  it.each([
+    { id: 'a', toolName: 'search', args: { query: 'policy' } },
+    { id: 'a', mode: 'direct', toolName: 'search', args: {} },
+    {
+      id: 'a',
+      mode: 'host',
+      scenario: 'Find policy',
+      host: { type: 'custom-host', option: true },
+    },
+    {
+      id: 'a',
+      mode: 'mcp_host',
+      scenario: 'Find policy',
+      mcpHostConfig: { provider: 'openai', model: 'case-model' },
+    },
+    {
+      id: 'a',
+      mode: 'external_host',
+      scenario: 'Find policy',
+      externalHost: { driver: 'custom-driver' },
+    },
+  ])('preserves canonical mode and case host override: $mode', (case_) => {
+    const dataset = buildEvalDataset(
+      {
+        name: 'canonical',
+        cases: [{ ...case_, iterations: 2, accuracyThreshold: 0.75 }],
+      },
+      { provider: 'anthropic', model: 'manifest-model' },
+      { ...manifest, iterations: 9, host: { type: 'different-host' } }
+    );
+    expect(dataset.cases[0]).toEqual({
+      ...case_,
+      iterations: 2,
+      accuracyThreshold: 0.75,
+    });
+  });
+
+  it('preserves explicit custom judge assertions without applying manifest policy', () => {
+    const case_ = {
+      id: 'a',
+      toolName: 'search',
+      expect: {
+        passesJudge: { judge: 'my-judge', reference: 'answer', threshold: 0.7 },
+      },
+    };
+    expect(
+      buildEvalDataset({ name: 'canonical', cases: [case_] }, undefined, {
+        ...manifest,
+        judges: [{ type: 'another-judge' }],
+      }).cases[0]
+    ).toEqual(case_);
+  });
+
+  it.each([
+    { id: 'a', scenario: 'find policy', expected_tool: 'search' },
+    { id: 'a', tool: 'search', expect: { isError: false } },
+    { id: 'a', scenario: 'find policy' },
+    {
+      id: 'a',
+      mode: 'mcp_host',
+      scenario: 'find policy',
+      expected_tool: 'search',
+    },
+    { id: 'a', toolName: 'search', tool: 'other' },
+  ])('rejects legacy inputs clearly without a source adapter: $id', (case_) => {
+    expect(() =>
+      buildEvalDataset({ name: 'legacy', cases: [case_] }, undefined, manifest)
+    ).toThrow(/canonical EvalDataset.*explicit dataset source adapter/);
+  });
+
+  it('validates every case, even after maxCases and a canonical first case', () => {
+    expect(() =>
+      buildEvalDataset(
+        {
+          name: 'mixed',
+          cases: [
+            { id: 'good', toolName: 'search' },
+            {
+              id: 'legacy',
+              mode: 'host',
+              scenario: 'Find policy',
+              expected_tool: 'search',
+            },
+          ],
+        },
+        undefined,
+        { ...manifest, maxCases: 1 }
+      )
+    ).toThrow(/expected_tool/);
+  });
+
+  it('reports invalid canonical cases and empty datasets', () => {
+    expect(() =>
+      buildEvalDataset(
+        { name: 'bad', cases: [{ id: 'a', toolName: 123 }] },
+        undefined,
+        manifest
+      )
+    ).toThrow(/toolName/);
+    expect(() =>
+      buildEvalDataset({ name: 'empty', cases: [] }, undefined, manifest)
+    ).toThrow(/at least one case/);
+  });
+
+  it('truncates validated canonical datasets to maxCases', () => {
+    expect(
+      buildEvalDataset(
+        {
+          name: 'canonical',
+          cases: [
+            { id: 'a', toolName: 'search' },
+            { id: 'b', toolName: 'search' },
+          ],
+        },
+        undefined,
+        { ...manifest, maxCases: 1 }
+      ).cases.map((case_) => case_.id)
+    ).toEqual(['a']);
+  });
+});

--- a/src/evals/buildEvalDataset.ts
+++ b/src/evals/buildEvalDataset.ts
@@ -7,6 +7,7 @@ import {
 import type { EvalManifest } from './evalManifest.js';
 import type { MCPHostConfig } from './mcpHost/mcpHostTypes.js';
 import { loadEvalDatasetFromObject } from './datasetLoader.js';
+import { normalizeSuiteControls } from './frameworkRegistries.js';
 
 // Source ingestion must not silently discard noncanonical fields. In particular,
 // dropping an assertion field can turn an intended failure into a passing case.
@@ -53,7 +54,23 @@ export function buildEvalDataset(
     );
   }
   const dataset = loadEvalDatasetFromObject(result.data);
-  return manifest.maxCases && dataset.cases.length > manifest.maxCases
-    ? { ...dataset, cases: dataset.cases.slice(0, manifest.maxCases) }
-    : dataset;
+  return selectEvalCases(dataset, manifest);
+}
+
+/** Apply the same tag selection and case cap to built-in and plugin datasets. */
+export function selectEvalCases(
+  dataset: EvalDataset,
+  manifest: EvalManifest
+): EvalDataset {
+  const controls = normalizeSuiteControls(manifest);
+  const tags = controls.filterTags as string[] | undefined;
+  const cases = tags?.length
+    ? dataset.cases.filter((evalCase) =>
+        evalCase.tags?.some((tag) => tags.includes(tag))
+      )
+    : dataset.cases;
+  return {
+    ...dataset,
+    cases: controls.maxCases ? cases.slice(0, controls.maxCases) : cases,
+  };
 }

--- a/src/evals/buildEvalDataset.ts
+++ b/src/evals/buildEvalDataset.ts
@@ -1,0 +1,59 @@
+import { z } from 'zod';
+import {
+  EvalCaseSchema,
+  EvalDatasetSchema,
+  type EvalDataset,
+} from './datasetTypes.js';
+import type { EvalManifest } from './evalManifest.js';
+import type { MCPHostConfig } from './mcpHost/mcpHostTypes.js';
+import { loadEvalDatasetFromObject } from './datasetLoader.js';
+
+// Source ingestion must not silently discard noncanonical fields. In particular,
+// dropping an assertion field can turn an intended failure into a passing case.
+const SourceDatasetSchema = EvalDatasetSchema.extend({
+  cases: z
+    .array(
+      EvalCaseSchema.strict().superRefine((case_, context) => {
+        if ((case_.mode ?? 'direct') === 'direct') {
+          if (!case_.toolName) {
+            context.addIssue({
+              code: 'custom',
+              path: ['toolName'],
+              message: 'Direct cases require toolName.',
+            });
+          }
+        } else if (!case_.scenario) {
+          context.addIssue({
+            code: 'custom',
+            path: ['scenario'],
+            message: 'Host cases require scenario.',
+          });
+        }
+      })
+    )
+    .min(1, 'dataset must have at least one case'),
+});
+
+/**
+ * Validate a canonical EvalDataset and apply the manifest case limit.
+ * The host argument is retained for API compatibility; sources never infer a
+ * mode, attach a host, or manufacture assertions. Use an opt-in dataset source
+ * adapter to migrate other formats before canonical validation.
+ */
+export function buildEvalDataset(
+  raw: unknown,
+  _hostConfig: MCPHostConfig | undefined,
+  manifest: EvalManifest
+): EvalDataset {
+  const result = SourceDatasetSchema.safeParse(raw);
+  if (!result.success) {
+    throw new Error(
+      'Expected a canonical EvalDataset. Noncanonical inputs require an explicit dataset source adapter. ' +
+        result.error.message
+    );
+  }
+  const dataset = loadEvalDatasetFromObject(result.data);
+  return manifest.maxCases && dataset.cases.length > manifest.maxCases
+    ? { ...dataset, cases: dataset.cases.slice(0, manifest.maxCases) }
+    : dataset;
+}

--- a/src/evals/builtinDatasetSources.ts
+++ b/src/evals/builtinDatasetSources.ts
@@ -1,0 +1,46 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { z } from 'zod';
+import { registerDatasetSource } from './frameworkRegistries.js';
+import type { DatasetConfig } from './evalManifest.js';
+import type { DatasetSourceContext } from './evalFrameworkTypes.js';
+import { buildEvalDataset } from './buildEvalDataset.js';
+import type { EvalDataset } from './datasetTypes.js';
+
+const FileDatasetSchema = z
+  .object({
+    type: z.enum(['file', 'dir']),
+    path: z.string().min(1),
+    recursive: z.boolean().optional(),
+  })
+  .passthrough();
+async function loadFileDataset(
+  config: DatasetConfig,
+  context: DatasetSourceContext
+): Promise<EvalDataset> {
+  const source = FileDatasetSchema.parse(config);
+  const filePath = path.isAbsolute(source.path)
+    ? source.path
+    : path.resolve(context.rootDir, source.path);
+  const raw = JSON.parse(await fs.readFile(filePath, 'utf8')) as unknown;
+  return buildEvalDataset(raw, context.hostConfig, context.manifest);
+}
+
+let registered = false;
+
+/**
+ * Register source-only file, directory-entry, and GCS readers. Every payload is
+ * validated as canonical EvalDataset JSON, regardless of its transport. The
+ * suite expands directory declarations into individual JSON file entries.
+ */
+export function registerBuiltinDatasetSources(): void {
+  if (registered) return;
+  for (const name of ['file', 'dir'] as const) {
+    registerDatasetSource({
+      name,
+      schema: FileDatasetSchema,
+      load: loadFileDataset,
+    });
+  }
+  registered = true;
+}

--- a/src/evals/builtinDatasetSources.ts
+++ b/src/evals/builtinDatasetSources.ts
@@ -14,6 +14,7 @@ const FileDatasetSchema = z
     recursive: z.boolean().optional(),
   })
   .passthrough();
+
 async function loadFileDataset(
   config: DatasetConfig,
   context: DatasetSourceContext
@@ -26,21 +27,78 @@ async function loadFileDataset(
   return buildEvalDataset(raw, context.hostConfig, context.manifest);
 }
 
+async function loadDirectoryDataset(
+  config: DatasetConfig,
+  context: DatasetSourceContext
+): Promise<EvalDataset> {
+  const source = FileDatasetSchema.parse(config);
+  const directory = path.resolve(context.rootDir, source.path);
+  if (!(await fs.stat(directory)).isDirectory()) {
+    return loadFileDataset(config, context);
+  }
+
+  async function collect(dir: string): Promise<string[]> {
+    const entries = (await fs.readdir(dir, { withFileTypes: true })).sort(
+      (a, b) => a.name.localeCompare(b.name)
+    );
+    const files: string[] = [];
+    for (const entry of entries) {
+      const entryPath = path.join(dir, entry.name);
+      if (entry.isDirectory() && source.recursive) {
+        files.push(...(await collect(entryPath)));
+      } else if (entry.isFile() && entry.name.endsWith('.json')) {
+        files.push(entryPath);
+      }
+    }
+    return files;
+  }
+
+  const files = await collect(directory);
+  if (files.length === 0) {
+    throw new Error(
+      `Dataset directory contains no JSON datasets: ${directory}`
+    );
+  }
+  const datasets = await Promise.all(
+    files.map((filePath) =>
+      loadFileDataset(
+        { type: 'file', path: filePath },
+        {
+          ...context,
+          manifest: {
+            ...context.manifest,
+            maxCases: undefined,
+            filterTags: undefined,
+            run: undefined,
+          },
+        }
+      )
+    )
+  );
+  return buildEvalDataset(
+    {
+      name: path.basename(directory),
+      cases: datasets.flatMap((dataset) => dataset.cases),
+    },
+    undefined,
+    context.manifest
+  );
+}
+
 let registered = false;
 
-/**
- * Register source-only file, directory-entry, and GCS readers. Every payload is
- * validated as canonical EvalDataset JSON, regardless of its transport. The
- * suite expands directory declarations into individual JSON file entries.
- */
+/** Register source-owned canonical file and recursive directory readers. */
 export function registerBuiltinDatasetSources(): void {
   if (registered) return;
-  for (const name of ['file', 'dir'] as const) {
-    registerDatasetSource({
-      name,
-      schema: FileDatasetSchema,
-      load: loadFileDataset,
-    });
-  }
+  registerDatasetSource({
+    name: 'file',
+    schema: FileDatasetSchema,
+    load: loadFileDataset,
+  });
+  registerDatasetSource({
+    name: 'dir',
+    schema: FileDatasetSchema,
+    load: loadDirectoryDataset,
+  });
   registered = true;
 }

--- a/src/evals/builtinHosts.cli.test.ts
+++ b/src/evals/builtinHosts.cli.test.ts
@@ -1,0 +1,250 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { spawn } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { registerBuiltinHosts } from './builtinHosts.js';
+import { getHost } from './frameworkRegistries.js';
+import type { HostRunContext } from './evalFrameworkTypes.js';
+
+let directory: string;
+beforeEach(() => {
+  registerBuiltinHosts();
+  directory = fs.mkdtempSync(path.join(os.tmpdir(), 'builtin-cli-test-'));
+  fs.writeFileSync(
+    path.join(directory, 'claude'),
+    `#!${process.execPath}
+console.log(JSON.stringify({ type: 'result', result: process.argv[process.argv.indexOf('--model') + 1] }));
+`,
+    { mode: 0o700 }
+  );
+});
+afterEach(() => {
+  vi.unstubAllEnvs();
+  fs.rmSync(directory, { recursive: true, force: true });
+});
+
+function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ESRCH') return false;
+    throw error;
+  }
+}
+
+describe('registered CLI host with a local process', () => {
+  it.each(['generated', 'legacy'] as const)(
+    'preserves environment precedence in an actual %s CLI command without mutation',
+    async (command) => {
+      vi.stubEnv('HOST_ENV_SHARED', 'ambient');
+      vi.stubEnv('HOST_ENV_REMOVED', 'ambient');
+      vi.stubEnv('MCP_PLUGIN_DIR', undefined);
+      fs.writeFileSync(
+        path.join(directory, 'claude'),
+        `#!${process.execPath}
+const keys = ['HOST_ENV_SHARED', 'HOST_ENV_HOST_WINS', 'HOST_ENV_SUITE_ONLY', 'HOST_ENV_REMOVED', 'CLAUDE_CODE_DISABLE_AUTO_MEMORY', 'CLAUDE_CODE_DISABLE_CLAUDE_MDS'];
+const env = Object.fromEntries(keys.map(key => [key, process.env[key] ?? null]));
+console.log(JSON.stringify({ type: 'result', result: JSON.stringify({ env, strict: process.argv.includes('--strict-mcp-config') }) }));
+`
+      );
+      const input = {
+        scenario: 'hello',
+        servers: [],
+        env: {
+          PATH: directory,
+          HOST_ENV_SHARED: 'suite',
+          HOST_ENV_HOST_WINS: 'suite',
+          HOST_ENV_SUITE_ONLY: 'suite-only',
+        },
+      };
+      const host = {
+        type: 'claude-cli',
+        env: {
+          HOST_ENV_SHARED: 'host',
+          HOST_ENV_HOST_WINS: 'host',
+          HOST_ENV_REMOVED: undefined,
+          CLAUDE_CODE_DISABLE_AUTO_MEMORY: '0',
+        },
+      };
+      const context: HostRunContext = {
+        manifest: { name: 'offline', datasets: [] },
+        env: { HOST_ENV_SHARED: 'context' },
+        mcpHostConfig: {
+          env: {
+            HOST_ENV_SHARED: 'case',
+            CLAUDE_CODE_DISABLE_CLAUDE_MDS: '0',
+          },
+          ...(command === 'legacy'
+            ? {
+                cli: {
+                  command: path.join(directory, 'claude'),
+                  args: [],
+                  outputFormat: 'stream-json',
+                  env: { HOST_ENV_SHARED: 'cli-case' },
+                },
+              }
+            : {}),
+        },
+      };
+      const before = structuredClone({ input, host, context });
+      const result = await getHost('claude-cli').run!(input, host, context);
+      expect(result.error).toBeUndefined();
+      const observed: {
+        env: Record<string, string | null>;
+        strict: boolean;
+      } = JSON.parse(result.finalText ?? '');
+      expect(observed.env).toMatchObject({
+        HOST_ENV_SHARED: command === 'legacy' ? 'cli-case' : 'case',
+        HOST_ENV_HOST_WINS: 'host',
+        HOST_ENV_SUITE_ONLY: 'suite-only',
+        HOST_ENV_REMOVED: null,
+      });
+      if (command === 'generated') {
+        expect(observed.strict).toBe(true);
+        expect(observed.env).toMatchObject({
+          CLAUDE_CODE_DISABLE_AUTO_MEMORY: '1',
+          CLAUDE_CODE_DISABLE_CLAUDE_MDS: '1',
+        });
+      }
+      expect({ input, host, context }).toEqual(before);
+      expect(process.env.HOST_ENV_SHARED).toBe('ambient');
+      expect(process.env.HOST_ENV_REMOVED).toBe('ambient');
+    }
+  );
+
+  it('bounds the CLI lifecycle, removes its config and stops only its owned child', async () => {
+    const marker = path.join(directory, 'child.json');
+    fs.writeFileSync(
+      path.join(directory, 'claude'),
+      `#!${process.execPath}
+const fs = require('node:fs');
+const config = process.argv[process.argv.indexOf('--mcp-config') + 1];
+fs.writeFileSync(${JSON.stringify(marker)}, JSON.stringify({ pid: process.pid, config, configExists: fs.existsSync(config) }));
+process.on('SIGTERM', () => {});
+setTimeout(() => process.exit(0), 5000);
+`,
+      { mode: 0o700 }
+    );
+    const unrelated = spawn(
+      process.execPath,
+      ['-e', 'setTimeout(() => {}, 5000)'],
+      { stdio: 'ignore' }
+    );
+    let ownedPid: number | undefined;
+    try {
+      const pending = getHost('claude-cli').run!(
+        { scenario: 'hello', servers: [], env: { PATH: directory } },
+        { type: 'claude-cli', timeout: 1000 },
+        { manifest: { name: 'offline', datasets: [] } }
+      );
+      await vi.waitFor(() => expect(fs.existsSync(marker)).toBe(true));
+      const child = JSON.parse(fs.readFileSync(marker, 'utf8')) as {
+        pid: number;
+        config: string;
+        configExists: boolean;
+      };
+      ownedPid = child.pid;
+      expect(child.configExists).toBe(true);
+      const result = await pending;
+      expect(result.error).toContain('timed out');
+      expect(fs.existsSync(child.config)).toBe(false);
+      await vi.waitFor(() => expect(isProcessAlive(child.pid)).toBe(false), {
+        timeout: 500,
+      });
+      expect(unrelated.pid).toBeDefined();
+      expect(isProcessAlive(unrelated.pid!)).toBe(true);
+    } finally {
+      unrelated.kill('SIGKILL');
+      if (ownedPid && isProcessAlive(ownedPid))
+        process.kill(ownedPid, 'SIGKILL');
+    }
+  });
+
+  it('keeps the supplied host deadline when legacy CLI arguments replace the generated config', async () => {
+    const pending = getHost('claude-cli').run!(
+      { scenario: 'hello', servers: [] },
+      { type: 'claude-cli', timeout: 50 },
+      {
+        manifest: { name: 'offline', datasets: [] },
+        mcpHostConfig: {
+          cli: {
+            command: process.execPath,
+            args: [
+              '-e',
+              'setTimeout(() => console.log(JSON.stringify({ success: true, toolCalls: [], response: "late" })), 150)',
+            ],
+            outputFormat: 'json',
+            timeout: 1000,
+          },
+        },
+      }
+    );
+    expect((await pending).error).toContain('timed out');
+  });
+
+  it('retains an immediate legacy CLI timeout of zero', async () => {
+    const result = await getHost('claude-cli').run!(
+      { scenario: 'hello', servers: [] },
+      { type: 'claude-cli' },
+      {
+        manifest: { name: 'offline', datasets: [] },
+        mcpHostConfig: {
+          cli: { command: process.execPath, args: [], timeout: 0 },
+        },
+      }
+    );
+    expect(result.error).toContain('timed out after 0 ms');
+  });
+
+  it.each([{ temperature: 0.4 }, { maxTokens: 123 }, { maxToolCalls: 0 }])(
+    'explicitly rejects unsupported legacy CLI generation settings %j',
+    async (mcpHostConfig) => {
+      await expect(
+        getHost('claude-cli').run!(
+          { scenario: 'hello', servers: [] },
+          { type: 'claude-cli' },
+          { manifest: { name: 'offline', datasets: [] }, mcpHostConfig }
+        )
+      ).rejects.toThrow();
+    }
+  );
+
+  it('applies the legacy case model before constructing generated CLI arguments', async () => {
+    const result = await getHost('claude-cli').run!(
+      { scenario: 'hello', servers: [], env: { PATH: directory } },
+      { type: 'claude-cli', model: 'suite-model' },
+      {
+        manifest: { name: 'offline', datasets: [] },
+        mcpHostConfig: { model: 'legacy-model' },
+      }
+    );
+    expect(result.error).toBeUndefined();
+    expect(result.finalText).toBe('legacy-model');
+  });
+
+  it('preserves explicit legacy command arguments instead of rewriting them', async () => {
+    const result = await getHost('claude-cli').run!(
+      { scenario: 'hello', servers: [] },
+      { type: 'claude-cli', model: 'suite-model' },
+      {
+        manifest: { name: 'offline', datasets: [] },
+        mcpHostConfig: {
+          model: 'legacy-model',
+          cli: {
+            command: process.execPath,
+            args: [
+              '-e',
+              'console.log(JSON.stringify({ success: true, toolCalls: [], response: process.argv[1] }))',
+              '{{scenario}}',
+            ],
+            outputFormat: 'json',
+          },
+        },
+      }
+    );
+    expect(result.error).toBeUndefined();
+    expect(result.finalText).toBe('hello');
+  });
+});

--- a/src/evals/builtinHosts.execution.test.ts
+++ b/src/evals/builtinHosts.execution.test.ts
@@ -1,0 +1,148 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import fs from 'node:fs';
+import { z } from 'zod';
+import {
+  createMCPClientForConfig,
+  closeMCPClient,
+} from '../mcp/clientFactory.js';
+import { simulateMCPHost } from './mcpHost/mcpHostSimulation.js';
+import { registerBuiltinHosts, getBuiltinHostConfig } from './builtinHosts.js';
+import { getHost } from './frameworkRegistries.js';
+import type { HostRunOptions, HostDefinition } from './evalFrameworkTypes.js';
+import { hostTraceToExecution } from './hostTrace.js';
+async function run(host: HostDefinition, options: HostRunOptions) {
+  const trace = await host.run!(
+    { scenario: options.cases[0]!.scenario!, servers: options.servers },
+    options.host,
+    {
+      manifest: options.manifest,
+      arm: options.arm,
+      mcpHostConfig: options.cases[0]?.mcpHostConfig,
+    }
+  );
+  return hostTraceToExecution(trace, host.evidence ?? 'none', options.servers);
+}
+vi.mock('../mcp/clientFactory.js', () => ({
+  createMCPClientForConfig: vi.fn(),
+  closeMCPClient: vi.fn(async () => {}),
+}));
+vi.mock('./mcpHost/mcpHostSimulation.js', () => ({ simulateMCPHost: vi.fn() }));
+const case_ = {
+  id: 'one',
+  scenario: 'Find documents',
+  mode: 'mcp_host' as const,
+};
+function options(): HostRunOptions {
+  return {
+    dataset: { name: 'test', cases: [case_] },
+    cases: [case_],
+    servers: [{ transport: 'http', serverUrl: 'https://example.com' }],
+    host: { type: 'vercel-sdk', model: 'selected' },
+    manifest: { name: 'test', datasets: [] },
+  };
+}
+beforeEach(() => {
+  vi.clearAllMocks();
+  registerBuiltinHosts();
+  vi.mocked(createMCPClientForConfig).mockResolvedValue({
+    listTools: vi.fn(async () => ({
+      tools: [
+        {
+          name: 'search',
+          description: 'original',
+          inputSchema: { type: 'object' },
+        },
+      ],
+    })),
+  } as unknown as Awaited<ReturnType<typeof createMCPClientForConfig>>);
+  vi.mocked(simulateMCPHost).mockResolvedValue({
+    success: true,
+    response: 'OK',
+    toolCalls: [],
+  });
+});
+afterEach(() => vi.unstubAllEnvs());
+describe('built-in host execution', () => {
+  it('exposes different descriptions to SDK arms and retains the selected model', async () => {
+    const descriptions: string[] = [];
+    vi.mocked(simulateMCPHost).mockImplementation(
+      async (mcp, _scenario, config) => {
+        descriptions.push((await mcp.listTools())[0]!.description!);
+        expect(config.model).toBe('selected');
+        return { success: true, response: 'OK', toolCalls: [] };
+      }
+    );
+    const host = getHost('vercel-sdk');
+    await run(host, options());
+    await run(host, {
+      ...options(),
+      arm: {
+        name: 'variant',
+        toolOverrides: {
+          id: 'changed',
+          tools: { search: { description: 'variant description' } },
+        },
+      },
+    });
+    expect(descriptions).toEqual(['original', 'variant description']);
+    expect(closeMCPClient).toHaveBeenCalledTimes(2);
+  });
+  it('allows zero servers and exposes all servers with labels in SDK execution', async () => {
+    vi.mocked(simulateMCPHost).mockImplementation(async (mcp) => ({
+      success: true,
+      response: (await mcp.listTools()).map((tool) => tool.name).join(','),
+      toolCalls: [],
+    }));
+    const host = getHost('vercel-sdk');
+    expect(
+      (await run(host, { ...options(), servers: [] })).response
+    ).toMatchObject({ response: '' });
+    expect(
+      (
+        await run(host, {
+          ...options(),
+          servers: ['a', 'b'].map((label) => ({
+            transport: 'http',
+            label,
+            serverUrl: 'https://example.com',
+          })),
+        })
+      ).response
+    ).toMatchObject({ response: 'a.search,b.search' });
+  });
+  it('keeps provider configuration in child env and removes its temporary credential file', async () => {
+    vi.stubEnv('ANTHROPIC_API_KEY', 'do-not-change');
+    vi.stubEnv('CLAUDE_CODE_USE_VERTEX', 'original');
+    const config = getBuiltinHostConfig('claude-cli', { provider: 'vertex' });
+    expect(config.cli?.env?.ANTHROPIC_API_KEY).toBeUndefined();
+    expect(process.env.ANTHROPIC_API_KEY).toBe('do-not-change');
+    expect(process.env.CLAUDE_CODE_USE_VERTEX).toBe('original');
+    let file = '';
+    vi.mocked(simulateMCPHost).mockImplementation(
+      async (_mcp, _scenario, cfg) => {
+        file = cfg.cli!.args[cfg.cli!.args.indexOf('--mcp-config') + 1]!;
+        const content: unknown = JSON.parse(fs.readFileSync(file, 'utf8'));
+        expect(
+          z
+            .object({
+              mcpServers: z.object({ first: z.unknown(), second: z.unknown() }),
+            })
+            .safeParse(content).success
+        ).toBe(true);
+        expect(fs.statSync(file).mode & 0o777).toBe(0o600);
+        return { success: true, toolCalls: [] };
+      }
+    );
+    await run(getHost('claude-cli'), {
+      ...options(),
+      host: { type: 'claude-cli' },
+      servers: ['first', 'second'].map((label) => ({
+        transport: 'http',
+        label,
+        serverUrl: 'https://example.com',
+      })),
+    });
+    expect(fs.existsSync(file)).toBe(false);
+    expect(createMCPClientForConfig).not.toHaveBeenCalled();
+  });
+});

--- a/src/evals/builtinHosts.lifecycle.test.ts
+++ b/src/evals/builtinHosts.lifecycle.test.ts
@@ -8,9 +8,23 @@ import { MockLanguageModelV3 } from 'ai/test';
 import { registerBuiltinHosts } from './builtinHosts.js';
 import { getHost } from './frameworkRegistries.js';
 
-// Only the model provider is fake. Hosts create and close real local MCP clients.
-const mocks = vi.hoisted(() => ({ provider: vi.fn() }));
+// The model provider is fake; the AI SDK and host cancellation path are real.
+// A barrier before simulation models setup time without HTTP under fake timers.
+const mocks = vi.hoisted(() => ({
+  provider: vi.fn(),
+  beforeSimulation: vi.fn<() => Promise<void>>(),
+}));
 vi.mock('@ai-sdk/openai', () => ({ createOpenAI: mocks.provider }));
+vi.mock(import('./mcpHost/mcpHostSimulation.js'), async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    async simulateMCPHost(...args: Parameters<typeof actual.simulateMCPHost>) {
+      await mocks.beforeSimulation();
+      return actual.simulateMCPHost(...args);
+    },
+  };
+});
 const answer = {
   content: [{ type: 'text' as const, text: 'done' }],
   finishReason: { unified: 'stop' as const, raw: 'stop' },
@@ -21,12 +35,11 @@ const answer = {
   warnings: [],
 };
 let model: MockLanguageModelV3;
-let server: http.Server;
+let server: http.Server | undefined;
 let serverUrl: string;
 let initialize: http.ServerResponse | undefined;
 let deletion: http.ServerResponse | undefined;
 let initializeId: unknown;
-let onInitialize: (() => void) | undefined;
 let holdInitialize: boolean;
 let holdDelete: boolean;
 let deleteAborted: boolean;
@@ -61,19 +74,16 @@ function run(timeout: number) {
   );
 }
 
-beforeEach(async () => {
-  registerBuiltinHosts();
-  vi.stubEnv('HTTP_PROXY', undefined);
-  vi.stubEnv('HTTPS_PROXY', undefined);
-  holdInitialize = false;
-  holdDelete = false;
-  deleteAborted = false;
-  initialize = undefined;
-  onInitialize = undefined;
-  deletion = undefined;
-  model = new MockLanguageModelV3({ doGenerate: answer });
-  mocks.provider.mockReturnValue(() => model);
-  server = http.createServer((request, response) => {
+function barrier() {
+  let release!: () => void;
+  const promise = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  return { promise, release };
+}
+
+async function startServer() {
+  const localServer = http.createServer((request, response) => {
     if (request.method === 'DELETE') {
       deletion = response;
       response.on('close', () => {
@@ -95,7 +105,6 @@ beforeEach(async () => {
       if (message.method === 'initialize') {
         initialize = response;
         initializeId = message.id;
-        onInitialize?.();
         if (!holdInitialize) releaseInitialize();
       } else if (message.id !== undefined) {
         response.writeHead(200, { 'Content-Type': 'application/json' }).end(
@@ -108,23 +117,45 @@ beforeEach(async () => {
       } else response.writeHead(202).end();
     });
   });
-  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
-  const address = server.address();
+  server = localServer;
+  await new Promise<void>((resolve) =>
+    localServer.listen(0, '127.0.0.1', resolve)
+  );
+  const address = localServer.address();
   if (!address || typeof address === 'string')
     throw new Error('No test server address');
   serverUrl = `http://127.0.0.1:${address.port}/mcp`;
+}
+
+beforeEach(() => {
+  registerBuiltinHosts();
+  vi.stubEnv('HTTP_PROXY', undefined);
+  vi.stubEnv('HTTPS_PROXY', undefined);
+  holdInitialize = false;
+  holdDelete = false;
+  deleteAborted = false;
+  initialize = undefined;
+  deletion = undefined;
+  server = undefined;
+  model = new MockLanguageModelV3({ doGenerate: answer });
+  mocks.provider.mockReturnValue(() => model);
+  mocks.beforeSimulation.mockReset().mockResolvedValue(undefined);
 });
 afterEach(async () => {
   vi.useRealTimers();
   releaseInitialize();
   deletion?.end();
-  server.closeAllConnections();
-  await new Promise<void>((resolve) => server.close(() => resolve()));
+  const localServer = server;
+  if (localServer) {
+    localServer.closeAllConnections();
+    await new Promise<void>((resolve) => localServer.close(() => resolve()));
+  }
   vi.unstubAllEnvs();
 });
 
 describe('registered SDK owned lifecycle deadline', () => {
   it('bounds delayed connection setup without starting model execution', async () => {
+    await startServer();
     holdInitialize = true;
     const pending = run(50);
     await vi.waitFor(() => expect(initialize).toBeDefined());
@@ -138,47 +169,75 @@ describe('registered SDK owned lifecycle deadline', () => {
   });
 
   it('uses the remaining lifecycle budget for model execution and aborts it at the deadline', async () => {
-    holdInitialize = true;
-    const initializeStarted = new Promise<void>((resolve) => {
-      onInitialize = resolve;
+    const setupStarted = barrier();
+    const setupReleased = barrier();
+    const modelStarted = barrier();
+    const modelReleased = barrier();
+    let modelAborted = false;
+    mocks.beforeSimulation.mockImplementationOnce(async () => {
+      setupStarted.release();
+      await setupReleased.promise;
     });
-    const modelStarted = new Promise<void>((resolve) => {
-      model = new MockLanguageModelV3({
-        doGenerate: async () => {
-          resolve();
-          return new Promise(() => {});
-        },
-      });
+    model = new MockLanguageModelV3({
+      doGenerate: async ({ abortSignal }) => {
+        function onAbort() {
+          modelAborted = true;
+          modelReleased.release();
+        }
+        abortSignal?.addEventListener('abort', onAbort, { once: true });
+        modelStarted.release();
+        try {
+          await modelReleased.promise;
+          abortSignal?.throwIfAborted();
+          return answer;
+        } finally {
+          abortSignal?.removeEventListener('abort', onAbort);
+        }
+      },
     });
     vi.useFakeTimers({ toFake: ['Date', 'setTimeout', 'clearTimeout'] });
     const startedAt = Date.now();
     let settled = false;
-    const pending = run(200).finally(() => {
+    // No HTTP fixture or MCP clients: only promises, imports and the real AI SDK.
+    const pending = getHost('vercel-sdk').run!(
+      { scenario: 'hello', servers: [] },
+      { type: 'vercel-sdk', provider: 'openai', timeout: 200 },
+      { manifest: { name: 'offline', datasets: [] } }
+    ).finally(() => {
       settled = true;
     });
 
-    // Wait for real HTTP/import readiness without advancing the fake clock.
-    await initializeStarted;
-    expect(model.doGenerateCalls).toHaveLength(0);
-    await vi.advanceTimersByTimeAsync(75);
-    releaseInitialize();
-    await modelStarted;
-    expect(Date.now() - startedAt).toBe(75);
-    expect(model.doGenerateCalls).toHaveLength(1);
-    const signal = model.doGenerateCalls[0]?.abortSignal;
+    try {
+      await setupStarted.promise;
+      expect(model.doGenerateCalls).toHaveLength(0);
+      await vi.advanceTimersByTimeAsync(75);
+      setupReleased.release();
+      await modelStarted.promise;
+      expect(Date.now() - startedAt).toBe(75);
+      expect(model.doGenerateCalls).toHaveLength(1);
+      const signal = model.doGenerateCalls[0]?.abortSignal;
 
-    // Setup consumed 75 ms, leaving only 125 ms for model execution.
-    await vi.advanceTimersByTimeAsync(124);
-    expect(settled).toBe(false);
-    expect(signal?.aborted).toBe(false);
-    await vi.advanceTimersByTimeAsync(1);
-    const result = await pending;
-    expect(Date.now() - startedAt).toBe(200);
-    expect(result.error).toContain('timed out');
-    expect(signal?.aborted).toBe(true);
+      // The adapter starts at t=75. Its own fresh timeout would expire at t=275,
+      // so only the propagated host signal can stop the model at t=200.
+      await vi.advanceTimersByTimeAsync(124);
+      expect(settled).toBe(false);
+      expect(signal?.aborted).toBe(false);
+      expect(modelAborted).toBe(false);
+      await vi.advanceTimersByTimeAsync(1);
+      const result = await pending;
+      expect(Date.now() - startedAt).toBe(200);
+      expect(result.error).toContain('timed out');
+      expect(signal?.aborted).toBe(true);
+      expect(modelAborted).toBe(true);
+      expect(model.doGenerateCalls).toHaveLength(1);
+    } finally {
+      setupReleased.release();
+      modelReleased.release();
+    }
   });
 
   it('bounds stalled session teardown and aborts its owned HTTP request', async () => {
+    await startServer();
     holdDelete = true;
     const pending = run(200);
     await vi.waitFor(() => expect(deletion).toBeDefined());

--- a/src/evals/builtinHosts.lifecycle.test.ts
+++ b/src/evals/builtinHosts.lifecycle.test.ts
@@ -1,0 +1,237 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import http from 'node:http';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { setTimeout as delay } from 'node:timers/promises';
+import { MockLanguageModelV3 } from 'ai/test';
+import { registerBuiltinHosts } from './builtinHosts.js';
+import { getHost } from './frameworkRegistries.js';
+
+// Only the model provider is fake. Hosts create and close real local MCP clients.
+const mocks = vi.hoisted(() => ({ provider: vi.fn() }));
+vi.mock('@ai-sdk/openai', () => ({ createOpenAI: mocks.provider }));
+const answer = {
+  content: [{ type: 'text' as const, text: 'done' }],
+  finishReason: { unified: 'stop' as const, raw: 'stop' },
+  usage: {
+    inputTokens: { total: 2, noCache: 2, cacheRead: 0, cacheWrite: 0 },
+    outputTokens: { total: 3, text: 3, reasoning: 0 },
+  },
+  warnings: [],
+};
+let model: MockLanguageModelV3;
+let server: http.Server;
+let serverUrl: string;
+let initialize: http.ServerResponse | undefined;
+let deletion: http.ServerResponse | undefined;
+let initializeId: unknown;
+let onInitialize: (() => void) | undefined;
+let holdInitialize: boolean;
+let holdDelete: boolean;
+let deleteAborted: boolean;
+
+function releaseInitialize() {
+  if (!initialize || initialize.writableEnded) return;
+  initialize
+    .writeHead(200, {
+      'Content-Type': 'application/json',
+      'Mcp-Session-Id': 'local-session',
+    })
+    .end(
+      JSON.stringify({
+        jsonrpc: '2.0',
+        id: initializeId,
+        result: {
+          protocolVersion: '2025-03-26',
+          capabilities: { tools: {} },
+          serverInfo: { name: 'local', version: '1' },
+        },
+      })
+    );
+}
+function run(timeout: number) {
+  return getHost('vercel-sdk').run!(
+    {
+      scenario: 'hello',
+      servers: [{ transport: 'http', serverUrl, label: 'local' }],
+    },
+    { type: 'vercel-sdk', provider: 'openai', timeout },
+    { manifest: { name: 'offline', datasets: [] } }
+  );
+}
+
+beforeEach(async () => {
+  registerBuiltinHosts();
+  vi.stubEnv('HTTP_PROXY', undefined);
+  vi.stubEnv('HTTPS_PROXY', undefined);
+  holdInitialize = false;
+  holdDelete = false;
+  deleteAborted = false;
+  initialize = undefined;
+  onInitialize = undefined;
+  deletion = undefined;
+  model = new MockLanguageModelV3({ doGenerate: answer });
+  mocks.provider.mockReturnValue(() => model);
+  server = http.createServer((request, response) => {
+    if (request.method === 'DELETE') {
+      deletion = response;
+      response.on('close', () => {
+        deleteAborted = !response.writableEnded;
+      });
+      if (!holdDelete) response.writeHead(200).end();
+      return;
+    }
+    if (request.method !== 'POST') {
+      response.writeHead(405).end();
+      return;
+    }
+    let body = '';
+    request.on('data', (chunk: Buffer) => {
+      body += chunk.toString();
+    });
+    request.on('end', () => {
+      const message = JSON.parse(body) as { id?: unknown; method: string };
+      if (message.method === 'initialize') {
+        initialize = response;
+        initializeId = message.id;
+        onInitialize?.();
+        if (!holdInitialize) releaseInitialize();
+      } else if (message.id !== undefined) {
+        response.writeHead(200, { 'Content-Type': 'application/json' }).end(
+          JSON.stringify({
+            jsonrpc: '2.0',
+            id: message.id,
+            result: { tools: [] },
+          })
+        );
+      } else response.writeHead(202).end();
+    });
+  });
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const address = server.address();
+  if (!address || typeof address === 'string')
+    throw new Error('No test server address');
+  serverUrl = `http://127.0.0.1:${address.port}/mcp`;
+});
+afterEach(async () => {
+  vi.useRealTimers();
+  releaseInitialize();
+  deletion?.end();
+  server.closeAllConnections();
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+  vi.unstubAllEnvs();
+});
+
+describe('registered SDK owned lifecycle deadline', () => {
+  it('bounds delayed connection setup without starting model execution', async () => {
+    holdInitialize = true;
+    const pending = run(50);
+    await vi.waitFor(() => expect(initialize).toBeDefined());
+    const bounded = await Promise.race([pending, delay(150).then(() => null)]);
+    releaseInitialize();
+    await pending;
+    expect(bounded?.error).toContain('timed out');
+    expect(model.doGenerateCalls).toHaveLength(0);
+    // Allow late connection cleanup to settle before closing the HTTP fixture.
+    await delay(50);
+  });
+
+  it('uses the remaining lifecycle budget for model execution and aborts it at the deadline', async () => {
+    holdInitialize = true;
+    const initializeStarted = new Promise<void>((resolve) => {
+      onInitialize = resolve;
+    });
+    const modelStarted = new Promise<void>((resolve) => {
+      model = new MockLanguageModelV3({
+        doGenerate: async () => {
+          resolve();
+          return new Promise(() => {});
+        },
+      });
+    });
+    vi.useFakeTimers({ toFake: ['Date', 'setTimeout', 'clearTimeout'] });
+    const startedAt = Date.now();
+    let settled = false;
+    const pending = run(200).finally(() => {
+      settled = true;
+    });
+
+    // Wait for real HTTP/import readiness without advancing the fake clock.
+    await initializeStarted;
+    expect(model.doGenerateCalls).toHaveLength(0);
+    await vi.advanceTimersByTimeAsync(75);
+    releaseInitialize();
+    await modelStarted;
+    expect(Date.now() - startedAt).toBe(75);
+    expect(model.doGenerateCalls).toHaveLength(1);
+    const signal = model.doGenerateCalls[0]?.abortSignal;
+
+    // Setup consumed 75 ms, leaving only 125 ms for model execution.
+    await vi.advanceTimersByTimeAsync(124);
+    expect(settled).toBe(false);
+    expect(signal?.aborted).toBe(false);
+    await vi.advanceTimersByTimeAsync(1);
+    const result = await pending;
+    expect(Date.now() - startedAt).toBe(200);
+    expect(result.error).toContain('timed out');
+    expect(signal?.aborted).toBe(true);
+  });
+
+  it('bounds stalled session teardown and aborts its owned HTTP request', async () => {
+    holdDelete = true;
+    const pending = run(200);
+    await vi.waitFor(() => expect(deletion).toBeDefined());
+    const bounded = await Promise.race([pending, delay(350).then(() => null)]);
+    // Release on failure too, so this regression never leaves a hung test run.
+    if (!bounded) deletion?.end();
+    await pending;
+    expect(bounded?.error).toContain('timed out');
+    await vi.waitFor(() => expect(deleteAborted).toBe(true));
+  });
+
+  it('closes a real stdio connection that finishes startup after the deadline', async () => {
+    const directory = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'builtin-mcp-test-')
+    );
+    const closed = path.join(directory, 'closed');
+    const script = `
+      const fs = require('node:fs');
+      const readline = require('node:readline');
+      const lines = readline.createInterface({ input: process.stdin });
+      process.stdin.on('end', () => { fs.writeFileSync(${JSON.stringify(closed)}, 'closed'); process.exit(0); });
+      lines.on('line', line => {
+        const message = JSON.parse(line);
+        if (message.method === 'initialize') setTimeout(() => console.log(JSON.stringify({
+          jsonrpc: '2.0', id: message.id,
+          result: { protocolVersion: '2025-03-26', capabilities: { tools: {} }, serverInfo: { name: 'local', version: '1' } }
+        })), 150);
+        else if (message.id !== undefined) console.log(JSON.stringify({ jsonrpc: '2.0', id: message.id, result: { tools: [] } }));
+      });
+      setTimeout(() => process.exit(0), 3000);
+    `;
+    try {
+      const result = await getHost('vercel-sdk').run!(
+        {
+          scenario: 'hello',
+          servers: [
+            {
+              transport: 'stdio',
+              command: process.execPath,
+              args: ['-e', script],
+            },
+          ],
+        },
+        { type: 'vercel-sdk', provider: 'openai', timeout: 50 },
+        { manifest: { name: 'offline', datasets: [] } }
+      );
+      expect(result.error).toContain('timed out');
+      await vi.waitFor(() => expect(fs.existsSync(closed)).toBe(true), {
+        timeout: 2000,
+      });
+      expect(model.doGenerateCalls).toHaveLength(0);
+    } finally {
+      fs.rmSync(directory, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/evals/builtinHosts.offline.test.ts
+++ b/src/evals/builtinHosts.offline.test.ts
@@ -68,6 +68,7 @@ beforeEach(() => {
 });
 afterEach(() => {
   vi.useRealTimers();
+  vi.unstubAllEnvs();
 });
 
 describe('registered SDK host through the real AI SDK', () => {
@@ -99,6 +100,11 @@ describe('registered SDK host through the real AI SDK', () => {
     expect(model.doGenerateCalls[0]?.abortSignal?.aborted).toBe(true);
     expect(vi.getTimerCount()).toBe(0);
   });
+  it('clears the lifecycle timer after successful execution', async () => {
+    vi.useFakeTimers();
+    expect((await run({ timeout: 1000 })).finalText).toBe('done');
+    expect(vi.getTimerCount()).toBe(0);
+  });
   it('uses execution-local credentials and does not mutate process.env', async () => {
     const before = process.env.OPENAI_API_KEY;
     await run({}, [], undefined, { OPENAI_API_KEY: 'run-only' });
@@ -107,6 +113,38 @@ describe('registered SDK host through the real AI SDK', () => {
     );
     expect(process.env.OPENAI_API_KEY).toBe(before);
   });
+  it.each(['host', 'case'] as const)(
+    'uses explicit %s credentials ahead of suite environment at the SDK provider boundary',
+    async (precedence) => {
+      vi.stubEnv('OPENAI_API_KEY', 'ambient');
+      registerBuiltinHosts();
+      const input = {
+        scenario: 'hello',
+        servers: [],
+        env: { OPENAI_API_KEY: 'suite' },
+      };
+      const host = {
+        type: 'vercel-sdk',
+        provider: 'openai',
+        env: { OPENAI_API_KEY: 'host' },
+      };
+      const context = {
+        manifest: { name: 'offline', datasets: [] },
+        env: { OPENAI_API_KEY: 'context' },
+        mcpHostConfig:
+          precedence === 'case' ? { env: { OPENAI_API_KEY: 'case' } } : {},
+      };
+      const before = structuredClone({ input, host, context });
+      const result = await getHost('vercel-sdk').run!(input, host, context);
+      expect(result.error).toBeUndefined();
+      expect(result.finalText).toBe('done');
+      expect(mocks.provider).toHaveBeenCalledWith(
+        expect.objectContaining({ apiKey: precedence })
+      );
+      expect({ input, host, context }).toEqual(before);
+      expect(process.env.OPENAI_API_KEY).toBe('ambient');
+    }
+  );
   it('applies server-qualified overrides before encoding provider names', async () => {
     const servers: MCPConfig[] = ['a', 'b'].map((label) => ({
       transport: 'http',
@@ -213,6 +251,8 @@ describe('CLI connection policy preflight', () => {
     }
   );
   it('uses runtime environment for CLI provider configuration without mutation', () => {
+    vi.stubEnv('ANTHROPIC_VERTEX_PROJECT_ID', undefined);
+    vi.stubEnv('GOOGLE_VERTEX_PROJECT', 'ambient-project');
     const before = process.env.GOOGLE_VERTEX_PROJECT;
     const config = getBuiltinHostConfig('claude-cli', {
       provider: 'vertex',

--- a/src/evals/builtinHosts.offline.test.ts
+++ b/src/evals/builtinHosts.offline.test.ts
@@ -1,0 +1,247 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { MockLanguageModelV3 } from 'ai/test';
+import { getBuiltinHostConfig, registerBuiltinHosts } from './builtinHosts.js';
+import { getHost } from './frameworkRegistries.js';
+import { createMCPClientForConfig } from '../mcp/clientFactory.js';
+import type { MCPConfig } from '../config/mcpConfig.js';
+import type { HostRunInput } from './evalFrameworkTypes.js';
+
+// Keep real ai.generateText + schema conversion; only the provider and transport are offline.
+const mocks = vi.hoisted(() => ({ model: vi.fn(), provider: vi.fn() }));
+vi.mock('@ai-sdk/openai', () => ({ createOpenAI: mocks.provider }));
+vi.mock('../mcp/clientFactory.js', () => ({
+  createMCPClientForConfig: vi.fn(),
+  closeMCPClient: vi.fn(async () => {}),
+}));
+const usage = {
+  inputTokens: { total: 2, noCache: 2, cacheRead: 0, cacheWrite: 0 },
+  outputTokens: { total: 3, text: 3, reasoning: 0 },
+};
+const answer = {
+  content: [{ type: 'text' as const, text: 'done' }],
+  finishReason: { unified: 'stop' as const, raw: 'stop' },
+  usage,
+  warnings: [],
+};
+let model: MockLanguageModelV3;
+const callTool = vi.fn(async () => ({
+  content: [{ type: 'text', text: 'found' }],
+}));
+function run(
+  config: Record<string, unknown> = {},
+  servers: MCPConfig[] = [],
+  toolOverrides?: {
+    id: string;
+    tools: Record<string, { description: string }>;
+  },
+  env?: Record<string, string | undefined>
+) {
+  registerBuiltinHosts();
+  const input: HostRunInput & { env?: Record<string, string | undefined> } = {
+    scenario: 'search',
+    servers,
+    env,
+  };
+  return getHost('vercel-sdk').run!(
+    input,
+    { type: 'vercel-sdk', provider: 'openai', ...config },
+    { manifest: { name: 'offline', datasets: [], toolOverrides } }
+  );
+}
+beforeEach(() => {
+  vi.clearAllMocks();
+  model = new MockLanguageModelV3({ doGenerate: answer });
+  mocks.model.mockImplementation(() => model);
+  mocks.provider.mockReturnValue(mocks.model);
+  vi.mocked(createMCPClientForConfig).mockResolvedValue({
+    listTools: vi.fn(async () => ({
+      tools: [
+        {
+          name: 'search',
+          description: 'original',
+          inputSchema: { type: 'object', properties: {} },
+        },
+      ],
+    })),
+    callTool,
+  } as unknown as Awaited<ReturnType<typeof createMCPClientForConfig>>);
+});
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('registered SDK host through the real AI SDK', () => {
+  it('forwards model, temperature, output token budget and a live deadline signal', async () => {
+    const result = await run({
+      model: 'case-model',
+      temperature: 0.4,
+      maxTokens: 123,
+      timeout: 5000,
+    });
+    expect(result.error).toBeUndefined();
+    expect(result.finalText).toBe('done');
+    expect(mocks.model).toHaveBeenCalledWith('case-model');
+    expect(model.doGenerateCalls[0]).toMatchObject({
+      temperature: 0.4,
+      maxOutputTokens: 123,
+    });
+    expect(model.doGenerateCalls[0]?.abortSignal).toBeInstanceOf(AbortSignal);
+    expect(result.usage).toMatchObject({ inputTokens: 2, outputTokens: 3 });
+  });
+  it('enforces timeout even when the model ignores cancellation', async () => {
+    vi.useFakeTimers();
+    model = new MockLanguageModelV3({
+      doGenerate: async () => new Promise(() => {}),
+    });
+    const pending = run({ timeout: 10 });
+    await vi.advanceTimersByTimeAsync(11);
+    expect((await pending).error).toContain('timed out');
+    expect(model.doGenerateCalls[0]?.abortSignal?.aborted).toBe(true);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+  it('uses execution-local credentials and does not mutate process.env', async () => {
+    const before = process.env.OPENAI_API_KEY;
+    await run({}, [], undefined, { OPENAI_API_KEY: 'run-only' });
+    expect(mocks.provider).toHaveBeenCalledWith(
+      expect.objectContaining({ apiKey: 'run-only' })
+    );
+    expect(process.env.OPENAI_API_KEY).toBe(before);
+  });
+  it('applies server-qualified overrides before encoding provider names', async () => {
+    const servers: MCPConfig[] = ['a', 'b'].map((label) => ({
+      transport: 'http',
+      serverUrl: `https://${label}.invalid`,
+      label,
+    }));
+    await run({}, servers, {
+      id: 'variant',
+      tools: { 'a.search': { description: 'changed' } },
+    });
+    expect(model.doGenerateCalls[0]?.tools).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ name: 'a__search', description: 'changed' }),
+        expect.objectContaining({ name: 'b__search', description: 'original' }),
+      ])
+    );
+    const ambiguous = await run({}, servers, {
+      id: 'bad',
+      tools: { search: { description: 'changed' } },
+    });
+    expect(ambiguous.error).toContain('Ambiguous tool override');
+  });
+  it('routes provider-encoded tool calls back to the original MCP name', async () => {
+    model = new MockLanguageModelV3({
+      doGenerate: async () =>
+        model.doGenerateCalls.length === 1
+          ? {
+              ...answer,
+              content: [
+                {
+                  type: 'tool-call',
+                  toolCallId: 'one',
+                  toolName: 'a__search',
+                  input: '{}',
+                },
+              ],
+              finishReason: { unified: 'tool-calls', raw: 'tool_use' },
+            }
+          : answer,
+    });
+    const result = await run(
+      {},
+      ['a', 'b'].map((label) => ({
+        transport: 'http',
+        serverUrl: `https://${label}.invalid`,
+        label,
+      }))
+    );
+    expect(result.error).toBeUndefined();
+    expect(callTool).toHaveBeenCalledWith({ name: 'search', arguments: {} });
+    expect(result.events).toMatchObject([
+      { source: 'mcp', server: 'a', name: 'search' },
+    ]);
+  });
+  it('enforces zero calls even if the real SDK receives a tool request', async () => {
+    model = new MockLanguageModelV3({
+      doGenerate: {
+        ...answer,
+        content: [
+          {
+            type: 'tool-call',
+            toolCallId: 'one',
+            toolName: 'search',
+            input: '{}',
+          },
+        ],
+        finishReason: { unified: 'tool-calls', raw: 'tool_use' },
+      },
+    });
+    const result = await run({ maxToolCalls: 0 }, [
+      { transport: 'http', serverUrl: 'https://test.invalid' },
+    ]);
+    expect(result.error).toContain('budget exhausted');
+    expect(callTool).not.toHaveBeenCalled();
+  });
+  it.each([
+    { timeout: 0 },
+    { maxTokens: 0 },
+    { temperature: 2 },
+    { maxToolCalls: -1 },
+    { unsupported: true },
+  ])('rejects invalid host options %j before execution', async (config) => {
+    await expect(run(config)).rejects.toThrow();
+    expect(mocks.model).not.toHaveBeenCalled();
+  });
+});
+
+describe('CLI connection policy preflight', () => {
+  it.each([
+    { auth: { clientCredentials: { tokenEndpoint: 'https://auth.invalid' } } },
+    { tls: { cert: '/cert.pem', key: '/key.pem' } },
+    { proxy: { url: 'http://proxy.invalid' } },
+    { retryAttempts: 2 },
+  ])(
+    'rejects unsupported HTTP policy before config generation: %j',
+    (policy) => {
+      expect(() =>
+        getBuiltinHostConfig('claude-cli', {
+          servers: [
+            { transport: 'http', serverUrl: 'https://test.invalid', ...policy },
+          ],
+        })
+      ).toThrow('cannot forward connection policy');
+    }
+  );
+  it('uses runtime environment for CLI provider configuration without mutation', () => {
+    const before = process.env.GOOGLE_VERTEX_PROJECT;
+    const config = getBuiltinHostConfig('claude-cli', {
+      provider: 'vertex',
+      env: { GOOGLE_VERTEX_PROJECT: 'run-project' },
+    });
+    expect(config.cli?.env?.ANTHROPIC_VERTEX_PROJECT_ID).toBe('run-project');
+    expect(config.cli?.env?.ANTHROPIC_API_KEY).toBeUndefined();
+    expect(process.env.GOOGLE_VERTEX_PROJECT).toBe(before);
+  });
+  it('serializes supported static token and headers', () => {
+    const config = getBuiltinHostConfig('claude-cli', {
+      servers: [
+        {
+          transport: 'http',
+          label: 'a',
+          serverUrl: 'https://test.invalid',
+          auth: { accessToken: 'token' },
+          headers: { 'X-Test': 'yes' },
+        },
+      ],
+    });
+    expect(config.mcpServers?.a).toMatchObject({
+      headers: { Authorization: 'Bearer token', 'X-Test': 'yes' },
+    });
+  });
+  it.each([{ maxTokens: 100 }, { temperature: 0.2 }, { maxToolCalls: 0 }])(
+    'explicitly rejects unsupported CLI generation policy %j',
+    (config) => {
+      expect(() => getBuiltinHostConfig('claude-cli', config)).toThrow();
+    }
+  );
+});

--- a/src/evals/builtinHosts.ts
+++ b/src/evals/builtinHosts.ts
@@ -2,13 +2,19 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { z } from 'zod';
-import type { MCPConfig } from '../config/mcpConfig.js';
+import { MCPConfigSchema, type MCPConfig } from '../config/mcpConfig.js';
+import {
+  GenerationOptions,
+  ProviderSchema,
+  hostEnvironment,
+  overrideHostTools,
+  type HostEnvironment,
+} from './mcpHost/hostOptions.js';
 import {
   createMCPClientForConfig,
   closeMCPClient,
 } from '../mcp/clientFactory.js';
 import type { MCPFixtureApi } from '../mcp/fixtures/mcpFixture.js';
-import { createToolOverrideMCP } from './evalRunner.js';
 import { simulateMCPHost } from './mcpHost/mcpHostSimulation.js';
 import type {
   HostRunInput,
@@ -26,6 +32,10 @@ async function runBuiltinHost(
   context: HostRunContext,
   factory: (options: BuiltinHostOptions) => MCPHostConfig
 ): Promise<HostRunResult> {
+  const env = hostEnvironment(
+    input as HostRunInput & { env?: HostEnvironment },
+    context as HostRunContext & { env?: HostEnvironment }
+  );
   const options = { ...input, host, ...context };
   const case_ = {
     scenario: input.scenario,
@@ -33,8 +43,9 @@ async function runBuiltinHost(
   };
   if (!input.scenario) throw new Error('Hosts require a scenario.');
   const config = {
-    ...factory({ ...options.host, servers: options.servers }),
+    ...factory({ ...options.host, servers: options.servers, env }),
     ...case_.mcpHostConfig,
+    env,
   };
   const clients: Array<Awaited<ReturnType<typeof createMCPClientForConfig>>> =
     [];
@@ -49,6 +60,8 @@ async function runBuiltinHost(
       string,
       { client: (typeof clients)[number]; name: string }
     >();
+    const overrides =
+      options.arm?.toolOverrides ?? options.manifest.toolOverrides;
     const mcp: MCPFixtureApi = {
       get client() {
         if (!clients[0]) throw new Error('No MCP client for this host.');
@@ -66,10 +79,15 @@ async function runBuiltinHost(
                 ? `${options.servers[index]!.label}.${tool.name}`
                 : tool.name;
             routes.set(name, { client, name: tool.name });
-            tools.push({ ...tool, name });
+            tools.push({ ...tool, server: options.servers[index]!.label });
           }
         }
-        return tools;
+        return overrideHostTools(tools, overrides).map(
+          ({ server, ...tool }) => ({
+            ...tool,
+            name: clients.length > 1 ? `${server}.${tool.name}` : tool.name,
+          })
+        );
       },
       async callTool(name, args) {
         if (!routes.size) await this.listTools();
@@ -91,17 +109,11 @@ async function runBuiltinHost(
         config.cli.args[position + 1] = file;
       }
     }
-    const overrides =
-      options.arm?.toolOverrides ?? options.manifest.toolOverrides;
     if (overrides && config.hostType === 'cli')
       throw new Error(
         'CLI description overrides require a host plugin that exposes overridden tools.'
       );
-    const response = await simulateMCPHost(
-      overrides ? createToolOverrideMCP(mcp, overrides) : mcp,
-      case_.scenario,
-      config
-    );
+    const response = await simulateMCPHost(mcp, case_.scenario, config);
     return simulationToHostTrace(response, input.servers);
   } finally {
     await Promise.allSettled(clients.map(closeMCPClient));
@@ -110,6 +122,10 @@ async function runBuiltinHost(
 }
 
 export interface BuiltinHostOptions {
+  env?: HostEnvironment;
+  temperature?: number;
+  maxTokens?: number;
+  apiKeyEnvVar?: string;
   model?: string;
   maxToolCalls?: number;
   timeout?: number;
@@ -126,7 +142,31 @@ export interface BuiltinHostOptions {
  * Built-in client host configs. Organization-specific plugin wiring stays
  * outside the framework and is provided through generic plugin options.
  */
-const BuiltinHostSchema = z.object({}).passthrough();
+const SdkHostSchema = z
+  .object({
+    type: z.literal('vercel-sdk').optional(),
+    ...GenerationOptions,
+    provider: ProviderSchema.optional(),
+    apiKeyEnvVar: z.string().min(1).optional(),
+    env: z.record(z.string(), z.string().optional()).optional(),
+    server: MCPConfigSchema.optional(),
+    servers: z.array(MCPConfigSchema).optional(),
+  })
+  .strict();
+const CliHostSchema = z
+  .object({
+    type: z.literal('claude-cli').optional(),
+    model: GenerationOptions.model,
+    timeout: GenerationOptions.timeout,
+    provider: z.enum(['anthropic', 'vertex', 'vertex-anthropic']).optional(),
+    apiToken: z.string().optional(),
+    pluginDir: z.string().optional(),
+    pluginMcpUrl: z.string().optional(),
+    env: z.record(z.string(), z.string().optional()).optional(),
+    server: MCPConfigSchema.optional(),
+    servers: z.array(MCPConfigSchema).optional(),
+  })
+  .strict();
 let builtinsRegistered = false;
 
 export function registerBuiltinHosts(): void {
@@ -134,7 +174,7 @@ export function registerBuiltinHosts(): void {
   for (const [name, factory] of Object.entries(BUILTIN_HOSTS)) {
     registerHost({
       name,
-      schema: BuiltinHostSchema,
+      schema: name === 'vercel-sdk' ? SdkHostSchema : CliHostSchema,
       createConfig: (options) => factory(options ?? {}),
       evidence: 'structured',
       run: (input, config, context) =>
@@ -165,7 +205,13 @@ const BUILTIN_HOSTS: Record<
 };
 
 function vercelSdkHost(options: BuiltinHostOptions): MCPHostConfig {
+  SdkHostSchema.parse(options);
   return {
+    timeout: options.timeout,
+    temperature: options.temperature,
+    maxTokens: options.maxTokens,
+    apiKeyEnvVar: options.apiKeyEnvVar,
+    env: options.env,
     hostType: 'sdk',
     provider: (options.provider as MCPHostConfig['provider']) ?? 'anthropic',
     model: options.model ?? 'claude-sonnet-4-20250514',
@@ -174,19 +220,46 @@ function vercelSdkHost(options: BuiltinHostOptions): MCPHostConfig {
 }
 
 function claudeCliHost(options: BuiltinHostOptions): MCPHostConfig {
-  const provider = options.provider ?? 'anthropic';
+  CliHostSchema.parse(options);
+  const env = { ...process.env, ...options.env };
+  for (const server of [
+    ...(options.servers ?? []),
+    ...(options.server ? [options.server] : []),
+  ]) {
+    if (server.transport !== 'http') continue;
+    const unsupported = [
+      server.auth?.clientCredentials && 'clientCredentials',
+      server.auth?.oauth && 'oauth',
+      server.auth?.accessTokenEnv &&
+        !server.auth.accessToken &&
+        'unresolved accessTokenEnv',
+      server.tls && 'tls/mTLS',
+      server.proxy && 'proxy',
+      server.retryAttempts !== undefined && 'retryAttempts',
+      server.connectTimeoutMs !== undefined && 'connectTimeoutMs',
+      server.requestTimeoutMs !== undefined && 'requestTimeoutMs',
+      server.callTimeoutMs !== undefined && 'callTimeoutMs',
+      server.capabilities && 'capabilities',
+    ].filter(Boolean);
+    if (unsupported.length)
+      throw new Error(
+        `claude-cli cannot forward connection policy for ${server.label ?? server.serverUrl}: ${unsupported.join(', ')}. Use an SDK host or explicit proxy.`
+      );
+  }
+  const provider =
+    options.provider === 'vertex-anthropic'
+      ? 'vertex'
+      : (options.provider ?? 'anthropic');
 
   const server = options.server;
   const defaultServerUrl =
-    server?.transport === 'http'
-      ? server.serverUrl
-      : process.env.MCP_SERVER_URL;
+    server?.transport === 'http' ? server.serverUrl : env.MCP_SERVER_URL;
   const apiToken =
     options.apiToken ??
     (server?.transport === 'http' ? server.auth?.accessToken : undefined) ??
-    process.env.MCP_ACCESS_TOKEN ??
+    env.MCP_ACCESS_TOKEN ??
     '';
-  const pluginDir = options.pluginDir ?? process.env.MCP_PLUGIN_DIR ?? '';
+  const pluginDir = options.pluginDir ?? env.MCP_PLUGIN_DIR ?? '';
 
   const mcpServers: Record<string, unknown> = server
     ? server.transport === 'http'
@@ -222,10 +295,9 @@ function claudeCliHost(options: BuiltinHostOptions): MCPHostConfig {
 
   if (pluginDir) {
     const dataDir =
-      process.env.MCP_PLUGIN_DATA_DIR ??
+      env.MCP_PLUGIN_DATA_DIR ??
       path.join(os.homedir(), '.mcp-server-tester', 'plugins');
-    const serverUrl =
-      options.pluginMcpUrl ?? process.env.MCP_PLUGIN_SERVER_URL ?? '';
+    const serverUrl = options.pluginMcpUrl ?? env.MCP_PLUGIN_SERVER_URL ?? '';
     fs.mkdirSync(dataDir, { recursive: true });
     fs.writeFileSync(
       path.join(dataDir, 'mcp-server-url.json'),
@@ -240,7 +312,7 @@ function claudeCliHost(options: BuiltinHostOptions): MCPHostConfig {
           ENABLE_HITL: 'false',
           CLAUDE_PLUGIN_DATA: dataDir,
         },
-        alwaysLoad: process.env.MCP_PLUGIN_ALWAYS_LOAD !== '0',
+        alwaysLoad: env.MCP_PLUGIN_ALWAYS_LOAD !== '0',
       };
     }
   }
@@ -300,6 +372,7 @@ function claudeCliHost(options: BuiltinHostOptions): MCPHostConfig {
       outputFormat: 'stream-json',
       timeout: options.timeout ?? 180_000,
       env: {
+        ...env,
         CLAUDE_CODE_DISABLE_AUTO_MEMORY: '1',
         CLAUDE_CODE_DISABLE_CLAUDE_MDS: '1',
         ...(provider === 'vertex'
@@ -307,12 +380,10 @@ function claudeCliHost(options: BuiltinHostOptions): MCPHostConfig {
               ANTHROPIC_API_KEY: undefined,
               CLAUDE_CODE_USE_VERTEX: '1',
               ANTHROPIC_VERTEX_PROJECT_ID:
-                process.env.ANTHROPIC_VERTEX_PROJECT_ID ??
-                process.env.GOOGLE_VERTEX_PROJECT,
+                env.ANTHROPIC_VERTEX_PROJECT_ID ?? env.GOOGLE_VERTEX_PROJECT,
             }
           : { CLAUDE_CODE_USE_VERTEX: undefined }),
       },
     },
-    maxToolCalls: options.maxToolCalls ?? 5,
   };
 }

--- a/src/evals/builtinHosts.ts
+++ b/src/evals/builtinHosts.ts
@@ -1,0 +1,318 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { z } from 'zod';
+import type { MCPConfig } from '../config/mcpConfig.js';
+import {
+  createMCPClientForConfig,
+  closeMCPClient,
+} from '../mcp/clientFactory.js';
+import type { MCPFixtureApi } from '../mcp/fixtures/mcpFixture.js';
+import { createToolOverrideMCP } from './evalRunner.js';
+import { simulateMCPHost } from './mcpHost/mcpHostSimulation.js';
+import type {
+  HostRunInput,
+  HostRunContext,
+  HostRunResult,
+} from './evalFrameworkTypes.js';
+import type { HostConfig } from './evalManifest.js';
+import { simulationToHostTrace } from './hostTrace.js';
+import { getHost, registerHost } from './frameworkRegistries.js';
+import type { MCPHostConfig } from './mcpHost/mcpHostTypes.js';
+
+async function runBuiltinHost(
+  input: HostRunInput,
+  host: HostConfig,
+  context: HostRunContext,
+  factory: (options: BuiltinHostOptions) => MCPHostConfig
+): Promise<HostRunResult> {
+  const options = { ...input, host, ...context };
+  const case_ = {
+    scenario: input.scenario,
+    mcpHostConfig: context.mcpHostConfig,
+  };
+  if (!input.scenario) throw new Error('Hosts require a scenario.');
+  const config = {
+    ...factory({ ...options.host, servers: options.servers }),
+    ...case_.mcpHostConfig,
+  };
+  const clients: Array<Awaited<ReturnType<typeof createMCPClientForConfig>>> =
+    [];
+  let configDir: string | undefined;
+  try {
+    // CLI hosts manage their own server connections.
+    if (config.hostType !== 'cli' || !case_.scenario) {
+      for (const server of options.servers)
+        clients.push(await createMCPClientForConfig(server));
+    }
+    const routes = new Map<
+      string,
+      { client: (typeof clients)[number]; name: string }
+    >();
+    const mcp: MCPFixtureApi = {
+      get client() {
+        if (!clients[0]) throw new Error('No MCP client for this host.');
+        return clients[0];
+      },
+      authType: 'none',
+      getServerInfo: () => null,
+      async listTools() {
+        const tools = [];
+        for (const [index, client] of clients.entries()) {
+          const result = await client.listTools();
+          for (const tool of result.tools) {
+            const name =
+              clients.length > 1
+                ? `${options.servers[index]!.label}.${tool.name}`
+                : tool.name;
+            routes.set(name, { client, name: tool.name });
+            tools.push({ ...tool, name });
+          }
+        }
+        return tools;
+      },
+      async callTool(name, args) {
+        if (!routes.size) await this.listTools();
+        const route = routes.get(name);
+        if (!route) throw new Error(`Unknown MCP tool: ${name}`);
+        return route.client.callTool({
+          name: route.name,
+          arguments: args,
+        }) as ReturnType<MCPFixtureApi['callTool']>;
+      },
+    };
+    if (config.cli) {
+      const position = config.cli.args.indexOf('--mcp-config');
+      if (position >= 0 && config.cli.args[position + 1]?.startsWith('{')) {
+        configDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mcp_config_'));
+        const file = path.join(configDir, 'mcp.json');
+        fs.writeFileSync(file, config.cli.args[position + 1]!, { mode: 0o600 });
+        config.cli = { ...config.cli, args: [...config.cli.args] };
+        config.cli.args[position + 1] = file;
+      }
+    }
+    const overrides =
+      options.arm?.toolOverrides ?? options.manifest.toolOverrides;
+    if (overrides && config.hostType === 'cli')
+      throw new Error(
+        'CLI description overrides require a host plugin that exposes overridden tools.'
+      );
+    const response = await simulateMCPHost(
+      overrides ? createToolOverrideMCP(mcp, overrides) : mcp,
+      case_.scenario,
+      config
+    );
+    return simulationToHostTrace(response, input.servers);
+  } finally {
+    await Promise.allSettled(clients.map(closeMCPClient));
+    if (configDir) fs.rmSync(configDir, { recursive: true, force: true });
+  }
+}
+
+export interface BuiltinHostOptions {
+  model?: string;
+  maxToolCalls?: number;
+  timeout?: number;
+  provider?: string;
+  server?: MCPConfig;
+  servers?: MCPConfig[];
+  apiToken?: string;
+  pluginDir?: string;
+  pluginMcpUrl?: string;
+  mcpServers?: Record<string, Record<string, unknown>>;
+}
+
+/**
+ * Built-in client host configs. Organization-specific plugin wiring stays
+ * outside the framework and is provided through generic plugin options.
+ */
+const BuiltinHostSchema = z.object({}).passthrough();
+let builtinsRegistered = false;
+
+export function registerBuiltinHosts(): void {
+  if (builtinsRegistered) return;
+  for (const [name, factory] of Object.entries(BUILTIN_HOSTS)) {
+    registerHost({
+      name,
+      schema: BuiltinHostSchema,
+      createConfig: (options) => factory(options ?? {}),
+      evidence: 'structured',
+      run: (input, config, context) =>
+        runBuiltinHost(input, config, context, factory),
+    });
+  }
+  builtinsRegistered = true;
+}
+
+export function getBuiltinHostConfig(
+  name: string,
+  options: BuiltinHostOptions = {}
+): MCPHostConfig {
+  registerBuiltinHosts();
+  const definition = getHost(name);
+  const createConfig = definition.createConfig?.bind(definition);
+  if (!createConfig)
+    throw new Error(`Host ${name} does not expose a legacy config factory.`);
+  return createConfig(options as unknown as Record<string, unknown>);
+}
+
+const BUILTIN_HOSTS: Record<
+  string,
+  (options: BuiltinHostOptions) => MCPHostConfig
+> = {
+  'claude-cli': claudeCliHost,
+  'vercel-sdk': vercelSdkHost,
+};
+
+function vercelSdkHost(options: BuiltinHostOptions): MCPHostConfig {
+  return {
+    hostType: 'sdk',
+    provider: (options.provider as MCPHostConfig['provider']) ?? 'anthropic',
+    model: options.model ?? 'claude-sonnet-4-20250514',
+    maxToolCalls: options.maxToolCalls ?? 5,
+  };
+}
+
+function claudeCliHost(options: BuiltinHostOptions): MCPHostConfig {
+  const provider = options.provider ?? 'anthropic';
+
+  const server = options.server;
+  const defaultServerUrl =
+    server?.transport === 'http'
+      ? server.serverUrl
+      : process.env.MCP_SERVER_URL;
+  const apiToken =
+    options.apiToken ??
+    (server?.transport === 'http' ? server.auth?.accessToken : undefined) ??
+    process.env.MCP_ACCESS_TOKEN ??
+    '';
+  const pluginDir = options.pluginDir ?? process.env.MCP_PLUGIN_DIR ?? '';
+
+  const mcpServers: Record<string, unknown> = server
+    ? server.transport === 'http'
+      ? {
+          [server.label ?? 'mcp-server']: {
+            type: 'http',
+            url: server.serverUrl,
+            headers: {
+              ...server.headers,
+              ...(apiToken ? { Authorization: `Bearer ${apiToken}` } : {}),
+            },
+          },
+        }
+      : {
+          [server.label ?? 'mcp-server']: {
+            command: server.command,
+            args: server.args,
+            cwd: server.cwd,
+            env: server.env,
+          },
+        }
+    : defaultServerUrl
+      ? {
+          'mcp-server': {
+            type: 'http',
+            url: defaultServerUrl,
+            headers: apiToken
+              ? { Authorization: `Bearer ${apiToken}` }
+              : undefined,
+          },
+        }
+      : {};
+
+  if (pluginDir) {
+    const dataDir =
+      process.env.MCP_PLUGIN_DATA_DIR ??
+      path.join(os.homedir(), '.mcp-server-tester', 'plugins');
+    const serverUrl =
+      options.pluginMcpUrl ?? process.env.MCP_PLUGIN_SERVER_URL ?? '';
+    fs.mkdirSync(dataDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(dataDir, 'mcp-server-url.json'),
+      `${JSON.stringify({ serverUrl }, null, 2)}\n`
+    );
+    if (serverUrl) {
+      mcpServers['plugin'] = {
+        command: 'bash',
+        args: [path.join(pluginDir, 'start.sh')],
+        env: {
+          MCP_PLUGIN_SERVER_URL: serverUrl,
+          ENABLE_HITL: 'false',
+          CLAUDE_PLUGIN_DATA: dataDir,
+        },
+        alwaysLoad: process.env.MCP_PLUGIN_ALWAYS_LOAD !== '0',
+      };
+    }
+  }
+
+  if (options.servers) {
+    for (const key of Object.keys(mcpServers)) delete mcpServers[key];
+    for (const entry of options.servers) {
+      const label = entry.label ?? 'mcp-server';
+      mcpServers[label] =
+        entry.transport === 'http'
+          ? {
+              type: 'http',
+              url: entry.serverUrl,
+              headers: {
+                ...entry.headers,
+                ...(entry.auth?.accessToken
+                  ? { Authorization: `Bearer ${entry.auth.accessToken}` }
+                  : {}),
+              },
+            }
+          : {
+              command: entry.command,
+              args: entry.args,
+              cwd: entry.cwd,
+              env: entry.env,
+            };
+    }
+  }
+  const mcpConfigFile = JSON.stringify({ mcpServers });
+
+  const model = options.model ?? 'claude-sonnet-4-20250514';
+  const baseArgs = [
+    '-p',
+    '{{scenario}}',
+    '--model',
+    model,
+    '--output-format',
+    'stream-json',
+    '--verbose',
+    '--mcp-config',
+    mcpConfigFile,
+    '--strict-mcp-config',
+    '--permission-mode',
+    'bypassPermissions',
+  ];
+
+  return {
+    hostType: 'cli',
+    provider: (provider === 'vertex'
+      ? 'vertex-anthropic'
+      : provider) as MCPHostConfig['provider'],
+    mcpServers: mcpServers as Record<string, Record<string, unknown>>,
+    model,
+    cli: {
+      command: 'claude',
+      args: baseArgs,
+      outputFormat: 'stream-json',
+      timeout: options.timeout ?? 180_000,
+      env: {
+        CLAUDE_CODE_DISABLE_AUTO_MEMORY: '1',
+        CLAUDE_CODE_DISABLE_CLAUDE_MDS: '1',
+        ...(provider === 'vertex'
+          ? {
+              ANTHROPIC_API_KEY: undefined,
+              CLAUDE_CODE_USE_VERTEX: '1',
+              ANTHROPIC_VERTEX_PROJECT_ID:
+                process.env.ANTHROPIC_VERTEX_PROJECT_ID ??
+                process.env.GOOGLE_VERTEX_PROJECT,
+            }
+          : { CLAUDE_CODE_USE_VERTEX: undefined }),
+      },
+    },
+    maxToolCalls: options.maxToolCalls ?? 5,
+  };
+}

--- a/src/evals/builtinHosts.ts
+++ b/src/evals/builtinHosts.ts
@@ -32,91 +32,178 @@ async function runBuiltinHost(
   context: HostRunContext,
   factory: (options: BuiltinHostOptions) => MCPHostConfig
 ): Promise<HostRunResult> {
-  const env = hostEnvironment(
-    input as HostRunInput & { env?: HostEnvironment },
-    context as HostRunContext & { env?: HostEnvironment }
-  );
+  const startedAt = Date.now();
+  // Runtime values are fallbacks; explicit host and legacy case values win.
+  const env: HostEnvironment = {
+    ...hostEnvironment(input, context),
+    ...(host.env as HostEnvironment | undefined),
+    ...context.mcpHostConfig?.env,
+  };
   const options = { ...input, host, ...context };
   const case_ = {
     scenario: input.scenario,
     mcpHostConfig: context.mcpHostConfig,
   };
   if (!input.scenario) throw new Error('Hosts require a scenario.');
+  // Legacy execution details (especially caller-authored CLI args) remain
+  // intact, but accepted generation settings must reach the factory first.
+  const legacyOptions = { ...case_.mcpHostConfig };
+  delete legacyOptions.hostType;
+  delete legacyOptions.cli;
+  delete legacyOptions.browser;
+  delete legacyOptions.mcpServers;
   const config = {
-    ...factory({ ...options.host, servers: options.servers, env }),
+    ...factory({
+      ...options.host,
+      ...legacyOptions,
+      servers: options.servers,
+      env,
+    }),
     ...case_.mcpHostConfig,
     env,
   };
   const clients: Array<Awaited<ReturnType<typeof createMCPClientForConfig>>> =
     [];
   let configDir: string | undefined;
-  try {
-    // CLI hosts manage their own server connections.
-    if (config.hostType !== 'cli' || !case_.scenario) {
-      for (const server of options.servers)
-        clients.push(await createMCPClientForConfig(server));
+  const controller = new AbortController();
+  const timeout =
+    config.timeout ??
+    (config.hostType === 'cli' ? config.cli?.timeout : undefined);
+  const timeoutError = new Error(
+    `${config.hostType === 'cli' ? 'CLI' : 'SDK'} host timed out after ${timeout} ms.`
+  );
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const closing = new Map<(typeof clients)[number], Promise<void>>();
+
+  function closeOwnedClient(client: (typeof clients)[number]): Promise<void> {
+    let pending = closing.get(client);
+    if (!pending) {
+      pending = closeMCPClient(client);
+      closing.set(client, pending);
+      // Cleanup can finish after the deadline, but must not reject unobserved.
+      void pending.catch(() => {});
     }
-    const routes = new Map<
-      string,
-      { client: (typeof clients)[number]; name: string }
-    >();
-    const overrides =
-      options.arm?.toolOverrides ?? options.manifest.toolOverrides;
-    const mcp: MCPFixtureApi = {
-      get client() {
-        if (!clients[0]) throw new Error('No MCP client for this host.');
-        return clients[0];
-      },
-      authType: 'none',
-      getServerInfo: () => null,
-      async listTools() {
-        const tools = [];
-        for (const [index, client] of clients.entries()) {
-          const result = await client.listTools();
-          for (const tool of result.tools) {
-            const name =
-              clients.length > 1
-                ? `${options.servers[index]!.label}.${tool.name}`
-                : tool.name;
-            routes.set(name, { client, name: tool.name });
-            tools.push({ ...tool, server: options.servers[index]!.label });
-          }
+    if (controller.signal.aborted) {
+      // Bypass a stalled session DELETE. Only this host's clients are closed;
+      // the shared graceful-close policy and caller-owned fixtures are unchanged.
+      void client.close().catch(() => {});
+    }
+    return pending;
+  }
+
+  const expired = new Promise<never>((_, reject) => {
+    if (timeout === undefined) return;
+    function expire() {
+      controller.abort(timeoutError);
+      for (const client of clients) void closeOwnedClient(client);
+      reject(timeoutError);
+    }
+    const remaining = timeout - (Date.now() - startedAt);
+    if (remaining <= 0) expire();
+    else timer = setTimeout(expire, remaining);
+  });
+
+  function checkDeadline() {
+    if (timeout !== undefined && Date.now() - startedAt >= timeout) {
+      controller.abort(timeoutError);
+    }
+    controller.signal.throwIfAborted();
+  }
+
+  async function execute(): Promise<HostRunResult> {
+    try {
+      checkDeadline();
+      // CLI hosts manage their own server connections.
+      if (config.hostType !== 'cli') {
+        for (const server of options.servers) {
+          const client = await createMCPClientForConfig(server);
+          clients.push(client);
+          // A connection that settles late is still owned and closed in finally.
+          checkDeadline();
         }
-        return overrideHostTools(tools, overrides).map(
-          ({ server, ...tool }) => ({
-            ...tool,
-            name: clients.length > 1 ? `${server}.${tool.name}` : tool.name,
-          })
-        );
-      },
-      async callTool(name, args) {
-        if (!routes.size) await this.listTools();
-        const route = routes.get(name);
-        if (!route) throw new Error(`Unknown MCP tool: ${name}`);
-        return route.client.callTool({
-          name: route.name,
-          arguments: args,
-        }) as ReturnType<MCPFixtureApi['callTool']>;
-      },
-    };
-    if (config.cli) {
-      const position = config.cli.args.indexOf('--mcp-config');
-      if (position >= 0 && config.cli.args[position + 1]?.startsWith('{')) {
-        configDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mcp_config_'));
-        const file = path.join(configDir, 'mcp.json');
-        fs.writeFileSync(file, config.cli.args[position + 1]!, { mode: 0o600 });
-        config.cli = { ...config.cli, args: [...config.cli.args] };
-        config.cli.args[position + 1] = file;
       }
-    }
-    if (overrides && config.hostType === 'cli')
-      throw new Error(
-        'CLI description overrides require a host plugin that exposes overridden tools.'
+      const routes = new Map<
+        string,
+        { client: (typeof clients)[number]; name: string }
+      >();
+      const overrides =
+        options.arm?.toolOverrides ?? options.manifest.toolOverrides;
+      const mcp: MCPFixtureApi = {
+        get client() {
+          if (!clients[0]) throw new Error('No MCP client for this host.');
+          return clients[0];
+        },
+        authType: 'none',
+        getServerInfo: () => null,
+        async listTools() {
+          const tools = [];
+          for (const [index, client] of clients.entries()) {
+            const result = await client.listTools();
+            for (const tool of result.tools) {
+              const name =
+                clients.length > 1
+                  ? `${options.servers[index]!.label}.${tool.name}`
+                  : tool.name;
+              routes.set(name, { client, name: tool.name });
+              tools.push({ ...tool, server: options.servers[index]!.label });
+            }
+          }
+          return overrideHostTools(tools, overrides).map(
+            ({ server, ...tool }) => ({
+              ...tool,
+              name: clients.length > 1 ? `${server}.${tool.name}` : tool.name,
+            })
+          );
+        },
+        async callTool(name, args) {
+          if (!routes.size) await this.listTools();
+          const route = routes.get(name);
+          if (!route) throw new Error(`Unknown MCP tool: ${name}`);
+          return route.client.callTool({
+            name: route.name,
+            arguments: args,
+          }) as ReturnType<MCPFixtureApi['callTool']>;
+        },
+      };
+      if (config.cli) {
+        const position = config.cli.args.indexOf('--mcp-config');
+        if (position >= 0 && config.cli.args[position + 1]?.startsWith('{')) {
+          configDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mcp_config_'));
+          const file = path.join(configDir, 'mcp.json');
+          fs.writeFileSync(file, config.cli.args[position + 1]!, {
+            mode: 0o600,
+          });
+          config.cli = { ...config.cli, args: [...config.cli.args] };
+          config.cli.args[position + 1] = file;
+        }
+      }
+      if (overrides && config.hostType === 'cli')
+        throw new Error(
+          'CLI description overrides require a host plugin that exposes overridden tools.'
+        );
+      checkDeadline();
+      const response = await simulateMCPHost(
+        mcp,
+        case_.scenario,
+        config,
+        timeout === undefined ? undefined : controller.signal
       );
-    const response = await simulateMCPHost(mcp, case_.scenario, config);
-    return simulationToHostTrace(response, input.servers);
+      return simulationToHostTrace(response, input.servers);
+    } finally {
+      await Promise.allSettled(clients.map(closeOwnedClient));
+    }
+  }
+
+  try {
+    const result = await Promise.race([execute(), expired]);
+    checkDeadline();
+    return result;
+  } catch (error) {
+    if (error === timeoutError)
+      return { finalText: '', events: [], error: timeoutError.message };
+    throw error;
   } finally {
-    await Promise.allSettled(clients.map(closeMCPClient));
+    clearTimeout(timer);
     if (configDir) fs.rmSync(configDir, { recursive: true, force: true });
   }
 }
@@ -361,6 +448,7 @@ function claudeCliHost(options: BuiltinHostOptions): MCPHostConfig {
 
   return {
     hostType: 'cli',
+    timeout: options.timeout,
     provider: (provider === 'vertex'
       ? 'vertex-anthropic'
       : provider) as MCPHostConfig['provider'],

--- a/src/evals/datasetLoader.test.ts
+++ b/src/evals/datasetLoader.test.ts
@@ -23,6 +23,41 @@ describe('datasetLoader', () => {
       expect(dataset.cases[0]?.id).toBe('case-1');
     });
 
+    it('preserves a legacy host deadline through canonical dataset loading', () => {
+      const mcpHostConfig = {
+        provider: 'openai',
+        model: 'case-model',
+        timeout: 17,
+      };
+      const dataset = loadEvalDatasetFromObject({
+        name: 'host-deadline',
+        cases: [
+          { id: 'one', mode: 'mcp_host', scenario: 'hello', mcpHostConfig },
+        ],
+      });
+
+      expect(dataset.cases[0]?.mcpHostConfig).toEqual(mcpHostConfig);
+    });
+
+    it.each([0, -1, 1.5, Infinity, '17'])(
+      'rejects an invalid legacy host deadline: %s',
+      (timeout) => {
+        expect(() =>
+          loadEvalDatasetFromObject({
+            name: 'host-deadline',
+            cases: [
+              {
+                id: 'one',
+                mode: 'mcp_host',
+                scenario: 'hello',
+                mcpHostConfig: { provider: 'openai', timeout },
+              },
+            ],
+          })
+        ).toThrow();
+      }
+    );
+
     it('should attach schemas to dataset', () => {
       const data = {
         name: 'test-dataset',

--- a/src/evals/datasetTypes.ts
+++ b/src/evals/datasetTypes.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 import { TaggedConfigSchema, type HostConfig } from './evalManifest.js';
 import type { MCPHostConfig } from './mcpHost/mcpHostTypes.js';
+import { GenerationOptions } from './mcpHost/hostOptions.js';
 import type { ExternalHostConfig } from './externalHost/types.js';
 import { ExternalHostConfigSchema } from './externalHost/schema.js';
 import type { SnapshotSanitizer } from '../assertions/validators/types.js';
@@ -348,6 +349,7 @@ const MCPHostConfigSchema = z.object({
     .optional(),
   apiKeyEnvVar: z.string().optional(),
   model: z.string().optional(),
+  timeout: GenerationOptions.timeout,
   maxTokens: z.number().optional(),
   temperature: z.number().optional(),
   maxToolCalls: z.number().optional(),

--- a/src/evals/evalFrameworkTypes.ts
+++ b/src/evals/evalFrameworkTypes.ts
@@ -45,11 +45,15 @@ export interface HostRunOptions {
 export interface HostRunInput {
   scenario: string;
   servers: MCPConfig[];
+  /** Execution-local environment; never persisted. */
+  env?: Record<string, string | undefined>;
 }
 
 export interface HostRunContext {
   manifest: EvalManifest;
   arm?: EvalArm;
+  /** Runtime-only environment isolated per suite. */
+  env?: Record<string, string | undefined>;
   /** Optional compatibility settings for existing SDK/CLI case configurations. */
   mcpHostConfig?: MCPHostConfig;
 }

--- a/src/evals/frameworkRegistries.test.ts
+++ b/src/evals/frameworkRegistries.test.ts
@@ -155,6 +155,40 @@ describe('framework registries', () => {
     expect(manifest.datasets[0]).toEqual({ type: 'custom', ignored: true });
   });
 
+  it('preserves framework judge settings when policy schemas strip unknown fields', () => {
+    registerAll();
+    registerJudge({
+      name: 'policy',
+      schema: z.object({ count: z.number().transform((value) => value * 3) }),
+      evaluate: async () => ({ score: 0.8 }),
+    });
+    const manifest: EvalManifest = {
+      name: 'judge-settings',
+      datasets: [{ type: 'file' }],
+      judges: [
+        { type: 'policy', count: 2, threshold: 0.9, reference: 'base-gold' },
+      ],
+      arms: [
+        { name: 'inherited' },
+        {
+          name: 'override',
+          judges: [
+            { type: 'policy', count: 4, threshold: 0, reference: 'arm-gold' },
+          ],
+        },
+      ],
+    };
+    const parsed = validateManifestRegistrations(manifest);
+    expect(parsed.judges).toEqual([
+      { type: 'policy', count: 6, threshold: 0.9, reference: 'base-gold' },
+    ]);
+    expect(parsed.arms?.[0]?.judges).toEqual(parsed.judges);
+    expect(parsed.arms?.[1]?.judges).toEqual([
+      { type: 'policy', count: 12, threshold: 0, reference: 'arm-gold' },
+    ]);
+    expect(manifest.judges?.[0]?.count).toBe(2);
+  });
+
   it.each([
     'dataset',
     'host',

--- a/src/evals/frameworkRegistries.ts
+++ b/src/evals/frameworkRegistries.ts
@@ -215,26 +215,34 @@ function parseMetrics(
 function parseJudges(
   configs: ExtensionConfig[] | undefined
 ): ExtensionConfig[] | undefined {
-  return configs?.map((config) =>
-    parseConfig(config, getJudge(config.type), 'judge options')
-  );
+  return configs?.map((config) => {
+    const parsed = parseConfig(config, getJudge(config.type), 'judge options');
+    // These belong to the framework assertion, not the judge's policy schema.
+    // A stripping or transforming policy must not change the requested verdict.
+    for (const key of ['threshold', 'reference'] as const) {
+      if (config[key] !== undefined) parsed[key] = config[key];
+    }
+    return parsed;
+  });
 }
 
-export function parseHostConfig(config: HostConfig): HostConfig {
-  return parseConfig(config, getHost(config.type), 'host options');
+export function parseHostConfig(
+  config: HostConfig,
+  defaults?: EvalManifest
+): HostConfig {
+  const options = { ...config };
+  for (const key of ['model', 'provider', 'maxToolCalls', 'timeout'] as const) {
+    if (options[key] === undefined && defaults?.[key] !== undefined)
+      options[key] = defaults[key];
+  }
+  return parseConfig(options, getHost(config.type), 'host options');
 }
 
 function effectiveHost(
   manifest: EvalManifest,
   host: HostConfig | undefined
 ): HostConfig | undefined {
-  if (!host) return undefined;
-  const options = { ...host };
-  for (const key of ['model', 'provider', 'maxToolCalls', 'timeout'] as const) {
-    if (options[key] === undefined && manifest[key] !== undefined)
-      options[key] = manifest[key];
-  }
-  return parseHostConfig(options);
+  return host ? parseHostConfig(host, manifest) : undefined;
 }
 
 function validateLabels(

--- a/src/evals/frameworkRegistries.ts
+++ b/src/evals/frameworkRegistries.ts
@@ -1,4 +1,4 @@
-import type { ZodType } from 'zod';
+import { z, type ZodType } from 'zod';
 import type {
   DatasetSource,
   MetricDefinition,
@@ -163,6 +163,47 @@ function parseConfig<T extends TaggedConfig>(
   } as T;
 }
 
+const SuiteControlsSchema = z
+  .object({
+    iterations: z.number().int().positive().optional(),
+    maxCases: z.number().int().positive().optional(),
+    concurrency: z.number().int().positive().optional(),
+    filterTags: z.array(z.string().min(1)).optional(),
+  })
+  .strict();
+
+/** Canonical top-level controls, with explicit support for the run namespace. */
+export function normalizeSuiteControls(manifest: EvalManifest): EvalManifest {
+  if (manifest.profile !== undefined) {
+    throw new Error(
+      'Evaluation profile is not supported; use explicit host and run controls.'
+    );
+  }
+  const nested = SuiteControlsSchema.parse(manifest.run ?? {});
+  const top = SuiteControlsSchema.parse(
+    Object.fromEntries(
+      Object.keys(SuiteControlsSchema.shape).map((key) => [key, manifest[key]])
+    )
+  );
+  for (const key of Object.keys(nested) as Array<keyof typeof nested>) {
+    if (
+      top[key] !== undefined &&
+      JSON.stringify(top[key]) !== JSON.stringify(nested[key])
+    ) {
+      throw new Error(
+        `Conflicting evaluation controls: ${key} and run.${key}.`
+      );
+    }
+  }
+  return {
+    ...manifest,
+    ...nested,
+    ...Object.fromEntries(
+      Object.entries(top).filter(([, value]) => value !== undefined)
+    ),
+  };
+}
+
 function parseMetrics(
   configs: ExtensionConfig[] | undefined
 ): ExtensionConfig[] | undefined {
@@ -219,6 +260,7 @@ function validateLabels(
 export function validateManifestRegistrations(
   manifest: EvalManifest
 ): EvalManifest {
+  manifest = normalizeSuiteControls(manifest);
   validateLabels(manifest.servers ?? [], 'the manifest');
   const datasets = manifest.datasets.map((config) =>
     parseConfig(config, getDatasetSource(config.type), 'dataset options')

--- a/src/evals/legacyGleanDatasetSource.test.ts
+++ b/src/evals/legacyGleanDatasetSource.test.ts
@@ -1,0 +1,371 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { z } from 'zod';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  getDatasetSource,
+  registerHost,
+  registerJudge,
+} from './frameworkRegistries.js';
+import type { EvalManifest } from './evalManifest.js';
+import { runEvalSuite } from './runEvalSuite.js';
+
+// Exercise the copyable example against current source, not a stale dist build.
+vi.mock('@gleanwork/mcp-server-tester', async () => ({
+  ...(await import('./datasetLoader.js')),
+  ...(await import('./frameworkRegistries.js')),
+}));
+const download = vi.hoisted(() => vi.fn());
+vi.mock('@google-cloud/storage', () => ({
+  Storage: class {
+    bucket() {
+      return {
+        file() {
+          return { download };
+        },
+      };
+    }
+  },
+}));
+import {
+  convertLegacyGleanDataset,
+  register,
+  type LegacyFormat,
+} from '../../examples/plugins/legacy-glean-datasets.js';
+
+const manifest: EvalManifest = { name: 'legacy', datasets: [] };
+const hostConfig = { provider: 'openai' as const };
+register();
+
+describe('opt-in glean-legacy source', () => {
+  let rootDir: string;
+  beforeEach(async () => {
+    rootDir = await fs.mkdtemp(path.join(os.tmpdir(), 'legacy-source-'));
+    vi.clearAllMocks();
+  });
+  afterEach(async () => {
+    vi.unstubAllEnvs();
+    await fs.rm(rootDir, { recursive: true, force: true });
+  });
+
+  it.each(['file', 'gcs'] as const)(
+    'loads legacy JSON only through explicit %s transport and format',
+    async (type) => {
+      const raw = {
+        cases: [
+          {
+            id: 'a',
+            tool: 'search',
+            args: { query: 'policy' },
+            expect: { isError: false },
+          },
+        ],
+      };
+      await fs.writeFile(path.join(rootDir, 'cases.json'), JSON.stringify(raw));
+      download.mockResolvedValue([Buffer.from(JSON.stringify(raw))]);
+      const dataset = await getDatasetSource('glean-legacy').load(
+        {
+          type: 'glean-legacy',
+          format: 'tool-call',
+          transport:
+            type === 'file'
+              ? { type, path: 'cases.json' }
+              : { type, uri: 'gs://bucket/cases.json' },
+        },
+        { rootDir, manifest }
+      );
+      expect(dataset.cases[0]).toMatchObject({
+        toolName: 'search',
+        args: { query: 'policy' },
+        expect: { isError: false },
+        tags: ['tool_call'],
+      });
+      expect(download).toHaveBeenCalledTimes(type === 'gcs' ? 1 : 0);
+    }
+  );
+
+  it('requires explicit format rather than guessing from a first case', async () => {
+    await expect(
+      getDatasetSource('glean-legacy').load(
+        {
+          type: 'glean-legacy',
+          transport: { type: 'file', path: 'never-read.json' },
+        },
+        { rootDir, manifest }
+      )
+    ).rejects.toThrow(/format/);
+    expect(() =>
+      convertLegacyGleanDataset(
+        {
+          cases: [
+            { id: 'a', expected_tool: 'search', scenario: 'Find policy' },
+            { id: 'b', tool: 'search' },
+          ],
+        },
+        'tool-selection',
+        hostConfig,
+        manifest
+      )
+    ).toThrow(/case "b" requires expected_tool/);
+  });
+
+  it('preserves selection tags, expectations, iteration and accuracy defaults without ambient state', () => {
+    vi.stubEnv('EVAL_ITERATIONS', '99');
+    const raw = {
+      cases: [
+        {
+          id: 'a',
+          scenario: 'Find policy',
+          expected_tool: 'search',
+          tags: ['policy'],
+        },
+      ],
+    };
+    for (const iterations of [undefined, 1, 3]) {
+      const dataset = convertLegacyGleanDataset(
+        raw,
+        'tool-selection',
+        hostConfig,
+        { ...manifest, iterations }
+      );
+      expect(dataset.cases[0]).toMatchObject({
+        mode: 'mcp_host',
+        iterations: iterations ?? 5,
+        accuracyThreshold: iterations === 1 ? 1 : 0.8,
+        tags: ['mcp_host', 'tool_selection', 'policy'],
+        expect: {
+          toolsTriggered: { calls: [{ name: 'search', required: true }] },
+        },
+      });
+    }
+    const dataset = convertLegacyGleanDataset(
+      { cases: [{ ...raw.cases[0], iterations: 2, accuracyThreshold: 0.6 }] },
+      'tool-selection',
+      hostConfig,
+      { ...manifest, iterations: 9 }
+    );
+    expect(dataset.cases[0]).toMatchObject({
+      iterations: 2,
+      accuracyThreshold: 0.6,
+    });
+  });
+
+  it('retains tool-call defaults and explicit assertions', () => {
+    const dataset = convertLegacyGleanDataset(
+      {
+        cases: [
+          { id: 'default', tool: 'search' },
+          {
+            id: 'explicit',
+            tool: 'search',
+            mode: 'mcp_host',
+            scenario: 'Find policy',
+            iterations: 2,
+            accuracyThreshold: 0.7,
+            expect: {
+              passesJudge: { judge: 'custom-quality', threshold: 0.9 },
+            },
+          },
+        ],
+      },
+      'tool-call',
+      hostConfig,
+      { ...manifest, iterations: 8 }
+    );
+    expect(dataset.cases[0]?.expect).toEqual({
+      isError: false,
+      responseSize: { minBytes: 50 },
+    });
+    expect(dataset.cases[1]).toMatchObject({
+      mode: 'mcp_host',
+      iterations: 2,
+      accuracyThreshold: 0.7,
+      expect: { passesJudge: { judge: 'custom-quality', threshold: 0.9 } },
+    });
+  });
+
+  it('preserves all legacy quality references and thresholds', () => {
+    const dataset = convertLegacyGleanDataset(
+      {
+        cases: [
+          {
+            id: 'q',
+            scenario: 'Question?',
+            reference: 'Answer',
+            iterations: 2,
+            accuracyThreshold: 0.7,
+          },
+        ],
+      },
+      'e2e-quality',
+      hostConfig,
+      {
+        ...manifest,
+        judges: [
+          'glean-completeness',
+          'glean-correctness',
+          'task-completion',
+          'glean-rate-limit',
+          'glean-timeout',
+        ].map((type) => ({ type })),
+      }
+    );
+    expect(dataset.cases[0]).toMatchObject({
+      iterations: 2,
+      accuracyThreshold: 0.7,
+      tags: ['e2e_quality'],
+    });
+    expect(dataset.cases[0]?.expect?.passesJudge).toEqual([
+      { judge: 'glean-completeness', reference: 'Question?', threshold: 0.5 },
+      {
+        judge: 'glean-correctness',
+        reference: JSON.stringify({ question: 'Question?', answer: 'Answer' }),
+        threshold: 0.5,
+      },
+      { judge: 'task-completion', reference: 'Question?', threshold: 0.5 },
+      { judge: 'glean-rate-limit', reference: 'Question?', threshold: 0.5 },
+      { judge: 'glean-timeout', reference: 'Question?', threshold: 0.5 },
+    ]);
+    const explicit = convertLegacyGleanDataset(
+      { cases: [{ id: 'q', scenario: 'Question?' }] },
+      'e2e-quality',
+      hostConfig,
+      { ...manifest, judges: [{ type: 'glean-completeness', threshold: 0.85 }] }
+    );
+    expect(explicit.cases[0]?.expect?.passesJudge).toEqual([
+      { judge: 'glean-completeness', reference: 'Question?', threshold: 0.85 },
+    ]);
+  });
+
+  it.each<LegacyFormat>(['tool-selection', 'tool-call', 'e2e-quality'])(
+    'rejects unmapped manifest judges explicitly for %s',
+    (format) => {
+      expect(() =>
+        convertLegacyGleanDataset(
+          {
+            cases: [
+              {
+                id: 'a',
+                tool: 'search',
+                expected_tool: 'search',
+                scenario: 'Find policy',
+              },
+            ],
+          },
+          format,
+          hostConfig,
+          { ...manifest, judges: [{ type: 'custom-quality' }] }
+        )
+      ).toThrow(/cannot apply manifest judges: custom-quality/);
+    }
+  );
+
+  it('rejects quality case assertions rather than silently dropping custom judges', () => {
+    expect(() =>
+      convertLegacyGleanDataset(
+        {
+          cases: [
+            {
+              id: 'q',
+              scenario: 'Question?',
+              expect: { passesJudge: { judge: 'custom-quality' } },
+            },
+          ],
+        },
+        'e2e-quality',
+        hostConfig,
+        manifest
+      )
+    ).toThrow(/cannot apply case expect assertions/);
+  });
+
+  it('requires references for correctness and host config for scenario conversion', () => {
+    const raw = { cases: [{ id: 'q', scenario: 'Question?' }] };
+    expect(() =>
+      convertLegacyGleanDataset(raw, 'e2e-quality', hostConfig, {
+        ...manifest,
+        judges: [{ type: 'glean-correctness' }],
+      })
+    ).toThrow(/require a reference/);
+    expect(() =>
+      convertLegacyGleanDataset(raw, 'e2e-quality', undefined, manifest)
+    ).toThrow(/requires a resolved host/);
+    expect(
+      convertLegacyGleanDataset(raw, 'e2e-quality', hostConfig, manifest)
+        .cases[0]?.expect
+    ).toBeUndefined();
+  });
+
+  it('applies maxCases only after validating the whole legacy dataset', () => {
+    const raw = {
+      cases: [
+        { id: 'a', tool: 'search' },
+        { id: 'b', tool: 'search' },
+      ],
+    };
+    expect(
+      convertLegacyGleanDataset(raw, 'tool-call', undefined, {
+        ...manifest,
+        maxCases: 1,
+      }).cases
+    ).toHaveLength(1);
+    expect(() =>
+      convertLegacyGleanDataset(
+        { cases: [raw.cases[0], { id: 'b' }] },
+        'tool-call',
+        undefined,
+        { ...manifest, maxCases: 1 }
+      )
+    ).toThrow(/requires tool/);
+  });
+
+  it('executes quality assertions from the source through the suite without live host calls', async () => {
+    const evaluate = vi.fn(async () => ({
+      score: 0.4,
+      reasoning: 'below threshold',
+    }));
+    registerJudge({
+      name: 'glean-completeness',
+      schema: z.object({}).passthrough(),
+      evaluate,
+    });
+    const run = vi.fn(async () => ({
+      finalText: 'Candidate answer',
+      events: [],
+    }));
+    registerHost({
+      name: 'legacy-test-host',
+      schema: z.object({}).passthrough(),
+      createConfig: () => hostConfig,
+      run,
+    });
+    await fs.writeFile(
+      path.join(rootDir, 'quality.json'),
+      JSON.stringify({ cases: [{ id: 'q', scenario: 'Question?' }] })
+    );
+    await fs.writeFile(
+      path.join(rootDir, 'manifest.json'),
+      JSON.stringify({
+        name: 'legacy-execution',
+        host: { type: 'legacy-test-host' },
+        servers: [],
+        datasets: [
+          {
+            type: 'glean-legacy',
+            format: 'e2e-quality',
+            transport: { type: 'file', path: 'quality.json' },
+          },
+        ],
+        judges: [{ type: 'glean-completeness' }],
+      })
+    );
+    const result = await runEvalSuite({
+      manifestPath: path.join(rootDir, 'manifest.json'),
+      rootDir,
+    });
+    expect(run).toHaveBeenCalledTimes(1);
+    expect(evaluate).toHaveBeenCalledTimes(1);
+    expect(result.summary.results[0]?.pass).toBe(false);
+  });
+});

--- a/src/evals/manifestIdentity.ts
+++ b/src/evals/manifestIdentity.ts
@@ -1,0 +1,15 @@
+import { createHash } from 'node:crypto';
+import type { EvalManifest } from './evalManifest.js';
+
+/** Identity of the normalized manifest used to persist and resume a suite. */
+export function manifestIdentity(manifest: EvalManifest): {
+  manifestId: string;
+  contentHash: string;
+} {
+  return {
+    manifestId: manifest.name,
+    contentHash: createHash('sha256')
+      .update(JSON.stringify(manifest))
+      .digest('hex'),
+  };
+}

--- a/src/evals/mcpHost/adapters/cli/offline.test.ts
+++ b/src/evals/mcpHost/adapters/cli/offline.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from 'vitest';
+import { simulateMCPHost } from '../../mcpHostSimulation.js';
+import {
+  simulationToHostTrace,
+  hostTraceToExecution,
+} from '../../../hostTrace.js';
+import { runEvalDataset } from '../../../evalRunner.js';
+import type { MCPFixtureApi } from '../../../../mcp/fixtures/mcpFixture.js';
+
+const unusedMcp = {} as MCPFixtureApi;
+describe('offline CLI public execution path', () => {
+  it('preserves distinct MCP server identities and native tools through a real child process', async () => {
+    const event = JSON.stringify({
+      type: 'assistant',
+      message: {
+        content: [
+          'mcp__a__search',
+          'mcp__b__search',
+          'mcp__server_with_underscores__search',
+          'Bash',
+        ].map((name, index) => ({
+          type: 'tool_use',
+          name,
+          id: String(index),
+          input: {},
+        })),
+      },
+    });
+    const result = await simulateMCPHost(unusedMcp, 'hello', {
+      hostType: 'cli',
+      cli: {
+        command: process.execPath,
+        args: ['-e', `console.log(${JSON.stringify(event)})`],
+      },
+    });
+    expect(result.success).toBe(true);
+    expect(result.toolCalls).toMatchObject([
+      { name: 'search', source: 'mcp', server: 'a', rawName: 'mcp__a__search' },
+      { name: 'search', source: 'mcp', server: 'b', rawName: 'mcp__b__search' },
+      { name: 'search', source: 'mcp', server: 'server_with_underscores' },
+      { name: 'Bash', source: 'host', rawName: 'Bash' },
+    ]);
+    expect(result.toolCalls[3]).not.toHaveProperty('server');
+    const servers = ['a', 'b'].map((label) => ({
+      transport: 'http' as const,
+      serverUrl: 'https://example.com',
+      label,
+    }));
+    const trace = simulationToHostTrace(result, servers);
+    const scored = await runEvalDataset(
+      {
+        dataset: {
+          name: 'cli-provenance',
+          cases: [
+            {
+              id: 'one',
+              mode: 'host',
+              scenario: 'hello',
+              expect: {
+                toolsTriggered: {
+                  calls: [
+                    { name: 'search', source: 'mcp', server: 'a' },
+                    { name: 'search', source: 'mcp', server: 'b' },
+                    { name: 'Bash', source: 'host' },
+                  ],
+                },
+              },
+            },
+          ],
+        },
+        executeCase: async () =>
+          hostTraceToExecution(trace, 'structured', servers),
+      },
+      {}
+    );
+    expect(scored.passed).toBe(1);
+  });
+  it('passes per-execution environment to the child without changing process.env', async () => {
+    const before = process.env.HOST_OFFLINE_TEST;
+    const result = await simulateMCPHost(unusedMcp, 'hello', {
+      hostType: 'cli',
+      env: { HOST_OFFLINE_TEST: 'isolated' },
+      cli: {
+        command: process.execPath,
+        args: [
+          '-e',
+          'console.log(JSON.stringify({success:true, toolCalls:[], response:process.env.HOST_OFFLINE_TEST}))',
+        ],
+        outputFormat: 'json',
+      },
+    });
+    expect(result.response).toBe('isolated');
+    expect(process.env.HOST_OFFLINE_TEST).toBe(before);
+  });
+});

--- a/src/evals/mcpHost/adapters/cli/parsers.test.ts
+++ b/src/evals/mcpHost/adapters/cli/parsers.test.ts
@@ -28,6 +28,8 @@ describe('parseStreamJson', () => {
     expect(result.toolCalls).toHaveLength(1);
     expect(result.toolCalls[0]).toEqual({
       name: 'search',
+      source: 'host',
+      rawName: 'search',
       arguments: { query: 'test' },
       id: 'call_1',
     });
@@ -281,6 +283,8 @@ describe('parseStreamJson', () => {
     // Payload stored once, on the call.
     expect(result.toolCalls[0]).toEqual({
       name: 'search',
+      source: 'host',
+      rawName: 'search',
       arguments: { query: 'abcd' },
       id: 'call_1',
       output: '{"abc":"xyz"}',

--- a/src/evals/mcpHost/adapters/cli/parsers.ts
+++ b/src/evals/mcpHost/adapters/cli/parsers.ts
@@ -29,9 +29,12 @@ export function parseStreamJson(stdout: string): MCPHostSimulationResult {
       for (const block of event.message.content) {
         if (block.type === 'tool_use' && block.name) {
           const rawName = block.name;
-          const mcpMatch = /^mcp__[^_]+__(.+)$/.exec(rawName);
+          const mcpMatch = /^mcp__(.+?)__(.+)$/.exec(rawName);
           toolCalls.push({
-            name: mcpMatch ? mcpMatch[1]! : rawName,
+            name: mcpMatch ? mcpMatch[2]! : rawName,
+            source: mcpMatch ? 'mcp' : 'host',
+            ...(mcpMatch ? { server: mcpMatch[1] } : {}),
+            rawName,
             arguments: block.input ?? {},
             id: block.id,
           });
@@ -125,6 +128,13 @@ export function createJsonParser(paths: {
     const toolCalls: LLMToolCall[] = Array.isArray(rawToolCalls)
       ? rawToolCalls.map((tc: Record<string, unknown>) => ({
           name: typeof tc.name === 'string' ? tc.name : '',
+          ...(tc.source === 'mcp' || tc.source === 'host'
+            ? { source: tc.source }
+            : {}),
+          ...(typeof tc.server === 'string' ? { server: tc.server } : {}),
+          ...(typeof tc.rawName === 'string' ? { rawName: tc.rawName } : {}),
+          ...(typeof tc.id === 'string' ? { id: tc.id } : {}),
+          ...(typeof tc.output === 'string' ? { output: tc.output } : {}),
           arguments: (tc.arguments ?? tc.args ?? {}) as Record<string, unknown>,
         }))
       : [];

--- a/src/evals/mcpHost/adapters/cli/runner.ts
+++ b/src/evals/mcpHost/adapters/cli/runner.ts
@@ -53,7 +53,10 @@ export async function runCLIHost(
 
   let stdout: string;
   try {
-    const result = await spawnProcess(cliConfig.command, args, { timeout });
+    const result = await spawnProcess(cliConfig.command, args, {
+      timeout,
+      env: cliConfig.env,
+    });
     stdout = result.stdout;
   } catch (err) {
     const elapsed = Date.now() - startTime;
@@ -141,11 +144,12 @@ export function validateSimulationResult(result: unknown): string | null {
 function spawnProcess(
   command: string,
   args: string[],
-  options: { timeout: number }
+  options: { timeout: number; env?: Record<string, string | undefined> }
 ): Promise<{ stdout: string; stderr: string }> {
   return new Promise((resolve, reject) => {
     const child = spawn(command, args, {
       stdio: ['pipe', 'pipe', 'pipe'],
+      ...(options.env ? { env: { ...process.env, ...options.env } } : {}),
     });
 
     // Close stdin immediately so the CLI doesn't wait for input

--- a/src/evals/mcpHost/adapters/cli/runner.ts
+++ b/src/evals/mcpHost/adapters/cli/runner.ts
@@ -44,7 +44,8 @@ export function interpolateArgs(args: string[], scenario: string): string[] {
  */
 export async function runCLIHost(
   cliConfig: CLIConfig,
-  scenario: string
+  scenario: string,
+  signal?: AbortSignal
 ): Promise<MCPHostSimulationResult> {
   const timeout = cliConfig.timeout ?? DEFAULT_TIMEOUT;
   const args = interpolateArgs(cliConfig.args, scenario);
@@ -56,6 +57,7 @@ export async function runCLIHost(
     const result = await spawnProcess(cliConfig.command, args, {
       timeout,
       env: cliConfig.env,
+      signal,
     });
     stdout = result.stdout;
   } catch (err) {
@@ -144,9 +146,14 @@ export function validateSimulationResult(result: unknown): string | null {
 function spawnProcess(
   command: string,
   args: string[],
-  options: { timeout: number; env?: Record<string, string | undefined> }
+  options: {
+    timeout: number;
+    env?: Record<string, string | undefined>;
+    signal?: AbortSignal;
+  }
 ): Promise<{ stdout: string; stderr: string }> {
   return new Promise((resolve, reject) => {
+    options.signal?.throwIfAborted();
     const child = spawn(command, args, {
       stdio: ['pipe', 'pipe', 'pipe'],
       ...(options.env ? { env: { ...process.env, ...options.env } } : {}),
@@ -173,18 +180,40 @@ function spawnProcess(
       }
     });
 
-    const timer = setTimeout(() => {
-      child.kill('SIGTERM');
-      reject(new Error(`Process timed out after ${options.timeout}ms`));
-    }, options.timeout);
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    function cleanup() {
+      clearTimeout(timer);
+      options.signal?.removeEventListener('abort', abortFromHost);
+    }
+    function abortFromHost() {
+      // The enclosing lifecycle budget is exhausted: stop only our spawned
+      // process, never a process group or an unrelated CLI instance.
+      child.kill('SIGKILL');
+      cleanup();
+      const reason: unknown = options.signal?.reason;
+      reject(
+        reason instanceof Error
+          ? reason
+          : new Error(typeof reason === 'string' ? reason : 'CLI host aborted.')
+      );
+    }
+    if (options.signal) {
+      options.signal.addEventListener('abort', abortFromHost, { once: true });
+    } else {
+      // Preserve standalone CLI timeout behavior when there is no owner signal.
+      timer = setTimeout(() => {
+        child.kill('SIGTERM');
+        reject(new Error(`Process timed out after ${options.timeout}ms`));
+      }, options.timeout);
+    }
 
     child.on('error', (err) => {
-      clearTimeout(timer);
+      cleanup();
       reject(err);
     });
 
     child.on('close', (code) => {
-      clearTimeout(timer);
+      cleanup();
       const stdout = Buffer.concat(stdoutChunks).toString('utf-8');
       const stderr = Buffer.concat(stderrChunks).toString('utf-8');
 

--- a/src/evals/mcpHost/adapters/vercel.test.ts
+++ b/src/evals/mcpHost/adapters/vercel.test.ts
@@ -25,7 +25,7 @@ vi.mock('ai', () => ({
         text: '',
       },
     ],
-    usage: { promptTokens: 100, completionTokens: 50 },
+    usage: { inputTokens: 100, outputTokens: 50 },
   }),
   tool: vi.fn(
     (config: {
@@ -38,7 +38,7 @@ vi.mock('ai', () => ({
 }));
 
 vi.mock('@ai-sdk/openai', () => ({
-  openai: vi.fn(() => ({ id: 'gpt-4o' })),
+  createOpenAI: vi.fn(() => vi.fn(() => ({ id: 'gpt-4o' }))),
 }));
 
 function createMockMCP(
@@ -89,11 +89,13 @@ describe('createVercelOrchestrator', () => {
           text: '',
         },
       ],
-      usage: { promptTokens: 100, completionTokens: 50 },
+      usage: { inputTokens: 100, outputTokens: 50 },
     } as never);
 
-    const { openai } = await import('@ai-sdk/openai');
-    vi.mocked(openai).mockReturnValue({ id: 'gpt-4o' } as never);
+    const { createOpenAI } = await import('@ai-sdk/openai');
+    vi.mocked(createOpenAI).mockReturnValue(
+      vi.fn(() => ({ id: 'gpt-4o' })) as never
+    );
   });
 
   it('should return a simulation result with tool calls', async () => {

--- a/src/evals/mcpHost/adapters/vercel.ts
+++ b/src/evals/mcpHost/adapters/vercel.ts
@@ -227,10 +227,12 @@ export function createVercelOrchestrator(): MCPHostSimulator {
     async simulate(
       mcp: MCPFixtureApi,
       scenario: string,
-      config: MCPHostConfig
+      config: MCPHostConfig,
+      signal?: AbortSignal
     ): Promise<MCPHostSimulationResult> {
       const controller = new AbortController();
       let timer: ReturnType<typeof setTimeout> | undefined;
+      let abortFromHost: (() => void) | undefined;
       const allToolCalls: LLMToolCall[] = [];
       let expired: Promise<never>;
       function withinDeadline<T>(promise: Promise<T>): Promise<T> {
@@ -239,7 +241,21 @@ export function createVercelOrchestrator(): MCPHostSimulator {
       try {
         SdkConfigSchema.parse(config);
         expired = new Promise<never>((_, reject) => {
-          if (config.timeout !== undefined)
+          if (signal) {
+            abortFromHost = function abortFromHost() {
+              const reason: unknown = signal.reason;
+              const error =
+                reason instanceof Error
+                  ? reason
+                  : new Error(
+                      typeof reason === 'string' ? reason : 'SDK host aborted.'
+                    );
+              controller.abort(error);
+              reject(error);
+            };
+            signal.addEventListener('abort', abortFromHost, { once: true });
+            if (signal.aborted) abortFromHost();
+          } else if (config.timeout !== undefined)
             timer = setTimeout(() => {
               const error = new Error(
                 `SDK host timed out after ${config.timeout} ms.`
@@ -394,6 +410,7 @@ export function createVercelOrchestrator(): MCPHostSimulator {
         };
       } finally {
         clearTimeout(timer);
+        if (abortFromHost) signal?.removeEventListener('abort', abortFromHost);
         controller.abort();
       }
     },

--- a/src/evals/mcpHost/adapters/vercel.ts
+++ b/src/evals/mcpHost/adapters/vercel.ts
@@ -18,6 +18,22 @@ import type {
 import type { UsageMetrics } from '../../../types/index.js';
 import type { MCPFixtureApi } from '../../../mcp/fixtures/mcpFixture.js';
 import { extractText } from '../../../mcp/response.js';
+import { z } from 'zod';
+import {
+  GenerationOptions,
+  ProviderSchema,
+  type HostEnvironment,
+} from '../hostOptions.js';
+
+const SdkConfigSchema = z
+  .object({
+    hostType: z.literal('sdk').optional(),
+    provider: ProviderSchema,
+    ...GenerationOptions,
+    apiKeyEnvVar: z.string().min(1).optional(),
+    env: z.record(z.string(), z.string().optional()).optional(),
+  })
+  .strict();
 
 /**
  * Classifies a raw error from the Vercel AI SDK agentic loop and returns a
@@ -102,15 +118,29 @@ function enrichErrorMessage(err: unknown, provider: string): string {
 
 // Dynamic import helper bypasses TypeScript module resolution for optional peer deps.
 // Each @ai-sdk/* package is optional — install only the providers you need.
-async function loadModel(provider: LLMProvider, model: string): Promise<any> {
+async function loadModel(
+  provider: LLMProvider,
+  model: string,
+  config: MCPHostConfig
+): Promise<any> {
+  const env: HostEnvironment = { ...process.env, ...config.env };
+  function apiKey(defaultName: string): string {
+    return env[config.apiKeyEnvVar ?? defaultName] ?? '';
+  }
   switch (provider) {
     case 'openai': {
-      const { openai } = await import('@ai-sdk/openai');
-      return openai(model);
+      const { createOpenAI } = await import('@ai-sdk/openai');
+      return createOpenAI({
+        apiKey: apiKey('OPENAI_API_KEY'),
+        baseURL: env.OPENAI_BASE_URL,
+      })(model);
     }
     case 'anthropic': {
-      const { anthropic } = await import('@ai-sdk/anthropic');
-      return anthropic(model);
+      const { createAnthropic } = await import('@ai-sdk/anthropic');
+      return createAnthropic({
+        apiKey: apiKey('ANTHROPIC_API_KEY'),
+        baseURL: env.ANTHROPIC_BASE_URL,
+      })(model);
     }
     case 'vertex-anthropic': {
       // Anthropic via Google Vertex AI — uses Application Default Credentials.
@@ -120,40 +150,49 @@ async function loadModel(provider: LLMProvider, model: string): Promise<any> {
       const { createVertexAnthropic } =
         await import('@ai-sdk/google-vertex/anthropic');
       const vertexAnthropic = createVertexAnthropic({
-        project: process.env.GOOGLE_VERTEX_PROJECT,
-        location: process.env.GOOGLE_VERTEX_LOCATION ?? 'us-east5',
+        project: env.GOOGLE_VERTEX_PROJECT,
+        location: env.GOOGLE_VERTEX_LOCATION ?? 'us-east5',
+        googleAuthOptions: env.GOOGLE_APPLICATION_CREDENTIALS
+          ? { keyFilename: env.GOOGLE_APPLICATION_CREDENTIALS }
+          : undefined,
       });
       return (vertexAnthropic as unknown as (m: string) => unknown)(model);
     }
     case 'google': {
       // @ts-ignore - optional: npm install @ai-sdk/google
-      const { google } = await import('@ai-sdk/google');
-      return (google as any)(model);
+      const { createGoogleGenerativeAI } = await import('@ai-sdk/google');
+      return createGoogleGenerativeAI({
+        apiKey: apiKey('GOOGLE_GENERATIVE_AI_API_KEY'),
+      })(model);
     }
     case 'mistral': {
       // @ts-ignore - optional: npm install @ai-sdk/mistral
-      const { mistral } = await import('@ai-sdk/mistral');
-      return (mistral as any)(model);
+      const { createMistral } = await import('@ai-sdk/mistral');
+      return createMistral({ apiKey: apiKey('MISTRAL_API_KEY') })(model);
     }
     case 'azure': {
       // @ts-ignore - optional: npm install @ai-sdk/azure
-      const { azure } = await import('@ai-sdk/azure');
-      return (azure as any)(model);
+      const { createAzure } = await import('@ai-sdk/azure');
+      return createAzure({
+        apiKey: apiKey('AZURE_API_KEY'),
+        resourceName: env.AZURE_RESOURCE_NAME,
+        baseURL: env.AZURE_BASE_URL,
+      })(model);
     }
     case 'deepseek': {
       // @ts-ignore - optional: npm install @ai-sdk/deepseek
-      const { deepseek } = await import('@ai-sdk/deepseek');
-      return (deepseek as any)(model);
+      const { createDeepSeek } = await import('@ai-sdk/deepseek');
+      return createDeepSeek({ apiKey: apiKey('DEEPSEEK_API_KEY') })(model);
     }
     case 'openrouter': {
       // @ts-ignore - optional: npm install @openrouter/ai-sdk-provider
-      const { openrouter } = await import('@openrouter/ai-sdk-provider');
-      return (openrouter as any)(model);
+      const { createOpenRouter } = await import('@openrouter/ai-sdk-provider');
+      return createOpenRouter({ apiKey: apiKey('OPENROUTER_API_KEY') })(model);
     }
     case 'xai': {
       // @ts-ignore - optional: npm install @ai-sdk/xai
-      const { xai } = await import('@ai-sdk/xai');
-      return (xai as any)(model);
+      const { createXai } = await import('@ai-sdk/xai');
+      return createXai({ apiKey: apiKey('XAI_API_KEY') })(model);
     }
     default:
       throw new Error(
@@ -190,24 +229,49 @@ export function createVercelOrchestrator(): MCPHostSimulator {
       scenario: string,
       config: MCPHostConfig
     ): Promise<MCPHostSimulationResult> {
+      const controller = new AbortController();
+      let timer: ReturnType<typeof setTimeout> | undefined;
+      const allToolCalls: LLMToolCall[] = [];
+      let expired: Promise<never>;
+      function withinDeadline<T>(promise: Promise<T>): Promise<T> {
+        return Promise.race([promise, expired]);
+      }
       try {
-        const { generateText, stepCountIs } = await import('ai');
+        SdkConfigSchema.parse(config);
+        expired = new Promise<never>((_, reject) => {
+          if (config.timeout !== undefined)
+            timer = setTimeout(() => {
+              const error = new Error(
+                `SDK host timed out after ${config.timeout} ms.`
+              );
+              controller.abort(error);
+              reject(error);
+            }, config.timeout);
+        });
+        const { generateText, stepCountIs } = await withinDeadline(
+          import('ai')
+        );
         // jsonSchema from @ai-sdk/provider-utils creates a proper Schema object
         // (with .jsonSchema property) that ai's prepareToolsAndToolChoice can read.
         // Do NOT use jsonSchema from 'ai' — in v6 it produces the wrong shape.
-        const { jsonSchema } = await import('@ai-sdk/provider-utils');
+        const { jsonSchema } = await withinDeadline(
+          import('@ai-sdk/provider-utils')
+        );
 
         if (!config.provider) {
           throw new Error('provider is required for SDK host type');
         }
 
         const modelId = config.model ?? defaultModel(config.provider);
-        const model = await loadModel(config.provider, modelId);
+        const model = await withinDeadline(
+          loadModel(config.provider, modelId, config)
+        );
 
         // Get available MCP tools and wrap them for Vercel AI SDK
-        const mcpTools = await mcp.listTools();
+        const mcpTools = await withinDeadline(mcp.listTools());
         let mcpDurationMs = 0;
-        const allToolCalls: LLMToolCall[] = [];
+        let attemptedToolCalls = 0;
+        let budgetError: Error | undefined;
 
         // Build tool definitions in Vercel AI SDK format.
         // Uses any because the tool() generic requires inferred parameter types
@@ -224,21 +288,34 @@ export function createVercelOrchestrator(): MCPHostSimulator {
             type: 'object',
             ...(mcpTool.inputSchema as Record<string, unknown>),
           };
-          tools[toolName] = {
+          const encodedName = toolName.replaceAll('.', '__');
+          if (tools[encodedName])
+            throw new Error(`Duplicate encoded tool name: ${encodedName}`);
+          tools[encodedName] = {
             description: mcpTool.description ?? '',
             inputSchema: jsonSchema(rawSchema),
             execute: async (
               args: Record<string, unknown>,
               opts?: { toolCallId?: string }
             ) => {
+              if (controller.signal.aborted) throw controller.signal.reason;
+              if (attemptedToolCalls >= (config.maxToolCalls ?? 10)) {
+                budgetError = new Error(
+                  `Tool call budget exhausted (${config.maxToolCalls ?? 10}).`
+                );
+                throw budgetError;
+              }
+              attemptedToolCalls++;
               const mcpStart = Date.now();
-              const result = await mcp.callTool(toolName, args);
+              const result = await withinDeadline(mcp.callTool(toolName, args));
               mcpDurationMs += Date.now() - mcpStart;
 
               const output = extractText(result);
               allToolCalls.push({
                 id: opts?.toolCallId,
                 name: toolName,
+                source: 'mcp',
+                rawName: encodedName,
                 arguments: args,
                 output,
               });
@@ -250,22 +327,27 @@ export function createVercelOrchestrator(): MCPHostSimulator {
         const maxSteps = config.maxToolCalls ?? 10;
         const llmStart = Date.now();
 
-        const result = await (generateText as any)({
-          model,
-          prompt: scenario,
-          tools,
-          stopWhen: stepCountIs(maxSteps),
-          temperature: config.temperature ?? 0,
-          maxTokens: config.maxTokens,
-        });
+        const result = await withinDeadline(
+          generateText({
+            model,
+            prompt: scenario,
+            tools,
+            stopWhen: stepCountIs(Math.max(1, maxSteps)),
+            temperature: config.temperature ?? 0,
+            maxOutputTokens: config.maxTokens,
+            abortSignal: controller.signal,
+          })
+        );
+        if (budgetError) throw budgetError;
 
         const totalDurationMs = Date.now() - llmStart;
         const llmDurationMs = totalDurationMs - mcpDurationMs;
 
-        const hostUsage: UsageMetrics | undefined = result.usage
+        const usage = result.totalUsage ?? result.usage;
+        const hostUsage: UsageMetrics | undefined = usage
           ? {
-              inputTokens: (result.usage.promptTokens as number) ?? 0,
-              outputTokens: (result.usage.completionTokens as number) ?? 0,
+              inputTokens: usage.inputTokens ?? 0,
+              outputTokens: usage.outputTokens ?? 0,
               totalCostUsd: 0,
               durationMs: llmDurationMs,
             }
@@ -275,7 +357,11 @@ export function createVercelOrchestrator(): MCPHostSimulator {
           role: 'tool' | 'assistant';
           content?: string;
           toolCallId?: string;
-        }> = (result.steps ?? []).flatMap((step: any) => {
+        }> = (result.steps ?? []).flatMap<{
+          role: 'tool' | 'assistant';
+          content?: string;
+          toolCallId?: string;
+        }>((step) => {
           if (step.toolCalls?.length > 0) {
             // Reference each call by id; the payload lives once on allToolCalls.
             return (step.toolCalls as Array<{ toolCallId?: string }>).map(
@@ -303,9 +389,12 @@ export function createVercelOrchestrator(): MCPHostSimulator {
       } catch (err) {
         return {
           success: false,
-          toolCalls: [],
+          toolCalls: allToolCalls,
           error: enrichErrorMessage(err, config.provider ?? 'unknown'),
         };
+      } finally {
+        clearTimeout(timer);
+        controller.abort();
       }
     },
   };

--- a/src/evals/mcpHost/hostOptions.ts
+++ b/src/evals/mcpHost/hostOptions.ts
@@ -1,0 +1,67 @@
+import { z } from 'zod';
+import type { Tool } from '@modelcontextprotocol/sdk/types.js';
+
+export const ProviderSchema = z.enum([
+  'openai',
+  'anthropic',
+  'azure',
+  'google',
+  'mistral',
+  'deepseek',
+  'openrouter',
+  'xai',
+  'vertex-anthropic',
+]);
+export const GenerationOptions = {
+  model: z.string().min(1).optional(),
+  maxToolCalls: z.number().int().nonnegative().optional(),
+  timeout: z.number().int().positive().optional(),
+  temperature: z.number().min(0).max(1).optional(),
+  maxTokens: z.number().int().positive().optional(),
+};
+
+export type HostEnvironment = Record<string, string | undefined>;
+
+/** Read execution-local credentials without mutating the parent process. */
+export function hostEnvironment(
+  input: { env?: HostEnvironment },
+  context: { env?: HostEnvironment }
+): HostEnvironment {
+  return { ...process.env, ...context.env, ...input.env };
+}
+
+/** Overrides use canonical server.tool names, never provider-encoded names.
+ * Bare names are allowed only when unambiguous; qualified overrides take priority.
+ */
+export function overrideHostTools<T extends Tool & { server?: string }>(
+  tools: T[],
+  overrides?: {
+    tools: Record<
+      string,
+      { description?: string; inputSchema?: Record<string, unknown> }
+    >;
+  }
+): T[] {
+  for (const key of Object.keys(overrides?.tools ?? {})) {
+    const matches = tools.filter(
+      (tool) => key === tool.name || key === `${tool.server}.${tool.name}`
+    );
+    if (matches.length !== 1)
+      throw new Error(
+        `${matches.length ? 'Ambiguous' : 'Unknown'} tool override: ${key}`
+      );
+  }
+  return tools.map((tool) => {
+    const override =
+      overrides?.tools[`${tool.server}.${tool.name}`] ??
+      overrides?.tools[tool.name];
+    return override
+      ? {
+          ...tool,
+          ...override,
+          inputSchema: (override.inputSchema ??
+            tool.inputSchema) as Tool['inputSchema'],
+        }
+      : tool;
+  });
+}

--- a/src/evals/mcpHost/mcpHostSimulation.ts
+++ b/src/evals/mcpHost/mcpHostSimulation.ts
@@ -95,7 +95,23 @@ export async function simulateMCPHost(
           `Provide { command } with a shell command containing {{scenario}}.`
       );
     }
-    return runCLIHost(config.cli, scenario);
+    if (
+      config.temperature !== undefined ||
+      config.maxTokens !== undefined ||
+      config.maxToolCalls !== undefined
+    ) {
+      throw new Error(
+        'CLI hosts do not support temperature, maxTokens or maxToolCalls.'
+      );
+    }
+    return runCLIHost(
+      {
+        ...config.cli,
+        timeout: config.timeout ?? config.cli.timeout,
+        env: { ...config.env, ...config.cli.env },
+      },
+      scenario
+    );
   }
 
   if (hostType === 'browser' || hostType === 'desktop') {

--- a/src/evals/mcpHost/mcpHostSimulation.ts
+++ b/src/evals/mcpHost/mcpHostSimulation.ts
@@ -84,7 +84,8 @@ const simulatorRegistry = new Map<LLMProvider, MCPHostSimulator>(
 export async function simulateMCPHost(
   mcp: MCPFixtureApi,
   scenario: string,
-  config: MCPHostConfig
+  config: MCPHostConfig,
+  signal?: AbortSignal
 ): Promise<MCPHostSimulationResult> {
   const hostType = config.hostType ?? 'sdk';
 
@@ -110,7 +111,8 @@ export async function simulateMCPHost(
         timeout: config.timeout ?? config.cli.timeout,
         env: { ...config.env, ...config.cli.env },
       },
-      scenario
+      scenario,
+      signal
     );
   }
 
@@ -136,7 +138,7 @@ export async function simulateMCPHost(
         `Supported: ${allProviders.join(', ')}`
     );
   }
-  return simulator.simulate(mcp, scenario, config);
+  return simulator.simulate(mcp, scenario, config, signal);
 }
 
 /**

--- a/src/evals/mcpHost/mcpHostTypes.ts
+++ b/src/evals/mcpHost/mcpHostTypes.ts
@@ -176,7 +176,7 @@ export interface BrowserConfig {
 export interface MCPHostConfig {
   /** Execution-local environment overrides; never assigned to process.env. */
   env?: Record<string, string | undefined>;
-  /** End-to-end SDK execution deadline in milliseconds. */
+  /** Execution deadline in milliseconds, including registered host-owned setup and teardown. */
   timeout?: number;
   /**
    * Host type for the simulation.
@@ -326,6 +326,8 @@ export interface MCPHostSimulator {
   simulate(
     mcp: MCPFixtureApi,
     scenario: string,
-    config: MCPHostConfig
+    config: MCPHostConfig,
+    /** Optional enclosing host deadline; does not cover caller-owned fixtures. */
+    signal?: AbortSignal
   ): Promise<MCPHostSimulationResult>;
 }

--- a/src/evals/mcpHost/mcpHostTypes.ts
+++ b/src/evals/mcpHost/mcpHostTypes.ts
@@ -174,6 +174,10 @@ export interface BrowserConfig {
  * Configuration for MCP host simulation
  */
 export interface MCPHostConfig {
+  /** Execution-local environment overrides; never assigned to process.env. */
+  env?: Record<string, string | undefined>;
+  /** End-to-end SDK execution deadline in milliseconds. */
+  timeout?: number;
   /**
    * Host type for the simulation.
    *

--- a/src/evals/mcpHost/mcpHostTypes.ts
+++ b/src/evals/mcpHost/mcpHostTypes.ts
@@ -89,6 +89,8 @@ export type CLIOutputFormat = 'stream-json' | 'json';
  * ```
  */
 export interface CLIConfig {
+  /** Child-process-only environment overrides. Undefined removes an inherited key. */
+  env?: Record<string, string | undefined>;
   /**
    * CLI binary to invoke.
    */

--- a/src/evals/metrics.test.ts
+++ b/src/evals/metrics.test.ts
@@ -123,10 +123,111 @@ describe('computeMetrics', () => {
     expect(metrics.perCase.one!.judge_score).toEqual({ quality: 0.9 });
     expect(metrics.perCase.two!.cost_usd).toBeNull();
     expect(metrics.aggregated.passed_rate).toBe(0.5);
-    expect(metrics.aggregated.input_tokens_mean).toBe(8.5);
+    expect(metrics.perCase.two!.input_tokens).toBeNull();
+    expect(metrics.aggregated.input_tokens_mean).toBe(17);
     expect(metrics.aggregated.cost_usd_mean).toBe(0.2);
     expect(metrics.aggregated.quality_score_mean).toBe(0.9);
     expect(metrics.aggregated.judge_score).toEqual({ quality: 0.9 });
+  });
+
+  it('keeps unknown input usage null while including measured zero in the mean', () => {
+    const unknown = computeMetrics(['input_tokens'], [result('unknown', true)]);
+    expect(unknown.perCase.unknown?.input_tokens).toBeNull();
+    expect(unknown.aggregated).not.toHaveProperty('input_tokens_mean');
+    const measured = computeMetrics(
+      ['input_tokens'],
+      [
+        result('unknown', true),
+        result('zero', true, {
+          usage: {
+            inputTokens: 0,
+            outputTokens: 0,
+            totalCostUsd: 0,
+            durationMs: 0,
+          },
+        }),
+        result('known', true, {
+          usage: {
+            inputTokens: 10,
+            outputTokens: 1,
+            totalCostUsd: 0,
+            durationMs: 0,
+          },
+        }),
+      ]
+    );
+    expect(measured.perCase.zero?.input_tokens).toBe(0);
+    expect(measured.aggregated.input_tokens_mean).toBe(5);
+  });
+
+  it('passes tagged metric options through to compute without routing metadata', () => {
+    const compute = vi.fn(
+      (_row: EvalCaseResult, options?: Record<string, unknown>) =>
+        Number(options?.weight)
+    );
+    registerMetric({
+      name: 'weighted',
+      schema: z.object({ weight: z.number() }),
+      kind: 'continuous',
+      compute,
+    });
+    const metrics = computeMetrics(
+      [{ type: 'weighted', name: 'weighted_alias', weight: 7 }],
+      [result('one', true)]
+    );
+    expect(metrics.perCase.one?.weighted_alias).toBe(7);
+    expect(compute).toHaveBeenCalledWith(expect.anything(), { weight: 7 });
+  });
+
+  it('retains parsed top-level defaults and transforms without reparsing', () => {
+    registerMetric({
+      name: 'weighted-parsed',
+      schema: z.object({
+        weight: z
+          .number()
+          .default(3)
+          .transform((value) => value * 2),
+      }),
+      kind: 'continuous',
+      compute: (_row, options) => Number(options?.weight),
+    });
+    const parsed = validateManifestRegistrations({
+      name: 'metrics',
+      datasets: [],
+      metrics: [{ type: 'weighted-parsed', name: 'alias' }],
+    });
+    expect(
+      computeMetrics(parsed.metrics ?? [], [result('one', true)]).perCase.one
+        ?.alias
+    ).toBe(6);
+  });
+
+  it('flattens legacy params only when keys do not overlap top-level options', () => {
+    expect(
+      resolveMetric({ type: 'passed', params: { weight: 7 } }).params
+    ).toEqual({ weight: 7 });
+    expect(
+      resolveMetric({ type: 'passed', weight: 7, params: { offset: 2 } }).params
+    ).toEqual({ weight: 7, offset: 2 });
+    for (const weight of [7, 8]) {
+      expect(() =>
+        resolveMetric({ type: 'passed', weight: 7, params: { weight } })
+      ).toThrow('Ambiguous metric option "weight"');
+    }
+  });
+
+  it('accepts tagged top-level judge options with default output names', () => {
+    const manifest = validateManifestRegistrations({
+      name: 'metrics',
+      datasets: [],
+      metrics: [{ type: 'judge_score_for', judge: 'quality' }],
+    });
+    const metrics = computeMetrics(manifest.metrics ?? [], [
+      result('one', true, {
+        judge: { name: 'quality', pass: true, score: 0.7 },
+      }),
+    ]);
+    expect(metrics.perCase.one?.judge_quality_score).toBe(0.7);
   });
 
   it('extracts text from direct MCP content responses', () => {

--- a/src/evals/metrics.test.ts
+++ b/src/evals/metrics.test.ts
@@ -1,0 +1,261 @@
+import { z } from 'zod';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { EvalCaseResult } from '../types/reporter.js';
+import {
+  BUILT_IN_METRICS,
+  METRIC_REGISTRY,
+  computeMetrics,
+  registerMetric,
+  resolveMetric,
+  type MetricDefinition,
+} from './metrics.js';
+import {
+  clearMetrics,
+  getMetric,
+  registerMetric as registerFrameworkMetric,
+  validateManifestRegistrations,
+} from './frameworkRegistries.js';
+
+afterEach(() => {
+  clearMetrics();
+  for (const definition of Object.values(BUILT_IN_METRICS))
+    registerFrameworkMetric(definition);
+});
+
+function result(
+  id: string,
+  pass: boolean,
+  options: {
+    calls?: string[];
+    usage?: EvalCaseResult['hostUsage'];
+    judge?: { name: string; pass: boolean; score: number };
+    response?: EvalCaseResult['response'];
+  } = {}
+): EvalCaseResult {
+  return {
+    id,
+    datasetName: 'metrics',
+    toolName: 'test',
+    source: 'eval',
+    pass,
+    response: options.response ?? {
+      toolCalls: (options.calls ?? []).map((name) => ({ name })),
+      response: 'one two three',
+    },
+    expectations: options.judge
+      ? {
+          judge: {
+            pass: options.judge.pass,
+            score: options.judge.score,
+            judgeName: options.judge.name,
+          },
+        }
+      : {},
+    authType: 'none',
+    durationMs: 1000,
+    hostUsage: options.usage,
+  };
+}
+
+describe('computeMetrics', () => {
+  it('aggregates public plugin metrics by kind when no custom aggregate is provided', () => {
+    registerFrameworkMetric({
+      name: 'plugin-binary',
+      schema: z.object({}),
+      kind: 'binary',
+      compute: (row) => row.pass,
+    });
+    registerFrameworkMetric({
+      name: 'plugin-continuous',
+      schema: z.object({}),
+      kind: 'continuous',
+      compute: (row) => row.durationMs,
+    });
+    const metrics = computeMetrics(
+      ['plugin-binary', 'plugin-continuous'],
+      [result('a', true), result('b', false)]
+    );
+    expect(metrics.aggregated['plugin-binary_rate']).toBe(0.5);
+    expect(metrics.aggregated['plugin-continuous_mean']).toBe(1000);
+  });
+  it('computes Scio-compatible metrics and aggregates nulls correctly', () => {
+    const cases = [
+      result('one', true, {
+        calls: ['search', 'read'],
+        usage: {
+          inputTokens: 10,
+          outputTokens: 20,
+          totalCostUsd: 0.2,
+          durationMs: 100,
+          durationApiMs: 50,
+          cacheReadInputTokens: 3,
+          cacheCreationInputTokens: 4,
+        },
+        judge: { name: 'quality', pass: true, score: 0.9 },
+      }),
+      result('two', false),
+    ];
+
+    const metrics = computeMetrics(
+      [
+        'passed',
+        'input_tokens',
+        'input_tokens_uncached',
+        'cost_usd',
+        'duration_api_s',
+        'tool_count',
+        'response_words',
+        'judge_score',
+        {
+          metric: 'judge_score_for',
+          name: 'quality_score',
+          params: { judge: 'quality' },
+        },
+      ],
+      cases
+    );
+
+    expect(metrics.perCase.one!.input_tokens).toBe(17);
+    expect(metrics.perCase.one!.input_tokens_uncached).toBe(10);
+    expect(metrics.perCase.one!.duration_api_s).toBe(0.05);
+    expect(metrics.perCase.one!.tool_count).toBe(2);
+    expect(metrics.perCase.one!.response_words).toBe(3);
+    expect(metrics.perCase.one!.judge_score).toEqual({ quality: 0.9 });
+    expect(metrics.perCase.two!.cost_usd).toBeNull();
+    expect(metrics.aggregated.passed_rate).toBe(0.5);
+    expect(metrics.aggregated.input_tokens_mean).toBe(8.5);
+    expect(metrics.aggregated.cost_usd_mean).toBe(0.2);
+    expect(metrics.aggregated.quality_score_mean).toBe(0.9);
+    expect(metrics.aggregated.judge_score).toEqual({ quality: 0.9 });
+  });
+
+  it('extracts text from direct MCP content responses', () => {
+    const metrics = computeMetrics(
+      ['response_len', 'response_words'],
+      [
+        result('direct', true, {
+          response: {
+            content: [{ type: 'text', text: 'one two three' }],
+          },
+        }),
+      ]
+    );
+
+    expect(metrics.perCase.direct!.response_len).toBe(13);
+    expect(metrics.perCase.direct!.response_words).toBe(3);
+  });
+
+  it('aggregates duplicate IDs independently across datasets and repeated arms', () => {
+    const cases = [
+      result('shared', true),
+      { ...result('shared', false), datasetName: 'other' },
+      result('shared', false),
+    ];
+    const metrics = computeMetrics(['passed'], cases);
+    expect(Object.keys(metrics.perCase)).toHaveLength(3);
+    expect(Object.values(metrics.perCase).map((row) => row.passed)).toEqual([
+      true,
+      false,
+      false,
+    ]);
+    expect(metrics.aggregated.passed_rate).toBeCloseTo(1 / 3);
+    expect(
+      metrics.perCase[JSON.stringify(['metrics', 'shared', 0])]?.passed
+    ).toBe(true);
+  });
+
+  it('avoids collisions with generated keys and handles prototype-like case IDs', () => {
+    const cases = [
+      result('same', true),
+      result('same', false),
+      result(JSON.stringify(['metrics', 'same', 0]), true),
+      result('__proto__', false),
+    ];
+    const metrics = computeMetrics(['passed'], cases);
+    expect(Object.keys(metrics.perCase)).toHaveLength(4);
+    expect(metrics.perCase.__proto__?.passed).toBe(false);
+    expect(metrics.aggregated.passed_rate).toBe(0.5);
+  });
+
+  it('uses one registry for both registration APIs, validation, computation, and clearing', async () => {
+    const definition: MetricDefinition = {
+      name: 'plugin-metric',
+      schema: z.object({
+        params: z
+          .object({
+            factor: z
+              .number()
+              .default(3)
+              .transform((value) => value * 2),
+          })
+          .default({ factor: 6 }),
+      }),
+      kind: 'continuous',
+      compute: (_case, params) => Number(params?.factor),
+    };
+    registerFrameworkMetric(definition);
+    expect(METRIC_REGISTRY['plugin-metric']).toBe(definition);
+    const parsed = validateManifestRegistrations({
+      name: 'metrics',
+      datasets: [],
+      metrics: [{ type: 'plugin-metric', name: 'alias', params: {} }],
+    });
+    expect(
+      computeMetrics(parsed.metrics ?? [], [result('one', true)]).perCase.one
+        ?.alias
+    ).toBe(6);
+    const duplicate = { ...definition, compute: () => 99 };
+    expect(() => registerMetric(duplicate)).toThrow('already registered');
+    expect(() => {
+      METRIC_REGISTRY['plugin-metric'] = duplicate;
+    }).toThrow('already registered');
+    expect(getMetric('plugin-metric')).toBe(definition);
+    expect(resolveMetric('plugin-metric').metric).toBe(definition);
+    expect(() => registerMetric(definition)).not.toThrow();
+    vi.resetModules();
+    const secondCopy = await import('./metrics.js');
+    expect(secondCopy.resolveMetric('plugin-metric').metric).toBe(definition);
+    const secondDefinition = { ...definition, name: 'second-copy' };
+    secondCopy.registerMetric(secondDefinition);
+    expect(getMetric('second-copy')).toBe(secondDefinition);
+    clearMetrics();
+    expect(Object.keys(METRIC_REGISTRY)).toEqual([]);
+    expect(() => secondCopy.resolveMetric('plugin-metric')).toThrow(
+      'Unknown metric'
+    );
+  });
+
+  it('validates parameterized built-ins and output aliases through the same registry', () => {
+    const parsed = validateManifestRegistrations({
+      name: 'metrics',
+      datasets: [],
+      metrics: [
+        {
+          type: 'judge_score_for',
+          name: 'quality_score',
+          params: { judge: 'quality' },
+        },
+      ],
+    });
+    expect(
+      computeMetrics(parsed.metrics ?? [], [
+        result('one', true, {
+          judge: { name: 'quality', pass: true, score: 0.7 },
+        }),
+      ]).perCase.one?.quality_score
+    ).toBe(0.7);
+    expect(() =>
+      validateManifestRegistrations({
+        name: 'metrics',
+        datasets: [],
+        metrics: [{ type: 'judge_score_for' }],
+      })
+    ).toThrow('Invalid metric options');
+  });
+
+  it('rejects unknown metric names instead of silently dropping them', () => {
+    expect(() => computeMetrics(['not-a-metric'], [])).toThrow(
+      'Unknown metric "not-a-metric"'
+    );
+  });
+});

--- a/src/evals/metrics.ts
+++ b/src/evals/metrics.ts
@@ -1,0 +1,498 @@
+import { z } from 'zod';
+import type { EvalCaseResult } from '../types/reporter.js';
+import type { UsageMetrics } from '../types/index.js';
+import {
+  getMetric,
+  listMetrics,
+  registerMetric as registerFrameworkMetric,
+} from './frameworkRegistries.js';
+export type MetricSpec =
+  | string
+  | {
+      metric?: string;
+      type?: string;
+      name?: string;
+      params?: Record<string, unknown>;
+    };
+
+import type {
+  MetricValue,
+  MetricKind,
+  MetricDefinition,
+  ResolvedMetric,
+} from './evalFrameworkTypes.js';
+export type {
+  MetricValue,
+  MetricKind,
+  MetricDefinition,
+  ResolvedMetric,
+} from './evalFrameworkTypes.js';
+
+export interface MetricResult {
+  perCase: Record<string, Record<string, MetricValue>>;
+  aggregated: Record<string, unknown>;
+}
+
+function hostUsage(caseResult: EvalCaseResult): UsageMetrics | undefined {
+  return caseResult.hostUsage;
+}
+
+function responseObject(caseResult: EvalCaseResult): Record<string, unknown> {
+  const response = caseResult.response;
+  return response && typeof response === 'object'
+    ? (response as Record<string, unknown>)
+    : {};
+}
+
+function toolCalls(caseResult: EvalCaseResult): unknown[] {
+  const calls = responseObject(caseResult).toolCalls;
+  return Array.isArray(calls) ? calls : [];
+}
+
+function responseText(caseResult: EvalCaseResult): string {
+  const response = responseObject(caseResult);
+  if (typeof response.response === 'string') return response.response;
+  if (!Array.isArray(response.content)) return '';
+  return response.content
+    .map((item) => {
+      if (!item || typeof item !== 'object') return '';
+      const text = (item as Record<string, unknown>).text;
+      return typeof text === 'string' ? text : '';
+    })
+    .filter(Boolean)
+    .join('\n');
+}
+
+function judgeEntries(
+  caseResult: EvalCaseResult
+): Array<Record<string, unknown>> {
+  const judge = caseResult.expectations?.judge as
+    Record<string, unknown> | undefined;
+  if (!judge) return [];
+  const nested = judge.judgeResults;
+  if (Array.isArray(nested)) {
+    return nested.filter(
+      (entry): entry is Record<string, unknown> =>
+        Boolean(entry) && typeof entry === 'object'
+    );
+  }
+  return [judge];
+}
+
+function scoreFromJudge(entry: Record<string, unknown>): number | null {
+  if (typeof entry.score === 'number') return entry.score;
+  if (typeof entry.details !== 'string') return null;
+  const match = entry.details.match(/score\s+([0-9]*\.?[0-9]+)/i);
+  return match ? Number(match[1]) : null;
+}
+
+function judgeName(entry: Record<string, unknown>): string {
+  return typeof entry.judgeName === 'string' && entry.judgeName
+    ? entry.judgeName
+    : 'judge';
+}
+
+function judgeScores(caseResult: EvalCaseResult): Record<string, number> {
+  const scores: Record<string, number> = {};
+  for (const entry of judgeEntries(caseResult)) {
+    const score = scoreFromJudge(entry);
+    if (score !== null) scores[judgeName(entry)] = score;
+  }
+  return scores;
+}
+
+function judgePass(caseResult: EvalCaseResult): boolean | null {
+  const entries = judgeEntries(caseResult);
+  if (entries.length === 0) return null;
+  const verdicts = entries
+    .map((entry) => entry.pass)
+    .filter((value): value is boolean => typeof value === 'boolean');
+  return verdicts.length > 0 ? verdicts.every(Boolean) : null;
+}
+
+function meanAggregation(
+  values: MetricValue[],
+  metric: ResolvedMetric
+): { key: string; value: unknown } | undefined {
+  const numbers = values.filter(
+    (value): value is number => typeof value === 'number'
+  );
+  return numbers.length > 0
+    ? {
+        key: `${metric.outName}_mean`,
+        value: numbers.reduce((sum, value) => sum + value, 0) / numbers.length,
+      }
+    : undefined;
+}
+
+function rateAggregation(
+  values: MetricValue[],
+  metric: ResolvedMetric
+): { key: string; value: unknown } | undefined {
+  const booleans = values.filter(
+    (value): value is boolean => typeof value === 'boolean'
+  );
+  return booleans.length > 0
+    ? {
+        key: `${metric.outName}_rate`,
+        value: booleans.filter(Boolean).length / booleans.length,
+      }
+    : undefined;
+}
+
+function judgeScoreAggregation(
+  values: MetricValue[],
+  metric: ResolvedMetric
+): { key: string; value: unknown } | undefined {
+  const byJudge: Record<string, number[]> = {};
+  for (const value of values) {
+    if (!value || typeof value !== 'object' || Array.isArray(value)) continue;
+    for (const [name, score] of Object.entries(value)) {
+      if (typeof score === 'number') (byJudge[name] ??= []).push(score);
+    }
+  }
+  const averaged: Record<string, number> = {};
+  for (const [name, scores] of Object.entries(byJudge)) {
+    averaged[name] =
+      scores.reduce((sum, score) => sum + score, 0) / scores.length;
+  }
+  return Object.keys(averaged).length > 0
+    ? { key: metric.outName, value: averaged }
+    : undefined;
+}
+
+function metric(
+  name: string,
+  kind: MetricKind,
+  compute: MetricDefinition['compute'],
+  aggregate?: MetricDefinition['aggregate'],
+  unit?: string
+): MetricDefinition {
+  return {
+    name,
+    schema: z.object({}).passthrough(),
+    kind,
+    compute,
+    aggregate,
+    unit,
+  };
+}
+
+function parameterizedJudgeMetric(
+  name: 'judge_pass_for' | 'judge_score_for'
+): MetricDefinition {
+  const passMetric = name === 'judge_pass_for';
+  return {
+    ...metric(
+      name,
+      passMetric ? 'binary' : 'continuous',
+      (result, params) => {
+        const entry = judgeEntries(result).find(
+          (item) => judgeName(item) === params?.judge
+        );
+        if (!entry) return null;
+        return passMetric
+          ? typeof entry.pass === 'boolean'
+            ? entry.pass
+            : null
+          : scoreFromJudge(entry);
+      },
+      passMetric ? rateAggregation : meanAggregation
+    ),
+    schema: z
+      .object({ params: z.object({ judge: z.string().min(1) }) })
+      .passthrough(),
+  };
+}
+
+const BUILT_INS_KEY = Symbol.for('mcp-server-tester.built-in-metrics');
+const globalMetrics = globalThis as unknown as Record<symbol, unknown>;
+
+/** Built-in metrics, including the metrics used by Scio's evaluations. */
+export const BUILT_IN_METRICS: Record<string, MetricDefinition> =
+  (globalMetrics[BUILT_INS_KEY] as
+    Record<string, MetricDefinition> | undefined) ?? {
+    judge_pass_for: parameterizedJudgeMetric('judge_pass_for'),
+    judge_score_for: parameterizedJudgeMetric('judge_score_for'),
+    passed: metric(
+      'passed',
+      'binary',
+      (result) => result.pass,
+      rateAggregation
+    ),
+    response_success: metric(
+      'response_success',
+      'binary',
+      (result) => responseObject(result).success !== false,
+      rateAggregation
+    ),
+    is_no_action: metric(
+      'is_no_action',
+      'binary',
+      (result) => toolCalls(result).length === 0,
+      rateAggregation
+    ),
+    cost_usd: metric(
+      'cost_usd',
+      'continuous',
+      (result) => hostUsage(result)?.totalCostUsd ?? null,
+      meanAggregation,
+      'USD'
+    ),
+    input_tokens: metric(
+      'input_tokens',
+      'continuous',
+      (result) => {
+        const usage = hostUsage(result);
+        return usage
+          ? usage.inputTokens +
+              (usage.cacheReadInputTokens ?? 0) +
+              (usage.cacheCreationInputTokens ?? 0)
+          : 0;
+      },
+      meanAggregation,
+      'tokens'
+    ),
+    input_tokens_uncached: metric(
+      'input_tokens_uncached',
+      'continuous',
+      (result) => hostUsage(result)?.inputTokens ?? null,
+      meanAggregation,
+      'tokens'
+    ),
+    cache_read_tokens: metric(
+      'cache_read_tokens',
+      'continuous',
+      (result) => hostUsage(result)?.cacheReadInputTokens ?? null,
+      meanAggregation,
+      'tokens'
+    ),
+    cache_creation_tokens: metric(
+      'cache_creation_tokens',
+      'continuous',
+      (result) => hostUsage(result)?.cacheCreationInputTokens ?? null,
+      meanAggregation,
+      'tokens'
+    ),
+    output_tokens: metric(
+      'output_tokens',
+      'continuous',
+      (result) => hostUsage(result)?.outputTokens ?? null,
+      meanAggregation,
+      'tokens'
+    ),
+    duration_s: metric(
+      'duration_s',
+      'continuous',
+      (result) => result.durationMs / 1000,
+      meanAggregation,
+      'seconds'
+    ),
+    duration_api_s: metric(
+      'duration_api_s',
+      'continuous',
+      (result) => {
+        const durationMs = hostUsage(result)?.durationApiMs;
+        return durationMs === undefined ? null : durationMs / 1000;
+      },
+      meanAggregation,
+      'seconds'
+    ),
+    tool_count: metric(
+      'tool_count',
+      'continuous',
+      (result) => toolCalls(result).length,
+      meanAggregation,
+      'calls'
+    ),
+    first_tool: metric('first_tool', 'categorical', (result) => {
+      const first = toolCalls(result)[0];
+      return first && typeof first === 'object' && 'name' in first
+        ? String(first.name)
+        : null;
+    }),
+    response_len: metric(
+      'response_len',
+      'continuous',
+      (result) => responseText(result).length,
+      meanAggregation,
+      'chars'
+    ),
+    response_words: metric(
+      'response_words',
+      'continuous',
+      (result) =>
+        responseText(result).trim().split(/\s+/).filter(Boolean).length,
+      meanAggregation,
+      'words'
+    ),
+    judge_pass: metric('judge_pass', 'binary', judgePass, rateAggregation),
+    judge_score: metric(
+      'judge_score',
+      'object',
+      (result) => judgeScores(result),
+      judgeScoreAggregation
+    ),
+    judge_name: metric('judge_name', 'categorical', (result) => {
+      const first = judgeEntries(result)[0];
+      return first ? judgeName(first) : null;
+    }),
+  };
+
+globalMetrics[BUILT_INS_KEY] = BUILT_IN_METRICS;
+
+/**
+ * Live record-compatible view of the process-wide framework registry. Both
+ * registration APIs, validation, and computation use the same backing map.
+ */
+export const METRIC_REGISTRY: Record<string, MetricDefinition> = new Proxy(
+  Object.create(null) as Record<string, MetricDefinition>,
+  {
+    get(_target, key) {
+      return typeof key === 'string'
+        ? listMetrics().find((definition) => definition.name === key)
+        : undefined;
+    },
+    set(_target, key, definition: MetricDefinition) {
+      if (typeof key !== 'string' || key !== definition.name) {
+        throw new Error('Metric registry key must match the definition name.');
+      }
+      registerFrameworkMetric(definition);
+      return true;
+    },
+    has(_target, key) {
+      return (
+        typeof key === 'string' &&
+        listMetrics().some((definition) => definition.name === key)
+      );
+    },
+    ownKeys() {
+      return listMetrics().map((definition) => definition.name);
+    },
+    getOwnPropertyDescriptor(_target, key) {
+      if (
+        typeof key !== 'string' ||
+        !listMetrics().some((definition) => definition.name === key)
+      )
+        return undefined;
+      return {
+        configurable: true,
+        enumerable: true,
+        writable: true,
+        value: getMetric(key),
+      };
+    },
+    defineProperty() {
+      return false;
+    },
+    deleteProperty() {
+      return false;
+    },
+    preventExtensions() {
+      return false;
+    },
+  }
+);
+
+for (const definition of Object.values(BUILT_IN_METRICS)) {
+  registerFrameworkMetric(definition);
+}
+
+/** Register a named metric; conflicting duplicates leave the registry unchanged. */
+export function registerMetric(definition: MetricDefinition): void {
+  registerFrameworkMetric(definition);
+}
+
+function slug(value: string): string {
+  return value.replace(/-/g, '_');
+}
+
+/** Resolve one config metric, including parameterized judge metrics. */
+export function resolveMetric(
+  spec: MetricSpec,
+  registry: Record<string, MetricDefinition> = METRIC_REGISTRY
+): ResolvedMetric {
+  const name =
+    typeof spec === 'string' ? spec : (spec.metric ?? spec.type ?? spec.name);
+  const params = typeof spec === 'string' ? {} : (spec.params ?? {});
+  if (!name) throw new Error('Metric configuration requires a type or name.');
+  const base = registry[name];
+  if (base) {
+    const judge = typeof params.judge === 'string' ? params.judge : 'unknown';
+    const defaultName =
+      name === 'judge_pass_for' || name === 'judge_score_for'
+        ? `judge_${slug(judge)}_${name === 'judge_pass_for' ? 'pass' : 'score'}`
+        : name;
+    return {
+      metric: base,
+      outName:
+        typeof spec === 'string' ? defaultName : (spec.name ?? defaultName),
+      params,
+    };
+  }
+
+  throw new Error(
+    `Unknown metric "${name}". Available metrics: ${Object.keys(registry)
+      .sort()
+      .join(', ')}`
+  );
+}
+
+export function computeMetrics(
+  specs: MetricSpec[],
+  cases: EvalCaseResult[],
+  registry: Record<string, MetricDefinition> = METRIC_REGISTRY
+): MetricResult {
+  const resolved = specs.map((spec) => resolveMetric(spec, registry));
+  const perCase: MetricResult['perCase'] = Object.create(
+    null
+  ) as MetricResult['perCase'];
+  const idCounts = new Map<string, number>();
+  for (const caseResult of cases)
+    idCounts.set(caseResult.id, (idCounts.get(caseResult.id) ?? 0) + 1);
+  const usedKeys = new Set(cases.map((caseResult) => caseResult.id));
+  const rows = cases.map((caseResult) => {
+    const values: Record<string, MetricValue> = Object.create(null) as Record<
+      string,
+      MetricValue
+    >;
+    for (const item of resolved)
+      values[item.outName] = item.metric.compute(caseResult, item.params);
+    // Preserve legacy keys for unique IDs. Qualify collisions by dataset and
+    // occurrence (also distinguishes repeated cases from different arms).
+    let key = caseResult.id;
+    if (idCounts.get(key)! > 1) {
+      let occurrence = 0;
+      do {
+        key = JSON.stringify([
+          caseResult.datasetName,
+          caseResult.id,
+          occurrence++,
+        ]);
+      } while (usedKeys.has(key));
+      usedKeys.add(key);
+    }
+    perCase[key] = values;
+    return values;
+  });
+
+  const aggregated: Record<string, unknown> = {};
+  for (const item of resolved) {
+    // Aggregate rows directly, never via a potentially shared case ID.
+    const values = rows.map((row) => row[item.outName] ?? null);
+    const aggregate = item.metric.aggregate
+      ? item.metric.aggregate(values, item)
+      : item.metric.kind === 'binary'
+        ? rateAggregation(values, item)
+        : item.metric.kind === 'continuous'
+          ? meanAggregation(values, item)
+          : item.metric.kind === 'object'
+            ? judgeScoreAggregation(values, item)
+            : {
+                key: item.outName,
+                value: values.filter((value) => value !== null),
+              };
+    if (aggregate) aggregated[aggregate.key] = aggregate.value;
+  }
+  return { perCase, aggregated };
+}

--- a/src/evals/metrics.ts
+++ b/src/evals/metrics.ts
@@ -67,7 +67,8 @@ function judgeEntries(
   caseResult: EvalCaseResult
 ): Array<Record<string, unknown>> {
   const judge = caseResult.expectations?.judge as
-    Record<string, unknown> | undefined;
+    | Record<string, unknown>
+    | undefined;
   if (!judge) return [];
   const nested = judge.judgeResults;
   if (Array.isArray(nested)) {
@@ -211,7 +212,8 @@ const globalMetrics = globalThis as unknown as Record<symbol, unknown>;
 /** Built-in metrics, including the metrics used by Scio's evaluations. */
 export const BUILT_IN_METRICS: Record<string, MetricDefinition> =
   (globalMetrics[BUILT_INS_KEY] as
-    Record<string, MetricDefinition> | undefined) ?? {
+    | Record<string, MetricDefinition>
+    | undefined) ?? {
     judge_pass_for: parameterizedJudgeMetric('judge_pass_for'),
     judge_score_for: parameterizedJudgeMetric('judge_score_for'),
     passed: metric(

--- a/src/evals/metrics.ts
+++ b/src/evals/metrics.ts
@@ -6,6 +6,11 @@ import {
   listMetrics,
   registerMetric as registerFrameworkMetric,
 } from './frameworkRegistries.js';
+/**
+ * Tagged options are passed to compute without routing keys (type/metric/name).
+ * Legacy params are flattened for compatibility; keys may not also occur at the
+ * top level, since choosing either value would silently discard configuration.
+ */
 export type MetricSpec =
   | string
   | {
@@ -13,6 +18,7 @@ export type MetricSpec =
       type?: string;
       name?: string;
       params?: Record<string, unknown>;
+      [option: string]: unknown;
     };
 
 import type {
@@ -200,9 +206,12 @@ function parameterizedJudgeMetric(
       },
       passMetric ? rateAggregation : meanAggregation
     ),
-    schema: z
-      .object({ params: z.object({ judge: z.string().min(1) }) })
-      .passthrough(),
+    schema: z.union([
+      z.object({ judge: z.string().min(1) }).passthrough(),
+      z
+        .object({ params: z.object({ judge: z.string().min(1) }) })
+        .passthrough(),
+    ]),
   };
 }
 
@@ -250,7 +259,7 @@ export const BUILT_IN_METRICS: Record<string, MetricDefinition> =
           ? usage.inputTokens +
               (usage.cacheReadInputTokens ?? 0) +
               (usage.cacheCreationInputTokens ?? 0)
-          : 0;
+          : null;
       },
       meanAggregation,
       'tokens'
@@ -409,6 +418,29 @@ function slug(value: string): string {
   return value.replace(/-/g, '_');
 }
 
+function metricOptions(spec: MetricSpec): Record<string, unknown> {
+  if (typeof spec === 'string') return {};
+  const options = Object.fromEntries(
+    Object.entries(spec).filter(
+      ([key]) => !['metric', 'type', 'name', 'params'].includes(key)
+    )
+  );
+  for (const [key, value] of Object.entries(spec.params ?? {})) {
+    if (Object.hasOwn(options, key)) {
+      throw new Error(
+        `Ambiguous metric option "${key}": specify it at the top level or in params, not both.`
+      );
+    }
+    Object.defineProperty(options, key, {
+      value,
+      enumerable: true,
+      configurable: true,
+      writable: true,
+    });
+  }
+  return options;
+}
+
 /** Resolve one config metric, including parameterized judge metrics. */
 export function resolveMetric(
   spec: MetricSpec,
@@ -416,7 +448,7 @@ export function resolveMetric(
 ): ResolvedMetric {
   const name =
     typeof spec === 'string' ? spec : (spec.metric ?? spec.type ?? spec.name);
-  const params = typeof spec === 'string' ? {} : (spec.params ?? {});
+  const params = metricOptions(spec);
   if (!name) throw new Error('Metric configuration requires a type or name.');
   const base = registry[name];
   if (base) {

--- a/src/evals/resultSummary.test.ts
+++ b/src/evals/resultSummary.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  buildEvalSummaryPrompt,
+  summarizeEvalResults,
+} from './resultSummary.js';
+import type { EvalCaseResult } from '../types/reporter.js';
+
+const caseResult: EvalCaseResult = {
+  id: 'case-1',
+  datasetName: 'demo',
+  toolName: 'search',
+  source: 'eval',
+  pass: false,
+  request: { scenario: 'Find the design doc' },
+  response: { response: 'I could not find it' },
+  expectations: {
+    judge: { pass: false, score: 0.2, details: 'score 0.2: incomplete' },
+  },
+  authType: 'none',
+  durationMs: 10,
+};
+
+describe('result summary', () => {
+  it('builds a compact analysis prompt with metrics and case context', () => {
+    const prompt = buildEvalSummaryPrompt({
+      metrics: { total: 1, passed: 0 },
+      results: [caseResult],
+    });
+    expect(prompt).toContain('Find the design doc');
+    expect(prompt).toContain('score 0.2');
+    expect(prompt).toContain('total');
+  });
+
+  it('delegates summary generation to the supplied caller', async () => {
+    const callLLM = vi
+      .fn()
+      .mockResolvedValue('One failure: incomplete answer.');
+    const summary = await summarizeEvalResults(
+      { metrics: {}, results: [caseResult] },
+      callLLM
+    );
+    expect(summary).toBe('One failure: incomplete answer.');
+    expect(callLLM).toHaveBeenCalledOnce();
+  });
+
+  it('does not call the LLM for an empty run', async () => {
+    const callLLM = vi.fn();
+    expect(
+      await summarizeEvalResults({ metrics: {}, results: [] }, callLLM)
+    ).toBeNull();
+    expect(callLLM).not.toHaveBeenCalled();
+  });
+});

--- a/src/evals/resultSummary.ts
+++ b/src/evals/resultSummary.ts
@@ -1,0 +1,64 @@
+import type { EvalCaseResult } from '../types/reporter.js';
+
+export interface EvalSummaryResult {
+  metrics: Record<string, unknown>;
+  results: EvalCaseResult[];
+  aggregatedMetrics?: Record<string, unknown>;
+}
+
+export type EvalSummaryCaller = (prompt: string) => Promise<string>;
+
+function compactCase(result: EvalCaseResult): Record<string, unknown> {
+  const response = result.response;
+  const responseValue =
+    response && typeof response === 'object' && 'response' in response
+      ? (response as { response?: unknown }).response
+      : undefined;
+  const responseText = typeof responseValue === 'string' ? responseValue : '';
+  const judge = result.expectations?.judge;
+  return {
+    id: result.id,
+    dataset: result.datasetName,
+    pass: result.pass,
+    error: result.error,
+    scenario: result.request?.scenario ?? '',
+    judges: judge
+      ? {
+          pass: judge.pass,
+          score: judge.score,
+          details: judge.details,
+          judgeResults: judge.judgeResults,
+        }
+      : undefined,
+    response: responseText.slice(0, 500),
+  };
+}
+
+/** Build the stable, compact prompt used for post-run eval analysis. */
+export function buildEvalSummaryPrompt(result: EvalSummaryResult): string {
+  const metrics = result.aggregatedMetrics ?? result.metrics;
+  return `You are an eval analysis assistant. Analyze these MCP evaluation results and provide a concise summary.
+
+METRICS:
+${JSON.stringify(metrics, null, 2)}
+
+CASES:
+${JSON.stringify(result.results.map(compactCase), null, 2)}
+
+Cover:
+1. Overall quality assessment in 1-2 sentences.
+2. If there are failures, group them by pattern and explain what went wrong.
+3. Note passes with low judge scores.
+4. Give actionable recommendations when appropriate.
+
+Keep it concise and use plain text without markdown headers.`;
+}
+
+/** Generate an optional natural-language analysis through an application-supplied LLM. */
+export async function summarizeEvalResults(
+  result: EvalSummaryResult,
+  callLLM: EvalSummaryCaller
+): Promise<string | null> {
+  if (result.results.length === 0) return null;
+  return callLLM(buildEvalSummaryPrompt(result));
+}

--- a/src/evals/runEvalSuite.test.ts
+++ b/src/evals/runEvalSuite.test.ts
@@ -13,7 +13,11 @@ import {
   registerJudge,
 } from './frameworkRegistries.js';
 import type { EvalCase, EvalDataset } from './datasetTypes.js';
-import type { HostRunOptions } from './evalFrameworkTypes.js';
+import type {
+  HostRunOptions,
+  HostRunInput,
+  HostRunContext,
+} from './evalFrameworkTypes.js';
 
 const dirs: string[] = [];
 let sequence = 0;
@@ -36,6 +40,11 @@ async function fixture(
   dirs.push(dir);
   const type = `review-host-${sequence++}`;
   const source = `review-source-${sequence++}`;
+  const observe =
+    vi.fn<(input: HostRunInput, context: HostRunContext) => void>();
+  const load = vi.fn(
+    async (): Promise<EvalDataset> => ({ name: 'canonical', cases })
+  );
   registerHost({
     name: type,
     schema: z
@@ -43,6 +52,7 @@ async function fixture(
       .passthrough(),
     evidence: 'structured',
     async run(input, config, context) {
+      observe(input, context);
       const result = await run({
         dataset: { name: 'canonical', cases },
         cases,
@@ -60,9 +70,7 @@ async function fixture(
   registerDatasetSource({
     name: source,
     schema: z.object({ type: z.string() }),
-    async load(): Promise<EvalDataset> {
-      return { name: 'canonical', cases };
-    },
+    load,
   });
   const manifestPath = path.join(dir, 'manifest.json');
   const manifest = {
@@ -73,7 +81,7 @@ async function fixture(
     ...extra,
   };
   await fs.writeFile(manifestPath, JSON.stringify(manifest));
-  return { dir, manifestPath, manifest, run, type };
+  return { dir, manifestPath, manifest, run, type, observe, load };
 }
 const scenario: EvalCase = {
   id: 'same',
@@ -83,6 +91,179 @@ const scenario: EvalCase = {
 };
 
 describe('suite review regressions', () => {
+  it('isolates secrets files across dry, sequential, and concurrent suites', async () => {
+    vi.stubEnv('SUITE_DUMMY_TOKEN', undefined);
+    const f = await fixture([scenario], {
+      servers: [
+        {
+          transport: 'http',
+          serverUrl: 'https://example.com/eval',
+          auth: { accessTokenEnv: 'SUITE_DUMMY_TOKEN' },
+        },
+      ],
+    });
+    const first = path.join(f.dir, 'first.env');
+    const second = path.join(f.dir, 'second.json');
+    await fs.writeFile(
+      first,
+      'SUITE_DUMMY_TOKEN=first-dummy\nSUITE_DUMMY_HOST_KEY=first-host'
+    );
+    await fs.writeFile(
+      second,
+      JSON.stringify({
+        SUITE_DUMMY_TOKEN: 'second-dummy',
+        SUITE_DUMMY_HOST_KEY: 'second-host',
+      })
+    );
+    await runEvalSuite({
+      manifestPath: f.manifestPath,
+      rootDir: f.dir,
+      secretsFile: first,
+      dryRun: true,
+    });
+    expect(process.env.SUITE_DUMMY_TOKEN).toBeUndefined();
+    await runEvalSuite({
+      manifestPath: f.manifestPath,
+      rootDir: f.dir,
+      secretsFile: first,
+    });
+    await runEvalSuite({
+      manifestPath: f.manifestPath,
+      rootDir: f.dir,
+      secretsFile: second,
+    });
+    await Promise.all([
+      runEvalSuite({
+        manifestPath: f.manifestPath,
+        rootDir: f.dir,
+        secretsFile: first,
+      }),
+      runEvalSuite({
+        manifestPath: f.manifestPath,
+        rootDir: f.dir,
+        secretsFile: second,
+      }),
+    ]);
+    expect(
+      f.observe.mock.calls.map(([input]) => input.env?.SUITE_DUMMY_TOKEN)
+    ).toEqual(['first-dummy', 'second-dummy', 'first-dummy', 'second-dummy']);
+    expect(process.env.SUITE_DUMMY_TOKEN).toBeUndefined();
+    await expect(
+      runEvalSuite({ manifestPath: f.manifestPath, rootDir: f.dir })
+    ).rejects.toThrow('SUITE_DUMMY_TOKEN');
+  });
+
+  it('loads canonical datasets once and isolates arm prompts', async () => {
+    const original = { ...scenario, args: { nested: { untouched: true } } };
+    const f = await fixture([original], {
+      arms: [
+        { name: 'a', scenarioTemplate: 'A {{scenario}}' },
+        { name: 'b', scenarioTemplate: 'B {{scenario}}' },
+      ],
+    });
+    const result = await runEvalSuite({
+      manifestPath: f.manifestPath,
+      rootDir: f.dir,
+    });
+    expect(f.load).toHaveBeenCalledTimes(1);
+    expect(f.observe.mock.calls.map(([input]) => input.scenario)).toEqual([
+      'A Find documents',
+      'B Find documents',
+    ]);
+    expect(original.scenario).toBe('Find documents');
+    expect(result.datasets[0]?.dataset).toEqual({
+      name: 'canonical',
+      cases: [original],
+    });
+  });
+
+  it('merges raw base, arm, and case host options before parsing transforms once', async () => {
+    const name = `transform-host-${sequence++}`;
+    const run = vi.fn(async () => ({ finalText: 'OK', events: [] }));
+    registerHost({
+      name,
+      schema: z.object({
+        count: z.number().transform((value) => value * 3),
+        model: z.string(),
+      }),
+      run,
+    });
+    const f = await fixture(
+      [{ ...scenario, host: { type: name, model: 'case' } }],
+      {
+        host: { type: name, count: 2, model: 'base' },
+        arms: [{ name: 'a', host: { model: 'arm' } }],
+      }
+    );
+    await runEvalSuite({ manifestPath: f.manifestPath, rootDir: f.dir });
+    expect(run).toHaveBeenCalledWith(
+      expect.anything(),
+      { type: name, count: 6, model: 'case' },
+      expect.anything()
+    );
+  });
+
+  it('applies run controls and rejects unsupported/conflicting controls', async () => {
+    const f = await fixture(
+      [
+        { ...scenario, id: 'skip', tags: ['other'] },
+        { ...scenario, id: 'selected', tags: ['wanted'] },
+        { ...scenario, id: 'capped', tags: ['wanted'] },
+      ],
+      { filterTags: ['wanted'], run: { iterations: 2, maxCases: 1 } }
+    );
+    const result = await runEvalSuite({
+      manifestPath: f.manifestPath,
+      rootDir: f.dir,
+    });
+    expect(f.run).toHaveBeenCalledTimes(2);
+    expect(result.summary.results.map((entry) => entry.id)).toEqual([
+      'selected',
+    ]);
+    for (const extra of [
+      { profile: 'ignored' },
+      { run: { profile: 'ignored' } },
+      { run: { unknown: true } },
+      { iterations: 3, run: { iterations: 2 } },
+    ]) {
+      const invalid = await fixture([scenario], extra);
+      await expect(
+        runEvalSuite({
+          manifestPath: invalid.manifestPath,
+          rootDir: invalid.dir,
+          dryRun: true,
+        })
+      ).rejects.toThrow();
+      expect(invalid.run).not.toHaveBeenCalled();
+    }
+  });
+
+  it('traverses recursive directories through the public suite source path', async () => {
+    const f = await fixture([scenario]);
+    const sourceDir = path.join(f.dir, 'datasets');
+    await fs.mkdir(path.join(sourceDir, 'nested'), { recursive: true });
+    await fs.writeFile(
+      path.join(sourceDir, 'a.json'),
+      JSON.stringify({ name: 'a', cases: [{ ...scenario, id: 'a' }] })
+    );
+    await fs.writeFile(
+      path.join(sourceDir, 'nested', 'b.json'),
+      JSON.stringify({ name: 'b', cases: [{ ...scenario, id: 'b' }] })
+    );
+    await fs.writeFile(
+      f.manifestPath,
+      JSON.stringify({
+        ...f.manifest,
+        datasets: [{ type: 'dir', path: sourceDir, recursive: true }],
+      })
+    );
+    const result = await runEvalSuite({
+      manifestPath: f.manifestPath,
+      rootDir: f.dir,
+    });
+    expect(result.summary.results.map((entry) => entry.id)).toEqual(['a', 'b']);
+  });
+
   it('does not mutate TLS or per-suite environment settings, including dry runs', async () => {
     vi.stubEnv('NODE_TLS_REJECT_UNAUTHORIZED', '1');
     vi.stubEnv('EVAL_ITERATIONS', 'untouched');
@@ -141,6 +322,21 @@ describe('suite review regressions', () => {
     expect(alternate.run).toHaveBeenCalledTimes(2);
     expect(alternate.run.mock.calls[0]?.[0].host.model).toBe('case-model');
   });
+  it('retains transformed manifest judge options through suite execution', async () => {
+    const name = `options-judge-${sequence++}`;
+    const evaluate = vi.fn(async () => ({ score: 1 }));
+    registerJudge({
+      name,
+      schema: z.object({ count: z.number().transform((value) => value * 3) }),
+      evaluate,
+    });
+    const f = await fixture([scenario], { judges: [{ type: name, count: 2 }] });
+    await runEvalSuite({ manifestPath: f.manifestPath, rootDir: f.dir });
+    expect(evaluate).toHaveBeenCalledWith(expect.anything(), undefined, {
+      count: 6,
+    });
+  });
+
   it('applies manifest judges to canonical cases and respects arm judge overrides', async () => {
     const name = `manifest-judge-${sequence++}`;
     const evaluate = vi.fn(async () => ({ score: 0 }));

--- a/src/evals/runEvalSuite.test.ts
+++ b/src/evals/runEvalSuite.test.ts
@@ -7,6 +7,7 @@ import os from 'node:os';
 import path from 'node:path';
 import { z } from 'zod';
 import { runEvalSuite } from './runEvalSuite.js';
+import { getBuiltinHostConfig } from './builtinHosts.js';
 import {
   registerHost,
   registerDatasetSource,
@@ -14,6 +15,8 @@ import {
 } from './frameworkRegistries.js';
 import type { EvalCase, EvalDataset } from './datasetTypes.js';
 import type {
+  DatasetSourceContext,
+  HostDefinition,
   HostRunOptions,
   HostRunInput,
   HostRunContext,
@@ -144,14 +147,150 @@ describe('suite review regressions', () => {
         secretsFile: second,
       }),
     ]);
-    expect(
-      f.observe.mock.calls.map(([input]) => input.env?.SUITE_DUMMY_TOKEN)
-    ).toEqual(['first-dummy', 'second-dummy', 'first-dummy', 'second-dummy']);
+    const observedTokens = f.observe.mock.calls.map(
+      ([input]) => input.env?.SUITE_DUMMY_TOKEN
+    );
+    expect(observedTokens.slice(0, 2)).toEqual(['first-dummy', 'second-dummy']);
+    // Concurrent suites may finish in either order; each must keep its own token.
+    expect(observedTokens.slice(2).sort()).toEqual([
+      'first-dummy',
+      'second-dummy',
+    ]);
     expect(process.env.SUITE_DUMMY_TOKEN).toBeUndefined();
     await expect(
       runEvalSuite({ manifestPath: f.manifestPath, rootDir: f.dir })
     ).rejects.toThrow('SUITE_DUMMY_TOKEN');
   });
+
+  it.each(['manifest', 'override'] as const)(
+    'resolves %s server credentials before creating the source CLI config',
+    async (serverSource) => {
+      vi.stubEnv('SUITE_DUMMY_TOKEN', undefined);
+      vi.stubEnv('SUITE_DUMMY_HOST_KEY', undefined);
+      vi.stubEnv('MCP_PLUGIN_DIR', undefined);
+      const name = `source-cli-${sequence++}`;
+      const source = `source-cli-data-${sequence++}`;
+      const run = vi.fn<NonNullable<HostDefinition['run']>>(async () => ({
+        finalText: 'OK',
+        events: [],
+      }));
+      registerHost({
+        name,
+        schema: z.object({}),
+        createConfig(options) {
+          const { type: _type, ...hostOptions } = options ?? {};
+          return getBuiltinHostConfig('claude-cli', hostOptions);
+        },
+        run,
+      });
+      const sourceConfigs: DatasetSourceContext['hostConfig'][] = [];
+      registerDatasetSource({
+        name: source,
+        schema: z.object({}),
+        async load(_config, context) {
+          sourceConfigs.push(context.hostConfig);
+          return {
+            name: 'cli-source',
+            cases: [{ id: 'case', mode: 'host', scenario: 'Find documents' }],
+          };
+        },
+      });
+      const server = {
+        transport: 'http' as const,
+        label: 'protected',
+        serverUrl: 'https://example.com/eval',
+        auth: { accessTokenEnv: 'SUITE_DUMMY_TOKEN' },
+      };
+      const f = await fixture([], {
+        datasets: [{ type: source }],
+        host: { type: name },
+        servers: serverSource === 'manifest' ? [server] : [],
+      });
+      const secretsFile = path.join(f.dir, 'secrets.env');
+      await fs.writeFile(
+        secretsFile,
+        'SUITE_DUMMY_TOKEN=source-dummy\nSUITE_DUMMY_HOST_KEY=source-host'
+      );
+      const result = await runEvalSuite({
+        manifestPath: f.manifestPath,
+        rootDir: f.dir,
+        secretsFile,
+        ...(serverSource === 'override' ? { mcpConfig: server } : {}),
+      });
+      expect(result.summary.results[0]?.pass).toBe(true);
+      expect(sourceConfigs).toHaveLength(1);
+      expect(sourceConfigs[0]?.mcpServers?.protected).toMatchObject({
+        headers: { Authorization: 'Bearer source-dummy' },
+      });
+      expect(sourceConfigs[0]?.cli?.env?.SUITE_DUMMY_HOST_KEY).toBe(
+        'source-host'
+      );
+      expect(run.mock.calls[0]?.[0].servers[0]).toEqual({
+        ...server,
+        auth: { accessToken: 'source-dummy' },
+      });
+      expect(process.env.SUITE_DUMMY_TOKEN).toBeUndefined();
+      expect(process.env.SUITE_DUMMY_HOST_KEY).toBeUndefined();
+      const saved = await fs.readFile(
+        path.join(result.outputDir, 'results.json'),
+        'utf8'
+      );
+      expect(saved).not.toContain('source-dummy');
+      expect(saved).not.toContain('source-host');
+    }
+  );
+
+  it.each(['claude-cli', 'vercel-sdk'])(
+    'preserves declared %s environment in dataset source context',
+    async (type) => {
+      vi.stubEnv('HOST_ENV_SHARED', 'ambient');
+      vi.stubEnv('HOST_ENV_SUITE_ONLY', undefined);
+      vi.stubEnv('HOST_ENV_DECLARED_ONLY', undefined);
+      vi.stubEnv('MCP_PLUGIN_DIR', undefined);
+      const source = `host-env-source-${sequence++}`;
+      const sourceConfigs: DatasetSourceContext['hostConfig'][] = [];
+      registerDatasetSource({
+        name: source,
+        schema: z.object({}),
+        async load(_config, context) {
+          sourceConfigs.push(context.hostConfig);
+          return { name: 'host-env', cases: [] };
+        },
+      });
+      const declaredEnv = {
+        HOST_ENV_SHARED: 'declared',
+        HOST_ENV_DECLARED_ONLY: 'host-only',
+      };
+      const f = await fixture([], {
+        datasets: [{ type: source }],
+        host: { type, env: declaredEnv },
+      });
+      const secretsFile = path.join(f.dir, 'secrets.env');
+      await fs.writeFile(
+        secretsFile,
+        'HOST_ENV_SHARED=suite\nHOST_ENV_SUITE_ONLY=suite-only'
+      );
+      const result = await runEvalSuite({
+        manifestPath: f.manifestPath,
+        rootDir: f.dir,
+        secretsFile,
+      });
+      expect(sourceConfigs).toHaveLength(1);
+      const sourceConfig = sourceConfigs[0];
+      expect(sourceConfig?.cli?.env ?? sourceConfig?.env).toMatchObject({
+        HOST_ENV_SHARED: 'declared',
+        HOST_ENV_DECLARED_ONLY: 'host-only',
+        HOST_ENV_SUITE_ONLY: 'suite-only',
+      });
+      expect(result.manifest.host?.env).toEqual(declaredEnv);
+      expect(JSON.parse(await fs.readFile(f.manifestPath, 'utf8'))).toEqual(
+        f.manifest
+      );
+      expect(process.env.HOST_ENV_SHARED).toBe('ambient');
+      expect(process.env.HOST_ENV_SUITE_ONLY).toBeUndefined();
+      expect(process.env.HOST_ENV_DECLARED_ONLY).toBeUndefined();
+    }
+  );
 
   it('loads canonical datasets once and isolates arm prompts', async () => {
     const original = { ...scenario, args: { nested: { untouched: true } } };
@@ -201,6 +340,81 @@ describe('suite review regressions', () => {
       { type: name, count: 6, model: 'case' },
       expect.anything()
     );
+  });
+
+  it('retains top-level host defaults when a case patches the model', async () => {
+    const name = `defaults-host-${sequence++}`;
+    const run = vi.fn<NonNullable<HostDefinition['run']>>(async () => ({
+      finalText: 'OK',
+      events: [],
+    }));
+    registerHost({
+      name,
+      schema: z.object({
+        count: z.number().transform((value) => value * 3),
+        model: z.string().optional(),
+        provider: z.string().optional(),
+        timeout: z.number().optional(),
+        maxToolCalls: z.number().optional(),
+      }),
+      run,
+    });
+    const f = await fixture(
+      [
+        { ...scenario, id: 'baseline' },
+        { ...scenario, id: 'patched', host: { type: name, model: 'case' } },
+      ],
+      {
+        host: { type: name, count: 2 },
+        model: 'suite',
+        provider: 'openai',
+        timeout: 123,
+        maxToolCalls: 0,
+        arms: [
+          { name: 'inherited' },
+          { name: 'override', host: { timeout: 321 } },
+        ],
+      }
+    );
+    const result = await runEvalSuite({
+      manifestPath: f.manifestPath,
+      rootDir: f.dir,
+    });
+    expect(result.summary.results.every((entry) => entry.pass)).toBe(true);
+    expect(run.mock.calls.map(([, config]) => config)).toEqual([
+      {
+        type: name,
+        count: 6,
+        model: 'suite',
+        provider: 'openai',
+        timeout: 123,
+        maxToolCalls: 0,
+      },
+      {
+        type: name,
+        count: 6,
+        model: 'case',
+        provider: 'openai',
+        timeout: 123,
+        maxToolCalls: 0,
+      },
+      {
+        type: name,
+        count: 6,
+        model: 'suite',
+        provider: 'openai',
+        timeout: 321,
+        maxToolCalls: 0,
+      },
+      {
+        type: name,
+        count: 6,
+        model: 'case',
+        provider: 'openai',
+        timeout: 321,
+        maxToolCalls: 0,
+      },
+    ]);
   });
 
   it('applies run controls and rejects unsupported/conflicting controls', async () => {
@@ -322,20 +536,128 @@ describe('suite review regressions', () => {
     expect(alternate.run).toHaveBeenCalledTimes(2);
     expect(alternate.run.mock.calls[0]?.[0].host.model).toBe('case-model');
   });
-  it('retains transformed manifest judge options through suite execution', async () => {
+  it('retains manifest and arm judge settings with a stripping policy schema', async () => {
     const name = `options-judge-${sequence++}`;
-    const evaluate = vi.fn(async () => ({ score: 1 }));
+    const evaluate = vi.fn(async () => ({ score: 0.8 }));
     registerJudge({
       name,
       schema: z.object({ count: z.number().transform((value) => value * 3) }),
       evaluate,
     });
-    const f = await fixture([scenario], { judges: [{ type: name, count: 2 }] });
-    await runEvalSuite({ manifestPath: f.manifestPath, rootDir: f.dir });
-    expect(evaluate).toHaveBeenCalledWith(expect.anything(), undefined, {
-      count: 6,
+    const f = await fixture([scenario], {
+      judges: [
+        { type: name, count: 2, threshold: 0.9, reference: 'manifest-gold' },
+      ],
+      arms: [
+        { name: 'baseline' },
+        {
+          name: 'variant',
+          judges: [
+            { type: name, count: 4, threshold: 0.95, reference: 'arm-gold' },
+          ],
+        },
+      ],
+    });
+    const result = await runEvalSuite({
+      manifestPath: f.manifestPath,
+      rootDir: f.dir,
+    });
+    expect(result.summary.arms.map((arm) => arm.result?.passed)).toEqual([
+      0, 0,
+    ]);
+    expect(evaluate).toHaveBeenCalledTimes(2);
+    expect(evaluate).toHaveBeenNthCalledWith(
+      1,
+      expect.anything(),
+      'manifest-gold',
+      {
+        count: 6,
+      }
+    );
+    expect(evaluate).toHaveBeenNthCalledWith(2, expect.anything(), 'arm-gold', {
+      count: 12,
     });
   });
+
+  it.each([
+    ['stripping', 'nested'],
+    ['stripping', 'flat'],
+    ['passthrough', 'nested'],
+    ['passthrough', 'flat'],
+  ] as const)(
+    'lets case judge settings override manifest defaults with a %s schema and %s policy',
+    async (policyMode, casePolicy) => {
+      const name = `precedence-judge-${sequence++}`;
+      const policySchema = z.object({
+        count: z.number().transform((value) => value * 3),
+        retained: z.string(),
+      });
+      const evaluate = vi.fn(async () => ({ score: 0.8 }));
+      registerJudge({
+        name,
+        schema:
+          policyMode === 'passthrough'
+            ? policySchema.passthrough()
+            : policySchema,
+        evaluate,
+      });
+      const f = await fixture(
+        [
+          {
+            ...scenario,
+            id: 'default',
+          },
+          {
+            ...scenario,
+            id: 'case',
+            canonicalAnswer: 'canonical-gold',
+            expect: {
+              passesJudge: {
+                judge: name,
+                threshold: 0.9,
+                reference: 'case-gold',
+                ...(casePolicy === 'nested'
+                  ? { options: { count: 4 } }
+                  : { count: 4 }),
+              },
+            },
+          },
+        ],
+        {
+          judges: [
+            {
+              type: name,
+              count: 2,
+              retained: 'manifest-policy',
+              threshold: 0.7,
+              reference: 'manifest-gold',
+            },
+          ],
+        }
+      );
+      const result = await runEvalSuite({
+        manifestPath: f.manifestPath,
+        rootDir: f.dir,
+      });
+      expect(result.summary.results.map((entry) => entry.pass)).toEqual([
+        true,
+        false,
+      ]);
+      expect(evaluate).toHaveBeenCalledTimes(2);
+      expect(evaluate).toHaveBeenNthCalledWith(
+        1,
+        expect.anything(),
+        'manifest-gold',
+        expect.objectContaining({ count: 6, retained: 'manifest-policy' })
+      );
+      expect(evaluate).toHaveBeenNthCalledWith(
+        2,
+        expect.anything(),
+        'case-gold',
+        expect.objectContaining({ count: 12, retained: 'manifest-policy' })
+      );
+    }
+  );
 
   it('applies manifest judges to canonical cases and respects arm judge overrides', async () => {
     const name = `manifest-judge-${sequence++}`;

--- a/src/evals/runEvalSuite.test.ts
+++ b/src/evals/runEvalSuite.test.ts
@@ -1,0 +1,285 @@
+import type { EvalExecutionResult } from './hostTrace.js';
+import { simulationToHostTrace } from './hostTrace.js';
+import type { MCPHostSimulationResult } from './mcpHost/mcpHostTypes.js';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { z } from 'zod';
+import { runEvalSuite } from './runEvalSuite.js';
+import {
+  registerHost,
+  registerDatasetSource,
+  registerJudge,
+} from './frameworkRegistries.js';
+import type { EvalCase, EvalDataset } from './datasetTypes.js';
+import type { HostRunOptions } from './evalFrameworkTypes.js';
+
+const dirs: string[] = [];
+let sequence = 0;
+afterEach(async () => {
+  vi.unstubAllEnvs();
+  await Promise.all(
+    dirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true }))
+  );
+});
+async function fixture(
+  cases: EvalCase[],
+  extra: Record<string, unknown> = {},
+  run = vi.fn<(options: HostRunOptions) => Promise<EvalExecutionResult>>(
+    async () => ({
+      response: { success: true, response: 'WRONG', toolCalls: [] },
+    })
+  )
+) {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'suite-review-'));
+  dirs.push(dir);
+  const type = `review-host-${sequence++}`;
+  const source = `review-source-${sequence++}`;
+  registerHost({
+    name: type,
+    schema: z
+      .object({ type: z.string(), model: z.string().default('default-model') })
+      .passthrough(),
+    evidence: 'structured',
+    async run(input, config, context) {
+      const result = await run({
+        dataset: { name: 'canonical', cases },
+        cases,
+        servers: input.servers,
+        host: config,
+        manifest: context.manifest,
+        arm: context.arm,
+      });
+      return simulationToHostTrace(
+        result.response as MCPHostSimulationResult,
+        input.servers
+      );
+    },
+  });
+  registerDatasetSource({
+    name: source,
+    schema: z.object({ type: z.string() }),
+    async load(): Promise<EvalDataset> {
+      return { name: 'canonical', cases };
+    },
+  });
+  const manifestPath = path.join(dir, 'manifest.json');
+  const manifest = {
+    name: 'review',
+    datasets: [{ type: source }],
+    host: { type },
+    servers: [],
+    ...extra,
+  };
+  await fs.writeFile(manifestPath, JSON.stringify(manifest));
+  return { dir, manifestPath, manifest, run, type };
+}
+const scenario: EvalCase = {
+  id: 'same',
+  mode: 'mcp_host',
+  scenario: 'Find documents',
+  mcpHostConfig: { provider: 'anthropic' },
+};
+
+describe('suite review regressions', () => {
+  it('does not mutate TLS or per-suite environment settings, including dry runs', async () => {
+    vi.stubEnv('NODE_TLS_REJECT_UNAUTHORIZED', '1');
+    vi.stubEnv('EVAL_ITERATIONS', 'untouched');
+    const f = await fixture([scenario], { iterations: 9, model: 'chosen' });
+    await runEvalSuite({
+      manifestPath: f.manifestPath,
+      rootDir: f.dir,
+      dryRun: true,
+    });
+    expect(process.env.NODE_TLS_REJECT_UNAUTHORIZED).toBe('1');
+    expect(process.env.EVAL_ITERATIONS).toBe('untouched');
+    expect(f.run).not.toHaveBeenCalled();
+  });
+  it('runs text, call-count and registered judge assertions for every custom-host iteration', async () => {
+    const judge = vi.fn(async () => ({ score: 0 }));
+    const judgeName = `review-judge-${sequence++}`;
+    registerJudge({
+      name: judgeName,
+      schema: z.object({}).passthrough(),
+      evaluate: judge,
+    });
+    const f = await fixture([
+      {
+        ...scenario,
+        iterations: 3,
+        expect: {
+          containsText: 'EXPECTED',
+          toolCallCount: { min: 1 },
+          passesJudge: { judge: judgeName },
+        },
+      },
+    ]);
+    const result = await runEvalSuite({
+      manifestPath: f.manifestPath,
+      rootDir: f.dir,
+    });
+    expect(f.run).toHaveBeenCalledTimes(3);
+    expect(judge).toHaveBeenCalledTimes(3);
+    expect(result.summary.results[0]?.pass).toBe(false);
+    expect(result.summary.results[0]?.iterationResults).toHaveLength(3);
+  });
+  it('preserves per-case host overrides and iterations for canonical host mode', async () => {
+    const alternate = await fixture([scenario]);
+    const f = await fixture(
+      [
+        {
+          ...scenario,
+          mode: 'host',
+          host: { type: alternate.type, model: 'case-model' },
+        },
+      ],
+      { iterations: 2 }
+    );
+    await runEvalSuite({ manifestPath: f.manifestPath, rootDir: f.dir });
+    expect(f.run).not.toHaveBeenCalled();
+    expect(alternate.run).toHaveBeenCalledTimes(2);
+    expect(alternate.run.mock.calls[0]?.[0].host.model).toBe('case-model');
+  });
+  it('applies manifest judges to canonical cases and respects arm judge overrides', async () => {
+    const name = `manifest-judge-${sequence++}`;
+    const evaluate = vi.fn(async () => ({ score: 0 }));
+    registerJudge({ name, schema: z.object({}).passthrough(), evaluate });
+    const f = await fixture([scenario], {
+      judges: [{ type: name, reference: 'expected' }],
+      arms: [{ name: 'judged' }, { name: 'unjudged', judges: [] }],
+    });
+    const result = await runEvalSuite({
+      manifestPath: f.manifestPath,
+      rootDir: f.dir,
+    });
+    expect(evaluate).toHaveBeenCalledTimes(1);
+    expect(result.summary.arms.map((arm) => arm.result?.passed)).toEqual([
+      0, 1,
+    ]);
+  });
+  it('merges host patches, forwards parsed defaults and computes each arm independently', async () => {
+    const f = await fixture([
+      { ...scenario, expect: { containsText: 'EXPECTED' } },
+    ]);
+    f.manifest.host = {
+      type: f.type,
+      model: 'base',
+      retained: 'yes',
+    } as typeof f.manifest.host;
+    await fs.writeFile(
+      f.manifestPath,
+      JSON.stringify({
+        ...f.manifest,
+        metrics: ['passed'],
+        arms: [
+          { name: 'a' },
+          { name: 'b', host: { type: f.type, model: 'variant' } },
+        ],
+      })
+    );
+    f.run.mockImplementation(async (options) => ({
+      response: {
+        success: true,
+        response: options.host.model === 'base' ? 'EXPECTED' : 'WRONG',
+        toolCalls: [],
+      },
+    }));
+    const result = await runEvalSuite({
+      manifestPath: f.manifestPath,
+      rootDir: f.dir,
+    });
+    expect(f.run.mock.calls.map(([options]) => options.host.model)).toEqual([
+      'base',
+      'variant',
+    ]);
+    expect(f.run.mock.calls[1]?.[0].host.retained).toBe('yes');
+    expect(result.summary.arms.map((arm) => arm.result?.passed)).toEqual([
+      1, 0,
+    ]);
+    expect(result.summary.arms.map((arm) => arm.metrics?.passed_rate)).toEqual([
+      1, 0,
+    ]);
+  });
+  it('maps multiple native tools to a canonical expectation without dropping argument checks', async () => {
+    const f = await fixture(
+      [
+        {
+          ...scenario,
+          expect: {
+            toolsTriggered: {
+              calls: [
+                {
+                  name: 'search',
+                  required: true,
+                  arguments: { query: 'wanted' },
+                },
+              ],
+            },
+          },
+        },
+      ],
+      { toolMap: { search: ['github.search', 'chat.search'] } }
+    );
+    f.run.mockResolvedValue({
+      response: {
+        success: true,
+        response: 'OK',
+        toolCalls: [{ name: 'chat.search', arguments: { query: 'wrong' } }],
+      },
+    });
+    expect(
+      (await runEvalSuite({ manifestPath: f.manifestPath, rootDir: f.dir }))
+        .summary.results[0]?.pass
+    ).toBe(false);
+    f.run.mockResolvedValue({
+      response: {
+        success: true,
+        response: 'OK',
+        toolCalls: [{ name: 'github.search', arguments: { query: 'wanted' } }],
+      },
+    });
+    expect(
+      (await runEvalSuite({ manifestPath: f.manifestPath, rootDir: f.dir }))
+        .summary.results[0]?.pass
+    ).toBe(true);
+  });
+  it('passes complete labeled server sets but only persists allowlisted unresolved descriptions', async () => {
+    vi.stubEnv('REVIEW_TOKEN', 'dummy-secret-do-not-save');
+    const f = await fixture([scenario], {
+      servers: [
+        {
+          transport: 'http',
+          label: 'one',
+          serverUrl: 'https://example.com/eval',
+          headers: { 'X-Secret': 'header-secret' },
+          auth: { accessTokenEnv: 'REVIEW_TOKEN' },
+        },
+        {
+          transport: 'stdio',
+          label: 'two',
+          command: 'test',
+          args: ['arg-secret'],
+          env: { KEY: 'env-secret' },
+        },
+      ],
+    });
+    const result = await runEvalSuite({
+      manifestPath: f.manifestPath,
+      rootDir: f.dir,
+    });
+    expect(f.run.mock.calls[0]?.[0].servers).toHaveLength(2);
+    const json = await fs.readFile(
+      path.join(result.outputDir, 'results.json'),
+      'utf8'
+    );
+    for (const secret of [
+      'dummy-secret-do-not-save',
+      'header-secret',
+      'arg-secret',
+      'env-secret',
+    ])
+      expect(json).not.toContain(secret);
+    expect(json).toContain('REVIEW_TOKEN');
+  });
+});

--- a/src/evals/runEvalSuite.ts
+++ b/src/evals/runEvalSuite.ts
@@ -26,7 +26,12 @@ import { registerBuiltinHosts } from './builtinHosts.js';
 import { runEvalDataset, executeToolCall } from './evalRunner.js';
 import { hostTraceToExecution } from './hostTrace.js';
 import type { EvalRunnerResult } from './evalRunner.js';
-import { EvalExpectBlockSchema, type EvalDataset } from './datasetTypes.js';
+import {
+  EvalExpectBlockSchema,
+  type EvalDataset,
+  type EvalCase,
+} from './datasetTypes.js';
+import { selectEvalCases } from './buildEvalDataset.js';
 import type { EvalCaseResult } from '../types/reporter.js';
 import type { UsageMetrics } from '../types/index.js';
 import { loadPlugins } from '../plugins/loadPlugins.js';
@@ -60,7 +65,9 @@ export interface RunEvalSuiteResult {
   summary: EvaluationSummary;
 }
 
-async function loadSecretsFile(secretsFile: string): Promise<void> {
+async function loadSecretsFile(
+  secretsFile: string
+): Promise<Record<string, string>> {
   const raw = await fs.readFile(secretsFile, 'utf8');
   let entries: Record<string, unknown>;
   try {
@@ -84,17 +91,29 @@ async function loadSecretsFile(secretsFile: string): Promise<void> {
       entries[key] = value;
     }
   }
-  for (const [key, value] of Object.entries(entries)) {
-    if (typeof value === 'string' && process.env[key] === undefined) {
-      process.env[key] = value;
-    }
-  }
+  return Object.fromEntries(
+    Object.entries(entries).filter(
+      (entry): entry is [string, string] => typeof entry[1] === 'string'
+    )
+  );
 }
 
-function resolveServerSecrets(server: MCPConfig): MCPConfig {
+function resolveServerSecrets(
+  server: MCPConfig,
+  env: Record<string, string | undefined>
+): MCPConfig {
+  if (server.transport === 'stdio')
+    return {
+      ...server,
+      env: Object.fromEntries(
+        Object.entries({ ...env, ...server.env }).filter(
+          (entry): entry is [string, string] => typeof entry[1] === 'string'
+        )
+      ),
+    };
   if (!isHttpConfig(server) || !server.auth?.accessTokenEnv) return server;
   const envName = server.auth.accessTokenEnv;
-  const token = process.env[envName];
+  const token = env[envName];
   if (!token) {
     throw new Error(
       `MCP access token environment variable "${envName}" is not set.`
@@ -114,15 +133,6 @@ function assertEvalEndpoint(server: MCPConfig, manifest: EvalManifest): void {
   }
 }
 
-async function expandDatasetPath(datasetPath: string): Promise<string[]> {
-  const stat = await fs.stat(datasetPath);
-  if (!stat.isDirectory()) return [datasetPath];
-  return (await fs.readdir(datasetPath))
-    .filter((name) => name.endsWith('.json'))
-    .sort()
-    .map((name) => path.join(datasetPath, name));
-}
-
 function selectedArms(manifest: EvalManifest, name?: string): EvalArm[] {
   const arms = manifest.arms?.length
     ? manifest.arms
@@ -138,8 +148,10 @@ function resolveHost(
   arm: EvalArm,
   servers: MCPConfig[]
 ) {
-  const declaration: HostConfig = arm.host ??
-    manifest.host ?? { type: 'claude-cli' };
+  const declaration: HostConfig = {
+    ...(arm.host ?? manifest.host ?? { type: 'claude-cli' }),
+    type: arm.host?.type ?? manifest.host?.type ?? 'claude-cli',
+  };
   const definition: HostDefinition = getHost(declaration.type);
   const config = definition.createConfig?.({
     ...declaration,
@@ -255,19 +267,60 @@ function summarizeArm(
   };
 }
 
+function configuredJudges(
+  evalCase: EvalCase,
+  judges: Array<Record<string, unknown>>,
+  rawJudges: Array<Record<string, unknown>>
+) {
+  const existing = Array.isArray(evalCase.expect?.passesJudge)
+    ? evalCase.expect.passesJudge
+    : evalCase.expect?.passesJudge
+      ? [evalCase.expect.passesJudge]
+      : [];
+  return [
+    ...existing.filter(
+      (item) => !judges.some((judge) => judge.type === item.judge)
+    ),
+    ...judges.map((judge) => {
+      const inherited = existing.find((item) => item.judge === judge.type);
+      const raw =
+        rawJudges.find(
+          (item) => item.type === judge.type && item.name === judge.name
+        ) ?? judge;
+      return {
+        ...inherited,
+        ...judge,
+        judge: judge.type,
+        options: { ...inherited?.options, ...raw },
+        reference:
+          judge.reference ?? inherited?.reference ?? evalCase.canonicalAnswer,
+      };
+    }),
+  ];
+}
+
 export async function runEvalSuite(
   options: RunEvalSuiteOptions
 ): Promise<RunEvalSuiteResult> {
   const rootDir = options.rootDir ?? process.cwd();
-  let manifest = loadEvalManifest(options.manifestPath, { rootDir });
-  const identity = manifestIdentity(manifest);
-  if (options.secretsFile) {
-    await loadSecretsFile(
-      path.isAbsolute(options.secretsFile)
-        ? options.secretsFile
-        : path.resolve(rootDir, options.secretsFile)
-    );
-  }
+  const rawManifest = loadEvalManifest(options.manifestPath, { rootDir });
+  const identity = manifestIdentity(rawManifest);
+  let manifest = rawManifest;
+  const ambientEnv = Object.fromEntries(
+    Object.entries(process.env).filter(
+      (entry): entry is [string, string] => typeof entry[1] === 'string'
+    )
+  );
+  const env = {
+    ...ambientEnv,
+    ...(options.secretsFile
+      ? await loadSecretsFile(
+          path.isAbsolute(options.secretsFile)
+            ? options.secretsFile
+            : path.resolve(rootDir, options.secretsFile)
+        )
+      : {}),
+  };
 
   registerBuiltinDatasetSources();
   registerBuiltinHosts();
@@ -313,17 +366,38 @@ export async function runEvalSuite(
   const armResults: EvaluationArmResult[] = [];
   const allDatasets: RunEvalSuiteResult['datasets'] = [];
   const allResults: EvalCaseResult[] = [];
+  const sourceArm = arms[0] ?? { name: 'default' };
+  const sourceServers = sourceArm.servers ?? manifest.servers ?? [];
+  const sourceHost = resolveHost(manifest, sourceArm, sourceServers);
+  const canonicalDatasets = await Promise.all(
+    datasets.map(async (source) => ({
+      source,
+      dataset: await getDatasetSource(source.type).load(source, {
+        rootDir,
+        manifest: {
+          ...manifest,
+          maxCases: undefined,
+          filterTags: undefined,
+          run: undefined,
+        },
+        hostConfig: sourceHost.config,
+      }),
+    }))
+  );
 
   for (const arm of arms) {
     const servers = options.mcpConfig
       ? [options.mcpConfig]
       : (arm.servers ?? manifest.servers ?? []);
-    const resolvedServers = servers.map(resolveServerSecrets);
+    const resolvedServers = servers.map((server) =>
+      resolveServerSecrets(server, env)
+    );
     resolvedServers.forEach((server) => assertEvalEndpoint(server, manifest));
     const host = resolveHost(manifest, arm, resolvedServers);
-    const effectiveManifest = {
+    const effectiveManifest: EvalManifest = {
       ...manifest,
       ...arm,
+      host: host.declaration,
       name: manifest.name,
       datasets: manifest.datasets,
     };
@@ -331,6 +405,14 @@ export async function runEvalSuite(
       name: string;
       result: EvalRunnerResult;
     }> = [];
+    const rawArm = rawManifest.arms?.find(
+      (candidate) => candidate.name === arm.name
+    ) ?? { name: arm.name };
+    const rawDeclaration: HostConfig = {
+      type: 'claude-cli',
+      ...rawManifest.host,
+      ...rawArm.host,
+    };
     const client = host.definition.run
       ? undefined
       : resolvedServers.length === 1
@@ -341,156 +423,126 @@ export async function runEvalSuite(
       : undefined;
 
     try {
-      for (const source of datasets) {
-        const datasetPaths =
-          source.type === 'file' || source.type === 'dir'
-            ? await expandDatasetPath(
-                path.isAbsolute(String(source.path))
-                  ? String(source.path)
-                  : path.resolve(rootDir, String(source.path))
-              )
-            : [undefined];
-        for (const filePath of datasetPaths) {
-          const sourceConfig = filePath
-            ? { ...source, type: 'file', path: filePath }
-            : source;
-          const datasetSource = getDatasetSource(sourceConfig.type);
-          const dataset = await datasetSource.load(sourceConfig, {
-            rootDir,
-            manifest: effectiveManifest,
-            hostConfig: host.config,
-          });
-          const template = arm.scenarioTemplate ?? manifest.scenarioTemplate;
-          const effectiveDataset: EvalDataset = {
-            ...dataset,
-            cases: dataset.cases.map((evalCase) => ({
-              ...evalCase,
-              ...(evalCase.host
-                ? {
-                    host: parseHostConfig({
-                      ...host.declaration,
-                      ...evalCase.host,
-                    }),
-                  }
-                : {}),
-              ...(effectiveManifest.judges?.length
-                ? {
-                    expect: EvalExpectBlockSchema.parse({
-                      ...evalCase.expect,
-                      passesJudge: [
-                        ...(Array.isArray(evalCase.expect?.passesJudge)
-                          ? evalCase.expect.passesJudge
-                          : evalCase.expect?.passesJudge
-                            ? [evalCase.expect.passesJudge]
-                            : []),
-                        ...(effectiveManifest.judges ?? [])
-                          .filter((judge) => {
-                            const existing = evalCase.expect?.passesJudge;
-                            return !(
-                              Array.isArray(existing)
-                                ? existing
-                                : existing
-                                  ? [existing]
-                                  : []
-                            ).some((config) => config.judge === judge.type);
-                          })
-                          .map((judge) => ({
-                            ...judge,
-                            judge: judge.type,
-                            reference:
-                              judge.reference ?? evalCase.canonicalAnswer,
-                          })),
-                      ],
-                    }),
-                  }
-                : {}),
-              ...(template && evalCase.scenario
-                ? {
-                    scenario: template.replaceAll(
-                      '{{scenario}}',
-                      evalCase.scenario
+      for (const { source, dataset } of canonicalDatasets) {
+        const executionDataset = selectEvalCases(dataset, manifest);
+        const template = arm.scenarioTemplate ?? manifest.scenarioTemplate;
+        const effectiveDataset: EvalDataset = {
+          ...executionDataset,
+          cases: executionDataset.cases.map((evalCase) => ({
+            ...evalCase,
+            ...(evalCase.host
+              ? {
+                  host: parseHostConfig({
+                    ...rawDeclaration,
+                    ...evalCase.host,
+                  }),
+                }
+              : {}),
+            ...(effectiveManifest.judges?.length
+              ? {
+                  expect: EvalExpectBlockSchema.parse({
+                    ...evalCase.expect,
+                    passesJudge: configuredJudges(
+                      evalCase,
+                      effectiveManifest.judges,
+                      (rawArm.judges ?? rawManifest.judges ?? []) as Array<
+                        Record<string, unknown>
+                      >
                     ),
-                  }
-                : {}),
-            })),
-          };
-          const runHost = host.definition.run?.bind(host.definition);
-          const result = await runEvalDataset(
-            {
-              dataset: effectiveDataset,
-              concurrency: manifest.concurrency ?? 1,
-              defaultLlmIterations: manifest.iterations,
-              toolOverrides: arm.toolOverrides ?? manifest.toolOverrides,
-              toolMap: arm.toolMap ?? manifest.toolMap,
-              ...(runHost
-                ? {
-                    executeCase: async (evalCase) => {
-                      const declaration = evalCase.host ?? host.declaration;
-                      if ((evalCase.mode ?? 'direct') === 'direct') {
-                        const selected =
-                          resolvedServers.length === 1
-                            ? resolvedServers[0]
-                            : resolvedServers.find(
-                                (server) =>
-                                  server.label &&
-                                  evalCase.toolName?.startsWith(
-                                    `${server.label}.`
-                                  )
-                              );
-                        if (!selected)
-                          throw new Error(
-                            'Direct cases require one server or a label-qualified tool name.'
-                          );
-                        const directClient =
-                          await createMCPClientForConfig(selected);
-                        try {
-                          const toolName =
-                            selected.label &&
-                            evalCase.toolName?.startsWith(`${selected.label}.`)
-                              ? evalCase.toolName.slice(
-                                  selected.label.length + 1
+                  }),
+                }
+              : {}),
+            ...(template && evalCase.scenario
+              ? {
+                  scenario: template.replaceAll(
+                    '{{scenario}}',
+                    evalCase.scenario
+                  ),
+                }
+              : {}),
+          })),
+        };
+        const sourceConfig = source;
+        const runHost = host.definition.run?.bind(host.definition);
+        const result = await runEvalDataset(
+          {
+            dataset: effectiveDataset,
+            concurrency: manifest.concurrency ?? 1,
+            defaultLlmIterations: manifest.iterations,
+            toolOverrides: arm.toolOverrides ?? manifest.toolOverrides,
+            toolMap: arm.toolMap ?? manifest.toolMap,
+            ...(runHost
+              ? {
+                  executeCase: async (evalCase) => {
+                    const declaration = evalCase.host ?? host.declaration;
+                    if ((evalCase.mode ?? 'direct') === 'direct') {
+                      const selected =
+                        resolvedServers.length === 1
+                          ? resolvedServers[0]
+                          : resolvedServers.find(
+                              (server) =>
+                                server.label &&
+                                evalCase.toolName?.startsWith(
+                                  `${server.label}.`
                                 )
-                              : evalCase.toolName;
-                          return await executeToolCall(
-                            { ...evalCase, toolName },
-                            createMCPFixture(directClient)
-                          );
-                        } finally {
-                          await closeMCPClient(directClient);
-                        }
-                      }
-                      const definition = getHost(declaration.type);
-                      if (!definition.run)
+                            );
+                      if (!selected)
                         throw new Error(
-                          `Host ${declaration.type} must expose run() for per-case dispatch.`
+                          'Direct cases require one server or a label-qualified tool name.'
                         );
-                      const trace = await definition.run(
-                        {
-                          scenario: evalCase.scenario ?? '',
-                          servers: resolvedServers,
-                        },
-                        declaration,
-                        {
-                          manifest: effectiveManifest,
-                          arm,
-                          mcpHostConfig: evalCase.mcpHostConfig,
-                        }
+                      const directClient =
+                        await createMCPClientForConfig(selected);
+                      try {
+                        const toolName =
+                          selected.label &&
+                          evalCase.toolName?.startsWith(`${selected.label}.`)
+                            ? evalCase.toolName.slice(selected.label.length + 1)
+                            : evalCase.toolName;
+                        return await executeToolCall(
+                          { ...evalCase, toolName },
+                          createMCPFixture(directClient)
+                        );
+                      } finally {
+                        await closeMCPClient(directClient);
+                      }
+                    }
+                    const definition = getHost(declaration.type);
+                    if (!definition.run)
+                      throw new Error(
+                        `Host ${declaration.type} must expose run() for per-case dispatch.`
                       );
-                      return hostTraceToExecution(
-                        trace,
-                        definition.evidence ?? 'none',
-                        resolvedServers
-                      );
-                    },
-                  }
-                : {}),
-            },
-            { mcp }
-          );
-          allDatasets.push({ source: sourceConfig, dataset, result });
-          sourceResults.push({ name: dataset.name, result });
-          allResults.push(...result.caseResults);
-        }
+                    const trace = await definition.run(
+                      {
+                        scenario: evalCase.scenario ?? '',
+                        servers: resolvedServers,
+                        env,
+                      },
+                      declaration,
+                      {
+                        manifest: effectiveManifest,
+                        arm,
+                        env,
+                        mcpHostConfig: evalCase.mcpHostConfig,
+                      }
+                    );
+                    return hostTraceToExecution(
+                      trace,
+                      definition.evidence ?? 'none',
+                      resolvedServers
+                    );
+                  },
+                }
+              : {}),
+          },
+          { mcp }
+        );
+        allDatasets.push({
+          source: sourceConfig,
+          dataset: executionDataset,
+          result,
+        });
+        sourceResults.push({ name: executionDataset.name, result });
+        allResults.push(...result.caseResults);
       }
     } finally {
       if (client) await closeMCPClient(client);

--- a/src/evals/runEvalSuite.ts
+++ b/src/evals/runEvalSuite.ts
@@ -23,6 +23,10 @@ import type {
 } from './evalFrameworkTypes.js';
 import { registerBuiltinDatasetSources } from './builtinDatasetSources.js';
 import { registerBuiltinHosts } from './builtinHosts.js';
+import {
+  hostEnvironment,
+  type HostEnvironment,
+} from './mcpHost/hostOptions.js';
 import { runEvalDataset, executeToolCall } from './evalRunner.js';
 import { hostTraceToExecution } from './hostTrace.js';
 import type { EvalRunnerResult } from './evalRunner.js';
@@ -146,7 +150,8 @@ function selectedArms(manifest: EvalManifest, name?: string): EvalArm[] {
 function resolveHost(
   manifest: EvalManifest,
   arm: EvalArm,
-  servers: MCPConfig[]
+  servers: MCPConfig[],
+  env: HostEnvironment
 ) {
   const declaration: HostConfig = {
     ...(arm.host ?? manifest.host ?? { type: 'claude-cli' }),
@@ -157,6 +162,10 @@ function resolveHost(
     ...declaration,
     servers,
     server: servers[0],
+    env: hostEnvironment(
+      { env: declaration.env as HostEnvironment | undefined },
+      { env }
+    ),
   });
   return { definition, declaration, config };
 }
@@ -282,18 +291,25 @@ function configuredJudges(
       (item) => !judges.some((judge) => judge.type === item.judge)
     ),
     ...judges.map((judge) => {
-      const inherited = existing.find((item) => item.judge === judge.type);
+      const caseJudge = existing.find((item) => item.judge === judge.type);
       const raw =
         rawJudges.find(
           (item) => item.type === judge.type && item.name === judge.name
         ) ?? judge;
+      const { options: caseOptions, ...caseSettings } = caseJudge ?? {};
       return {
-        ...inherited,
         ...judge,
+        ...caseSettings,
         judge: judge.type,
-        options: { ...inherited?.options, ...raw },
+        // Merge raw policy inputs so the shared evaluator transforms them once.
+        // Explicit case settings, including flat policy fields, win over defaults.
+        options: { ...raw, ...caseSettings, ...caseOptions },
         reference:
-          judge.reference ?? inherited?.reference ?? evalCase.canonicalAnswer,
+          caseJudge?.reference !== undefined
+            ? caseJudge.reference
+            : judge.reference !== undefined
+              ? judge.reference
+              : evalCase.canonicalAnswer,
       };
     }),
   ];
@@ -367,8 +383,13 @@ export async function runEvalSuite(
   const allDatasets: RunEvalSuiteResult['datasets'] = [];
   const allResults: EvalCaseResult[] = [];
   const sourceArm = arms[0] ?? { name: 'default' };
-  const sourceServers = sourceArm.servers ?? manifest.servers ?? [];
-  const sourceHost = resolveHost(manifest, sourceArm, sourceServers);
+  const sourceServers = (
+    options.mcpConfig
+      ? [options.mcpConfig]
+      : (sourceArm.servers ?? manifest.servers ?? [])
+  ).map((server) => resolveServerSecrets(server, env));
+  sourceServers.forEach((server) => assertEvalEndpoint(server, manifest));
+  const sourceHost = resolveHost(manifest, sourceArm, sourceServers, env);
   const canonicalDatasets = await Promise.all(
     datasets.map(async (source) => ({
       source,
@@ -393,7 +414,7 @@ export async function runEvalSuite(
       resolveServerSecrets(server, env)
     );
     resolvedServers.forEach((server) => assertEvalEndpoint(server, manifest));
-    const host = resolveHost(manifest, arm, resolvedServers);
+    const host = resolveHost(manifest, arm, resolvedServers, env);
     const effectiveManifest: EvalManifest = {
       ...manifest,
       ...arm,
@@ -432,10 +453,10 @@ export async function runEvalSuite(
             ...evalCase,
             ...(evalCase.host
               ? {
-                  host: parseHostConfig({
-                    ...rawDeclaration,
-                    ...evalCase.host,
-                  }),
+                  host: parseHostConfig(
+                    { ...rawDeclaration, ...evalCase.host },
+                    rawManifest
+                  ),
                 }
               : {}),
             ...(effectiveManifest.judges?.length

--- a/src/evals/runEvalSuite.ts
+++ b/src/evals/runEvalSuite.ts
@@ -1,0 +1,558 @@
+import { manifestIdentity } from './manifestIdentity.js';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import {
+  createMCPClientForConfig,
+  closeMCPClient,
+} from '../mcp/clientFactory.js';
+import { createMCPFixture } from '../mcp/fixtures/mcpFixture.js';
+import type { MCPConfig } from '../config/mcpConfig.js';
+import { isHttpConfig } from '../config/mcpConfig.js';
+import {
+  loadEvalManifest,
+  type DatasetConfig,
+  type EvalArm,
+  type EvalManifest,
+  type HostConfig,
+} from './evalManifest.js';
+import type {
+  EvaluationArmResult,
+  EvaluationSummary,
+  HostDefinition,
+  RunTelemetry,
+} from './evalFrameworkTypes.js';
+import { registerBuiltinDatasetSources } from './builtinDatasetSources.js';
+import { registerBuiltinHosts } from './builtinHosts.js';
+import { runEvalDataset, executeToolCall } from './evalRunner.js';
+import { hostTraceToExecution } from './hostTrace.js';
+import type { EvalRunnerResult } from './evalRunner.js';
+import { EvalExpectBlockSchema, type EvalDataset } from './datasetTypes.js';
+import type { EvalCaseResult } from '../types/reporter.js';
+import type { UsageMetrics } from '../types/index.js';
+import { loadPlugins } from '../plugins/loadPlugins.js';
+import {
+  getDatasetSource,
+  getHost,
+  parseHostConfig,
+  validateManifestRegistrations,
+} from './frameworkRegistries.js';
+import { computeMetrics, type MetricSpec } from './metrics.js';
+
+export interface RunEvalSuiteOptions {
+  manifestPath: string;
+  rootDir?: string;
+  pluginPaths?: string[];
+  outputDir?: string;
+  secretsFile?: string;
+  mcpConfig?: MCPConfig;
+  dryRun?: boolean;
+  arm?: string;
+}
+
+export interface RunEvalSuiteResult {
+  manifest: EvalManifest;
+  outputDir: string;
+  datasets: Array<{
+    source: DatasetConfig;
+    dataset?: EvalDataset;
+    result?: EvalRunnerResult;
+  }>;
+  summary: EvaluationSummary;
+}
+
+async function loadSecretsFile(secretsFile: string): Promise<void> {
+  const raw = await fs.readFile(secretsFile, 'utf8');
+  let entries: Record<string, unknown>;
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      throw new Error('Secrets JSON must contain an object.');
+    }
+    entries = parsed as Record<string, unknown>;
+  } catch {
+    entries = {};
+    for (const rawLine of raw.split(/\r?\n/)) {
+      const line = rawLine.trim();
+      if (!line || line.startsWith('#')) continue;
+      const equals = line.indexOf('=');
+      if (equals < 1) continue;
+      const key = line.slice(0, equals).trim();
+      const value = line
+        .slice(equals + 1)
+        .trim()
+        .replace(/^['"]|['"]$/g, '');
+      entries[key] = value;
+    }
+  }
+  for (const [key, value] of Object.entries(entries)) {
+    if (typeof value === 'string' && process.env[key] === undefined) {
+      process.env[key] = value;
+    }
+  }
+}
+
+function resolveServerSecrets(server: MCPConfig): MCPConfig {
+  if (!isHttpConfig(server) || !server.auth?.accessTokenEnv) return server;
+  const envName = server.auth.accessTokenEnv;
+  const token = process.env[envName];
+  if (!token) {
+    throw new Error(
+      `MCP access token environment variable "${envName}" is not set.`
+    );
+  }
+  const { accessTokenEnv: _accessTokenEnv, ...auth } = server.auth;
+  return { ...server, auth: { ...auth, accessToken: token } };
+}
+
+function assertEvalEndpoint(server: MCPConfig, manifest: EvalManifest): void {
+  if (!manifest.requireEvalEndpoint || !isHttpConfig(server)) return;
+  const pathname = new URL(server.serverUrl).pathname;
+  if (!/\/eval(?:\/|$)/.test(pathname)) {
+    throw new Error(
+      `Evaluation requires an /eval MCP endpoint; received "${server.serverUrl}".`
+    );
+  }
+}
+
+async function expandDatasetPath(datasetPath: string): Promise<string[]> {
+  const stat = await fs.stat(datasetPath);
+  if (!stat.isDirectory()) return [datasetPath];
+  return (await fs.readdir(datasetPath))
+    .filter((name) => name.endsWith('.json'))
+    .sort()
+    .map((name) => path.join(datasetPath, name));
+}
+
+function selectedArms(manifest: EvalManifest, name?: string): EvalArm[] {
+  const arms = manifest.arms?.length
+    ? manifest.arms
+    : [{ name: 'default' } satisfies EvalArm];
+  if (!name) return arms;
+  const arm = arms.find((candidate) => candidate.name === name);
+  if (!arm) throw new Error(`Evaluation arm "${name}" was not found.`);
+  return [arm];
+}
+
+function resolveHost(
+  manifest: EvalManifest,
+  arm: EvalArm,
+  servers: MCPConfig[]
+) {
+  const declaration: HostConfig = arm.host ??
+    manifest.host ?? { type: 'claude-cli' };
+  const definition: HostDefinition = getHost(declaration.type);
+  const config = definition.createConfig?.({
+    ...declaration,
+    servers,
+    server: servers[0],
+  });
+  return { definition, declaration, config };
+}
+
+function sumUsage(
+  a: Partial<UsageMetrics> | undefined,
+  b: Partial<UsageMetrics>
+): Partial<UsageMetrics> {
+  const keys = [
+    'inputTokens',
+    'outputTokens',
+    'totalCostUsd',
+    'durationMs',
+    'cacheReadInputTokens',
+    'cacheCreationInputTokens',
+  ] as const;
+  const result: Partial<UsageMetrics> = { ...(a ?? {}) };
+  for (const key of keys) {
+    const va = a?.[key];
+    const vb = b[key];
+    if (va !== undefined || vb !== undefined) {
+      result[key] = (va ?? 0) + (vb ?? 0);
+    }
+  }
+  return result;
+}
+
+function countToolCalls(results: EvalCaseResult[]): number {
+  return results.reduce((count, result) => {
+    const response = result.response;
+    if (!response || typeof response !== 'object') return count;
+    const calls = (response as { toolCalls?: unknown }).toolCalls;
+    return count + (Array.isArray(calls) ? calls.length : 0);
+  }, 0);
+}
+
+function buildArmDeltas(
+  arms: EvaluationArmResult[]
+): Record<string, Record<string, unknown>> {
+  const baseline = arms[0]?.result;
+  if (!baseline || baseline.total === 0) return {};
+  const baselineRate = baseline.passed / baseline.total;
+  return Object.fromEntries(
+    arms.slice(1).map((arm) => {
+      const result = arm.result;
+      const passRate =
+        result && result.total > 0 ? result.passed / result.total : 0;
+      return [
+        arm.name,
+        {
+          passRate,
+          passRateDelta: passRate - baselineRate,
+          baseline: arms[0]?.name,
+        },
+      ];
+    })
+  );
+}
+
+function redactServerForReport(server: MCPConfig): MCPConfig {
+  const label = server.label ? { label: server.label } : {};
+  if (server.transport === 'stdio') {
+    // Arguments and environment may both contain credentials.
+    return { transport: 'stdio', command: server.command, ...label };
+  }
+  const url = new URL(server.serverUrl);
+  url.username = '';
+  url.password = '';
+  url.search = '';
+  url.hash = '';
+  return {
+    transport: 'http',
+    serverUrl: url.toString(),
+    ...label,
+    ...(server.auth?.accessTokenEnv
+      ? { auth: { accessTokenEnv: server.auth.accessTokenEnv } }
+      : {}),
+  };
+}
+
+function summarizeArm(
+  arm: EvalArm,
+  servers: MCPConfig[],
+  results: Array<{ name: string; result: EvalRunnerResult }>
+): EvaluationArmResult {
+  const caseResults: EvalCaseResult[] = [];
+  let totalHostUsage: Partial<UsageMetrics> | undefined;
+  for (const { result } of results) {
+    caseResults.push(...result.caseResults);
+    if (result.totalHostUsage) {
+      totalHostUsage = sumUsage(totalHostUsage, result.totalHostUsage);
+    }
+  }
+  return {
+    name: arm.name,
+    servers: servers.map(redactServerForReport),
+    result: {
+      caseResults,
+      total: caseResults.length,
+      passed: caseResults.filter((result) => result.pass).length,
+      failed: caseResults.filter((result) => !result.pass).length,
+      durationMs: results.reduce(
+        (sum, item) => sum + item.result.durationMs,
+        0
+      ),
+      totalHostUsage,
+    },
+  };
+}
+
+export async function runEvalSuite(
+  options: RunEvalSuiteOptions
+): Promise<RunEvalSuiteResult> {
+  const rootDir = options.rootDir ?? process.cwd();
+  let manifest = loadEvalManifest(options.manifestPath, { rootDir });
+  const identity = manifestIdentity(manifest);
+  if (options.secretsFile) {
+    await loadSecretsFile(
+      path.isAbsolute(options.secretsFile)
+        ? options.secretsFile
+        : path.resolve(rootDir, options.secretsFile)
+    );
+  }
+
+  registerBuiltinDatasetSources();
+  registerBuiltinHosts();
+  const pluginPaths = options.pluginPaths ?? manifest.plugins ?? [];
+  if (pluginPaths.length > 0) {
+    await loadPlugins(
+      pluginPaths.map((pluginPath) =>
+        path.isAbsolute(pluginPath)
+          ? pluginPath
+          : path.resolve(rootDir, pluginPath)
+      )
+    );
+  }
+
+  manifest = validateManifestRegistrations({
+    ...manifest,
+    host: manifest.host ?? { type: 'claude-cli' },
+  });
+  const outputDir =
+    options.outputDir ?? path.join(rootDir, '.mcp-test-results', manifest.name);
+  const arms = selectedArms(manifest, options.arm);
+  const datasets = manifest.datasets;
+
+  if (options.dryRun) {
+    return {
+      manifest,
+      outputDir,
+      datasets: datasets.map((source) => ({ source })),
+      summary: {
+        schemaVersion: 1,
+        ...identity,
+        timestamp: new Date().toISOString(),
+        durationMs: 0,
+        manifestName: manifest.name,
+        arms: [],
+        metrics: {},
+        armDeltas: {},
+        results: [],
+      },
+    };
+  }
+
+  const armResults: EvaluationArmResult[] = [];
+  const allDatasets: RunEvalSuiteResult['datasets'] = [];
+  const allResults: EvalCaseResult[] = [];
+
+  for (const arm of arms) {
+    const servers = options.mcpConfig
+      ? [options.mcpConfig]
+      : (arm.servers ?? manifest.servers ?? []);
+    const resolvedServers = servers.map(resolveServerSecrets);
+    resolvedServers.forEach((server) => assertEvalEndpoint(server, manifest));
+    const host = resolveHost(manifest, arm, resolvedServers);
+    const effectiveManifest = {
+      ...manifest,
+      ...arm,
+      name: manifest.name,
+      datasets: manifest.datasets,
+    };
+    const sourceResults: Array<{
+      name: string;
+      result: EvalRunnerResult;
+    }> = [];
+    const client = host.definition.run
+      ? undefined
+      : resolvedServers.length === 1
+        ? await createMCPClientForConfig(resolvedServers[0]!)
+        : undefined;
+    const mcp = client
+      ? createMCPFixture(client, undefined, { authType: 'api-token' })
+      : undefined;
+
+    try {
+      for (const source of datasets) {
+        const datasetPaths =
+          source.type === 'file' || source.type === 'dir'
+            ? await expandDatasetPath(
+                path.isAbsolute(String(source.path))
+                  ? String(source.path)
+                  : path.resolve(rootDir, String(source.path))
+              )
+            : [undefined];
+        for (const filePath of datasetPaths) {
+          const sourceConfig = filePath
+            ? { ...source, type: 'file', path: filePath }
+            : source;
+          const datasetSource = getDatasetSource(sourceConfig.type);
+          const dataset = await datasetSource.load(sourceConfig, {
+            rootDir,
+            manifest: effectiveManifest,
+            hostConfig: host.config,
+          });
+          const template = arm.scenarioTemplate ?? manifest.scenarioTemplate;
+          const effectiveDataset: EvalDataset = {
+            ...dataset,
+            cases: dataset.cases.map((evalCase) => ({
+              ...evalCase,
+              ...(evalCase.host
+                ? {
+                    host: parseHostConfig({
+                      ...host.declaration,
+                      ...evalCase.host,
+                    }),
+                  }
+                : {}),
+              ...(effectiveManifest.judges?.length
+                ? {
+                    expect: EvalExpectBlockSchema.parse({
+                      ...evalCase.expect,
+                      passesJudge: [
+                        ...(Array.isArray(evalCase.expect?.passesJudge)
+                          ? evalCase.expect.passesJudge
+                          : evalCase.expect?.passesJudge
+                            ? [evalCase.expect.passesJudge]
+                            : []),
+                        ...(effectiveManifest.judges ?? [])
+                          .filter((judge) => {
+                            const existing = evalCase.expect?.passesJudge;
+                            return !(
+                              Array.isArray(existing)
+                                ? existing
+                                : existing
+                                  ? [existing]
+                                  : []
+                            ).some((config) => config.judge === judge.type);
+                          })
+                          .map((judge) => ({
+                            ...judge,
+                            judge: judge.type,
+                            reference:
+                              judge.reference ?? evalCase.canonicalAnswer,
+                          })),
+                      ],
+                    }),
+                  }
+                : {}),
+              ...(template && evalCase.scenario
+                ? {
+                    scenario: template.replaceAll(
+                      '{{scenario}}',
+                      evalCase.scenario
+                    ),
+                  }
+                : {}),
+            })),
+          };
+          const runHost = host.definition.run?.bind(host.definition);
+          const result = await runEvalDataset(
+            {
+              dataset: effectiveDataset,
+              concurrency: manifest.concurrency ?? 1,
+              defaultLlmIterations: manifest.iterations,
+              toolOverrides: arm.toolOverrides ?? manifest.toolOverrides,
+              toolMap: arm.toolMap ?? manifest.toolMap,
+              ...(runHost
+                ? {
+                    executeCase: async (evalCase) => {
+                      const declaration = evalCase.host ?? host.declaration;
+                      if ((evalCase.mode ?? 'direct') === 'direct') {
+                        const selected =
+                          resolvedServers.length === 1
+                            ? resolvedServers[0]
+                            : resolvedServers.find(
+                                (server) =>
+                                  server.label &&
+                                  evalCase.toolName?.startsWith(
+                                    `${server.label}.`
+                                  )
+                              );
+                        if (!selected)
+                          throw new Error(
+                            'Direct cases require one server or a label-qualified tool name.'
+                          );
+                        const directClient =
+                          await createMCPClientForConfig(selected);
+                        try {
+                          const toolName =
+                            selected.label &&
+                            evalCase.toolName?.startsWith(`${selected.label}.`)
+                              ? evalCase.toolName.slice(
+                                  selected.label.length + 1
+                                )
+                              : evalCase.toolName;
+                          return await executeToolCall(
+                            { ...evalCase, toolName },
+                            createMCPFixture(directClient)
+                          );
+                        } finally {
+                          await closeMCPClient(directClient);
+                        }
+                      }
+                      const definition = getHost(declaration.type);
+                      if (!definition.run)
+                        throw new Error(
+                          `Host ${declaration.type} must expose run() for per-case dispatch.`
+                        );
+                      const trace = await definition.run(
+                        {
+                          scenario: evalCase.scenario ?? '',
+                          servers: resolvedServers,
+                        },
+                        declaration,
+                        {
+                          manifest: effectiveManifest,
+                          arm,
+                          mcpHostConfig: evalCase.mcpHostConfig,
+                        }
+                      );
+                      return hostTraceToExecution(
+                        trace,
+                        definition.evidence ?? 'none',
+                        resolvedServers
+                      );
+                    },
+                  }
+                : {}),
+            },
+            { mcp }
+          );
+          allDatasets.push({ source: sourceConfig, dataset, result });
+          sourceResults.push({ name: dataset.name, result });
+          allResults.push(...result.caseResults);
+        }
+      }
+    } finally {
+      if (client) await closeMCPClient(client);
+    }
+
+    armResults.push(summarizeArm(arm, servers, sourceResults));
+  }
+
+  const durationMs = armResults.reduce(
+    (sum, arm) => sum + (arm.result?.durationMs ?? 0),
+    0
+  );
+  const armMetrics = armResults.map((arm, index) => {
+    const metricSpecs = (arms[index]?.metrics ??
+      manifest.metrics ??
+      []) as MetricSpec[];
+    return computeMetrics(metricSpecs, arm.result?.caseResults ?? [])
+      .aggregated;
+  });
+  armResults.forEach((arm, index) => {
+    arm.metrics = armMetrics[index];
+  });
+  // Top-level metrics describe the baseline arm. Comparison-arm metrics remain
+  // attached to their arm, avoiding case-id collisions across arms.
+  const computedMetrics = armMetrics[0] ?? {};
+  let totalHostUsage: Partial<UsageMetrics> | undefined;
+  for (const arm of armResults) {
+    totalHostUsage = sumUsage(totalHostUsage, arm.result?.totalHostUsage ?? {});
+  }
+  const telemetry: RunTelemetry = {
+    cases: allResults.length,
+    toolCalls: countToolCalls(allResults),
+    failedCases: allResults.filter((result) => !result.pass).length,
+    totalHostUsage,
+  };
+  const summary: EvaluationSummary = {
+    schemaVersion: 1,
+    ...identity,
+    timestamp: new Date().toISOString(),
+    durationMs,
+    manifestName: manifest.name,
+    arms: armResults,
+    metrics: {
+      total: allResults.length,
+      passed: allResults.filter((result) => result.pass).length,
+      failed: allResults.filter((result) => !result.pass).length,
+      passRate:
+        allResults.length > 0
+          ? allResults.filter((result) => result.pass).length /
+            allResults.length
+          : 0,
+      ...computedMetrics,
+    },
+    telemetry,
+    armDeltas: buildArmDeltas(armResults),
+    results: allResults,
+  };
+
+  await fs.mkdir(outputDir, { recursive: true });
+  await fs.writeFile(
+    path.join(outputDir, 'results.json'),
+    `${JSON.stringify(summary, null, 2)}\n`
+  );
+  return { manifest, outputDir, datasets: allDatasets, summary };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -304,6 +304,21 @@ export {
 } from './evals/frameworkRegistries.js';
 // Preserve both legacy name/executor and schema-bearing object registration.
 export { registerJudge } from './judge/judgeRegistry.js';
+export {
+  BUILT_IN_METRICS,
+  METRIC_REGISTRY,
+  computeMetrics,
+  resolveMetric,
+} from './evals/metrics.js';
+
+// Eval dataset building and suite runner
+export { buildEvalDataset } from './evals/buildEvalDataset.js';
+export { getBuiltinHostConfig } from './evals/builtinHosts.js';
+export { runEvalSuite } from './evals/runEvalSuite.js';
+export type {
+  RunEvalSuiteOptions,
+  RunEvalSuiteResult,
+} from './evals/runEvalSuite.js';
 
 // Plugin loading
 export { loadPluginModule, loadPlugins } from './plugins/loadPlugins.js';


### PR DESCRIPTION
Stacked on [#248](https://github.com/gleanwork/mcp-server-tester/pull/248).\n\n## Scope\n\n- Build evaluation datasets from manifests.\n- Add suite execution and Scio-compatible result shaping.\n- Route built-in hosts and judges through registries.\n- Add execution metrics and result summaries.\n\nThis consolidates the former eval-config and execution-metrics layers into one reviewable core-evaluation PR.