### PR TITLE
[Evals] Add runtime dispatch and direct Anthropic execution

### DIFF
--- a/src/cli/commands/run/index.ts
+++ b/src/cli/commands/run/index.ts
@@ -11,6 +11,7 @@ export interface RunOptions {
   dryRun?: boolean;
   arm?: string;
   outputDir?: string;
+  secretsFile?: string;
 }
 
 export async function run(options: RunOptions): Promise<void> {
@@ -19,6 +20,7 @@ export async function run(options: RunOptions): Promise<void> {
     rootDir: options.rootDir,
     pluginPaths: options.plugins,
     outputDir: options.outputDir,
+    secretsFile: options.secretsFile,
     dryRun: options.dryRun,
     arm: options.arm,
   };
@@ -42,6 +44,7 @@ export async function run(options: RunOptions): Promise<void> {
 
   const metrics = result.summary.metrics as {
     passed?: number;
+    failed?: number;
     total?: number;
     passRate?: number;
   };
@@ -50,4 +53,5 @@ export async function run(options: RunOptions): Promise<void> {
     `Results: ${metrics.passed ?? 0}/${metrics.total ?? 0} passed (${((metrics.passRate ?? 0) * 100).toFixed(1)}%)`
   );
   console.log(`Output: ${path.join(result.outputDir, 'results.json')}`);
+  if ((metrics.failed ?? 0) > 0) process.exitCode = 1;
 }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -73,6 +73,8 @@ program
   )
   .option('--plugins <paths...>', 'Plugin modules to load before the run')
   .option('--arm <name>', 'Run one named manifest arm')
+  .option('--output-dir <dir>', 'Directory for run artifacts')
+  .option('--secrets-file <path>', 'JSON or dotenv-style runtime secrets file')
   .option(
     '--root-dir <dir>',
     'Base directory for resolving relative paths',

--- a/src/evals/anthropicApiHost.test.ts
+++ b/src/evals/anthropicApiHost.test.ts
@@ -1,0 +1,153 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ANTHROPIC_API_HOST } from './anthropicApiHost.js';
+import { hostTraceToExecution } from './hostTrace.js';
+async function run(options: HostRunOptions) {
+  const trace = await ANTHROPIC_API_HOST.run!(
+    { scenario: options.cases[0]!.scenario!, servers: options.servers },
+    options.host,
+    { manifest: options.manifest, arm: options.arm }
+  );
+  return hostTraceToExecution(trace, 'structured', options.servers);
+}
+import type { HostRunOptions } from './evalFrameworkTypes.js';
+import {
+  createMCPClientForConfig,
+  closeMCPClient,
+} from '../mcp/clientFactory.js';
+
+vi.mock('../mcp/clientFactory.js', () => ({
+  createMCPClientForConfig: vi.fn(),
+  closeMCPClient: vi.fn(async () => {}),
+}));
+const callTool = vi.fn(async () => ({
+  content: [{ type: 'text', text: 'tool output' }],
+}));
+const close = vi.fn(async () => {});
+const listTools = vi.fn(async () => ({
+  tools: [
+    {
+      name: 'search',
+      description: 'original',
+      inputSchema: { type: 'object' },
+    },
+  ],
+}));
+const fetchMock = vi.fn<typeof fetch>();
+const case_ = {
+  id: 'one',
+  mode: 'mcp_host' as const,
+  scenario: 'Search',
+  iterations: 3,
+};
+function options(maxToolCalls = 10): HostRunOptions {
+  return {
+    dataset: { name: 'test', cases: [case_] },
+    cases: [case_],
+    servers: [{ transport: 'http', serverUrl: 'https://example.com' }],
+    host: { type: 'anthropic-api', maxToolCalls },
+    manifest: { name: 'test', datasets: [] },
+  };
+}
+function response(content: unknown[], stop_reason = 'end_turn'): Response {
+  return new Response(
+    JSON.stringify({
+      content,
+      stop_reason,
+      usage: { input_tokens: 2, output_tokens: 3 },
+    }),
+    { status: 200 }
+  );
+}
+function calls(count: number): Response {
+  return response(
+    Array.from({ length: count }, (_, index) => ({
+      type: 'tool_use',
+      id: `call-${index}`,
+      name: 'search',
+      input: { query: 'test' },
+    })),
+    'tool_use'
+  );
+}
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.stubEnv('ANTHROPIC_API_KEY', 'dummy-key');
+  vi.stubGlobal('fetch', fetchMock);
+  vi.mocked(createMCPClientForConfig).mockResolvedValue({
+    callTool,
+    listTools,
+    close,
+  } as unknown as Awaited<ReturnType<typeof createMCPClientForConfig>>);
+});
+afterEach(() => {
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+  vi.unstubAllEnvs();
+});
+describe('Anthropic trace execution', () => {
+  it.each([0, 1])(
+    'enforces a budget of %s before every tool call',
+    async (budget) => {
+      fetchMock.mockResolvedValueOnce(calls(3));
+      const result = await run(options(budget));
+      expect(callTool).toHaveBeenCalledTimes(budget);
+      expect(result.error).toContain('budget exhausted');
+      expect(result).not.toHaveProperty('passed');
+      expect(closeMCPClient).toHaveBeenCalledTimes(1);
+    }
+  );
+  it('returns text and argument evidence without scoring or owning iterations', async () => {
+    fetchMock
+      .mockResolvedValueOnce(calls(1))
+      .mockResolvedValueOnce(response([{ type: 'text', text: 'WRONG' }]));
+    const result = await run(options());
+    expect(result.error).toBeUndefined();
+    expect(result.response).toMatchObject({
+      response: 'WRONG',
+      success: true,
+      toolCalls: [{ name: 'search', arguments: { query: 'test' } }],
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(result.hostUsage?.inputTokens).toBe(4);
+  });
+  it('times out a never-settling fetch, aborts the request and closes the client', async () => {
+    vi.useFakeTimers();
+    fetchMock.mockImplementation(() => new Promise(() => {}));
+    const input = options();
+    input.host.timeout = 10;
+    const pending = run(input);
+    await vi.advanceTimersByTimeAsync(11);
+    const result = await pending;
+    expect(result.error).toContain('timed out');
+    expect(fetchMock.mock.calls[0]?.[1]?.signal?.aborted).toBe(true);
+    expect(closeMCPClient).toHaveBeenCalledTimes(1);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+  it('bounds session teardown and force-closes the transport when termination stalls', async () => {
+    vi.useFakeTimers();
+    fetchMock.mockResolvedValueOnce(response([{ type: 'text', text: 'OK' }]));
+    vi.mocked(closeMCPClient).mockImplementationOnce(
+      () => new Promise(() => {})
+    );
+    const input = options();
+    input.host.timeout = 10;
+    const pending = run(input);
+    await vi.advanceTimersByTimeAsync(11);
+    expect((await pending).error).toContain('timed out');
+    expect(close).toHaveBeenCalledOnce();
+    expect(vi.getTimerCount()).toBe(0);
+  });
+  it('applies description overrides and supports a no-server assistant', async () => {
+    fetchMock.mockResolvedValueOnce(response([{ type: 'text', text: 'OK' }]));
+    const input = options();
+    input.manifest.toolOverrides = {
+      id: 'variant',
+      tools: { search: { description: 'changed' } },
+    };
+    await run(input);
+    expect(fetchMock.mock.calls[0]?.[1]?.body).toContain('changed');
+    fetchMock.mockResolvedValueOnce(response([{ type: 'text', text: 'OK' }]));
+    await run({ ...options(), servers: [] });
+    expect(createMCPClientForConfig).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/evals/anthropicApiHost.test.ts
+++ b/src/evals/anthropicApiHost.test.ts
@@ -1,6 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
 import { ANTHROPIC_API_HOST } from './anthropicApiHost.js';
 import { hostTraceToExecution } from './hostTrace.js';
+import { runEvalSuite } from './runEvalSuite.js';
 async function run(
   options: HostRunOptions,
   extra: Partial<HostRunContext> = {}
@@ -65,6 +69,12 @@ function response(content: unknown[], stop_reason = 'end_turn'): Response {
     { status: 200 }
   );
 }
+function requestBody(index = 0): Record<string, unknown> {
+  const body = fetchMock.mock.calls[index]?.[1]?.body;
+  if (typeof body !== 'string')
+    throw new Error('Expected a JSON request body.');
+  return JSON.parse(body) as Record<string, unknown>;
+}
 function calls(count: number): Response {
   return response(
     Array.from({ length: count }, (_, index) => ({
@@ -78,6 +88,7 @@ function calls(count: number): Response {
 }
 beforeEach(() => {
   vi.clearAllMocks();
+  fetchMock.mockReset();
   vi.stubEnv('ANTHROPIC_API_KEY', 'dummy-key');
   vi.stubGlobal('fetch', fetchMock);
   vi.mocked(createMCPClientForConfig).mockResolvedValue({
@@ -91,6 +102,184 @@ afterEach(() => {
   vi.unstubAllGlobals();
   vi.unstubAllEnvs();
 });
+describe.each(['tagged', 'legacy', 'manifest'] as const)(
+  'Anthropic %s generation settings',
+  (source) => {
+    async function runWithSettings(settings: {
+      temperature?: number;
+      maxTokens?: number;
+    }) {
+      const input = options();
+      input.manifest.temperature = 0.8;
+      input.manifest.maxTokens = 789;
+      if (source === 'legacy') {
+        input.host.temperature = 0.7;
+        input.host.maxTokens = 456;
+        return run(input, { mcpHostConfig: settings });
+      }
+      Object.assign(
+        source === 'manifest' ? input.manifest : input.host,
+        settings
+      );
+      return run(input);
+    }
+
+    it('forwards resolved generation options in every Anthropic request', async () => {
+      fetchMock
+        .mockResolvedValueOnce(calls(1))
+        .mockResolvedValueOnce(response([{ type: 'text', text: 'OK' }]));
+      const result = await runWithSettings({
+        temperature: 0.4,
+        maxTokens: 123,
+      });
+      expect(result.error).toBeUndefined();
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+      for (const index of [0, 1]) {
+        expect(requestBody(index)).toMatchObject({
+          temperature: 0.4,
+          max_tokens: 123,
+        });
+      }
+    });
+
+    it.each([
+      [0, 1],
+      [1, 8192],
+    ])(
+      'accepts temperature=%s and maxTokens=%s',
+      async (temperature, maxTokens) => {
+        fetchMock.mockResolvedValueOnce(
+          response([{ type: 'text', text: 'OK' }])
+        );
+        const result = await runWithSettings({ temperature, maxTokens });
+        expect(result.error).toBeUndefined();
+        expect(requestBody()).toMatchObject({
+          temperature,
+          max_tokens: maxTokens,
+        });
+      }
+    );
+
+    it.each([
+      ['temperature', -0.01],
+      ['temperature', 1.01],
+      ['temperature', NaN],
+      ['temperature', Infinity],
+      ['maxTokens', 0],
+      ['maxTokens', -1],
+      ['maxTokens', 1.5],
+      ['maxTokens', NaN],
+      ['maxTokens', Infinity],
+      ['maxTokens', Number.MAX_SAFE_INTEGER + 1],
+    ] as const)(
+      'rejects %s=%s before connecting or fetching',
+      async (field, value) => {
+        fetchMock.mockResolvedValueOnce(
+          response([{ type: 'text', text: 'OK' }])
+        );
+        await expect(runWithSettings({ [field]: value })).rejects.toThrow(
+          field
+        );
+        expect(createMCPClientForConfig).not.toHaveBeenCalled();
+        expect(fetchMock).not.toHaveBeenCalled();
+      }
+    );
+  }
+);
+
+describe('Anthropic generation defaults and suite precedence', () => {
+  it('keeps 4096 tokens and omits temperature when neither is specified', async () => {
+    fetchMock.mockResolvedValueOnce(response([{ type: 'text', text: 'OK' }]));
+    const result = await run(options());
+    expect(result.error).toBeUndefined();
+    expect(requestBody()).toHaveProperty('max_tokens', 4096);
+    expect(requestBody()).not.toHaveProperty('temperature');
+  });
+
+  it('forwards serialized manifest, arm, tagged case and legacy case settings', async () => {
+    const dir = await fs.mkdtemp(
+      path.join(os.tmpdir(), 'anthropic-generation-')
+    );
+    try {
+      const manifestPath = path.join(dir, 'manifest.json');
+      await fs.writeFile(
+        manifestPath,
+        JSON.stringify({
+          name: 'generation-options',
+          datasets: [{ type: 'file', path: 'cases.json' }],
+          servers: [{ transport: 'http', serverUrl: 'https://example.com' }],
+          temperature: 0.8,
+          maxTokens: 789,
+          host: { type: 'anthropic-api' },
+          arms: [
+            { name: 'inherit' },
+            { name: 'override', host: { temperature: 0.6, maxTokens: 512 } },
+          ],
+        })
+      );
+      await fs.writeFile(
+        path.join(dir, 'cases.json'),
+        JSON.stringify({
+          name: 'generation-cases',
+          cases: [
+            { id: 'inherit' },
+            {
+              id: 'tagged',
+              host: { type: 'anthropic-api', temperature: 0, maxTokens: 1 },
+            },
+            {
+              id: 'legacy',
+              mcpHostConfig: {
+                provider: 'anthropic',
+                temperature: 1,
+                maxTokens: 123,
+              },
+            },
+            {
+              id: 'mixed',
+              host: { type: 'anthropic-api', temperature: 0.9, maxTokens: 999 },
+              mcpHostConfig: { provider: 'anthropic', maxTokens: 321 },
+            },
+          ].map((case_) => ({
+            ...case_,
+            mode: 'mcp_host',
+            scenario: case_.id,
+            expect: { containsText: ['OK'] },
+          })),
+        })
+      );
+      fetchMock.mockImplementation(async () =>
+        response([{ type: 'text', text: 'OK' }])
+      );
+      const result = await runEvalSuite({ manifestPath, rootDir: dir });
+      expect(result.summary.metrics).toMatchObject({
+        total: 8,
+        passed: 8,
+        failed: 0,
+      });
+      expect(fetchMock).toHaveBeenCalledTimes(8);
+      expect(
+        fetchMock.mock.calls.map((_, index) => {
+          const body = requestBody(index);
+          return { temperature: body.temperature, max_tokens: body.max_tokens };
+        })
+      ).toEqual([
+        { temperature: 0.8, max_tokens: 789 },
+        { temperature: 0, max_tokens: 1 },
+        { temperature: 1, max_tokens: 123 },
+        { temperature: 0.9, max_tokens: 321 },
+        { temperature: 0.6, max_tokens: 512 },
+        { temperature: 0, max_tokens: 1 },
+        { temperature: 1, max_tokens: 123 },
+        { temperature: 0.9, max_tokens: 321 },
+      ]);
+      expect(closeMCPClient).toHaveBeenCalledTimes(8);
+    } finally {
+      await fs.rm(dir, { recursive: true, force: true });
+    }
+  });
+});
+
 describe('Anthropic trace execution', () => {
   it.each([0, 1])(
     'enforces a budget of %s before every tool call',

--- a/src/evals/anthropicApiHost.test.ts
+++ b/src/evals/anthropicApiHost.test.ts
@@ -1,15 +1,22 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { ANTHROPIC_API_HOST } from './anthropicApiHost.js';
 import { hostTraceToExecution } from './hostTrace.js';
-async function run(options: HostRunOptions) {
+async function run(
+  options: HostRunOptions,
+  extra: Partial<HostRunContext> = {}
+) {
   const trace = await ANTHROPIC_API_HOST.run!(
-    { scenario: options.cases[0]!.scenario!, servers: options.servers },
+    {
+      scenario: options.cases[0]!.scenario!,
+      servers: options.servers,
+      env: extra.env,
+    },
     options.host,
-    { manifest: options.manifest, arm: options.arm }
+    { manifest: options.manifest, arm: options.arm, ...extra }
   );
   return hostTraceToExecution(trace, 'structured', options.servers);
 }
-import type { HostRunOptions } from './evalFrameworkTypes.js';
+import type { HostRunOptions, HostRunContext } from './evalFrameworkTypes.js';
 import {
   createMCPClientForConfig,
   closeMCPClient,
@@ -137,6 +144,37 @@ describe('Anthropic trace execution', () => {
     expect(close).toHaveBeenCalledOnce();
     expect(vi.getTimerCount()).toBe(0);
   });
+  it('honors legacy case host settings before execution', async () => {
+    fetchMock.mockResolvedValueOnce(calls(1));
+    const input = options(10);
+    input.host.model = 'suite-model';
+    const result = await run(input, {
+      mcpHostConfig: { model: 'case-model', maxToolCalls: 0 },
+    });
+    expect(result.error).toContain('budget exhausted');
+    expect(callTool).not.toHaveBeenCalled();
+    expect(JSON.stringify(fetchMock.mock.calls[0]?.[1]?.body)).toContain(
+      'case-model'
+    );
+  });
+
+  it('applies server-qualified overrides consistently across labeled servers', async () => {
+    fetchMock.mockResolvedValueOnce(response([{ type: 'text', text: 'OK' }]));
+    const input = options();
+    input.servers = [
+      { transport: 'http', serverUrl: 'https://a.example', label: 'a' },
+      { transport: 'http', serverUrl: 'https://b.example', label: 'b' },
+    ];
+    input.manifest.toolOverrides = {
+      id: 'qualified',
+      tools: { 'a.search': { description: 'only-a' } },
+    };
+    await run(input);
+    const body = JSON.stringify(fetchMock.mock.calls[0]?.[1]?.body);
+    expect(body).toContain('only-a');
+    expect(body).toContain('b__search');
+  });
+
   it('applies description overrides and supports a no-server assistant', async () => {
     fetchMock.mockResolvedValueOnce(response([{ type: 'text', text: 'OK' }]));
     const input = options();

--- a/src/evals/anthropicApiHost.ts
+++ b/src/evals/anthropicApiHost.ts
@@ -17,6 +17,7 @@ import type {
 import type { HostConfig } from './evalManifest.js';
 import type { MCPConfig } from '../config/mcpConfig.js';
 import { simulationToHostTrace } from './hostTrace.js';
+import { GenerationOptions } from './mcpHost/hostOptions.js';
 
 interface ContentBlock {
   type: string;
@@ -41,6 +42,8 @@ const HostSchema = z
     apiKeyEnv: z.string().min(1).default('ANTHROPIC_API_KEY'),
     maxToolCalls: z.number().int().nonnegative().default(20),
     timeout: z.number().int().positive().default(180_000),
+    temperature: GenerationOptions.temperature,
+    maxTokens: GenerationOptions.maxTokens,
   })
   .passthrough();
 
@@ -170,7 +173,8 @@ async function runAnthropicApiHost(
           },
           body: JSON.stringify({
             model: config.model,
-            max_tokens: 4096,
+            max_tokens: config.maxTokens ?? 4096,
+            temperature: config.temperature,
             messages,
             ...(tools.length ? { tools } : {}),
           }),

--- a/src/evals/anthropicApiHost.ts
+++ b/src/evals/anthropicApiHost.ts
@@ -1,0 +1,250 @@
+import {
+  closeMCPClient,
+  createMCPClientForConfig,
+} from '../mcp/clientFactory.js';
+import { z } from 'zod';
+import type {
+  HostRunInput,
+  HostRunContext,
+  HostDefinition,
+  HostRunResult,
+} from './evalFrameworkTypes.js';
+import type {
+  MCPHostConfig,
+  MCPHostSimulationResult,
+} from './mcpHost/mcpHostTypes.js';
+
+import type { HostConfig } from './evalManifest.js';
+import { simulationToHostTrace } from './hostTrace.js';
+
+interface ContentBlock {
+  type: string;
+  [key: string]: unknown;
+}
+interface ApiResponse {
+  content?: ContentBlock[];
+  stop_reason?: string;
+  usage?: { input_tokens?: number; output_tokens?: number };
+  error?: { message?: string };
+}
+interface Message {
+  role: 'user' | 'assistant';
+  content: string | ContentBlock[];
+}
+type Client = Awaited<ReturnType<typeof createMCPClientForConfig>>;
+
+const HostSchema = z
+  .object({
+    type: z.literal('anthropic-api'),
+    model: z.string().min(1).default('claude-sonnet-4-6'),
+    apiKeyEnv: z.string().min(1).default('ANTHROPIC_API_KEY'),
+    maxToolCalls: z.number().int().nonnegative().default(20),
+    timeout: z.number().int().positive().default(180_000),
+  })
+  .passthrough();
+
+/** Execute a single scenario. Iterations, assertions and judges belong to the runner. */
+async function runAnthropicApiHost(
+  input: HostRunInput,
+  host: HostConfig,
+  context: HostRunContext
+): Promise<HostRunResult> {
+  const options = { ...input, ...context, host };
+  const config = HostSchema.parse({ ...options.manifest, ...options.host });
+  const apiKey = process.env[config.apiKeyEnv];
+  if (!apiKey)
+    throw new Error(`Anthropic API key ${config.apiKeyEnv} is not set.`);
+  const case_ = { scenario: input.scenario };
+  if (!case_.scenario) {
+    throw new Error(
+      'Anthropic API host requires exactly one scenario per invocation.'
+    );
+  }
+  const started = Date.now();
+  const controller = new AbortController();
+  const clients: Client[] = [];
+  const timeoutError = new Error(
+    `Anthropic host timed out after ${config.timeout} ms.`
+  );
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const expired = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => {
+      controller.abort(timeoutError);
+      reject(timeoutError);
+    }, config.timeout);
+  });
+  const withinDeadline = <T>(promise: Promise<T>): Promise<T> =>
+    Promise.race([promise, expired]);
+  const toolCalls: MCPHostSimulationResult['toolCalls'] = [];
+  let inputTokens = 0;
+  let outputTokens = 0;
+  let text = '';
+  let error: string | undefined;
+  try {
+    const routing = new Map<
+      string,
+      { client: Client; name: string; label?: string }
+    >();
+    const tools: Array<Record<string, unknown>> = [];
+    for (const server of options.servers) {
+      const client = await withinDeadline(
+        createMCPClientForConfig(server).then(async (connected) => {
+          // Connection setup itself may not support cancellation. Close late arrivals.
+          if (controller.signal.aborted) {
+            await closeMCPClient(connected);
+            throw timeoutError;
+          }
+          clients.push(connected);
+          return connected;
+        })
+      );
+      const listed = await withinDeadline(
+        client.listTools({}, { signal: controller.signal })
+      );
+      for (const tool of listed.tools) {
+        const name =
+          options.servers.length > 1
+            ? `${server.label}__${tool.name}`
+            : tool.name;
+        if (routing.has(name))
+          throw new Error(`Duplicate host tool name: ${name}`);
+        routing.set(name, { client, name: tool.name, label: server.label });
+        const overrides =
+          options.arm?.toolOverrides ?? options.manifest.toolOverrides;
+        const override = overrides?.tools[tool.name];
+        tools.push({
+          name,
+          description: override?.description ?? tool.description,
+          input_schema: override?.inputSchema ?? tool.inputSchema,
+        });
+      }
+    }
+    const overrides =
+      options.arm?.toolOverrides ?? options.manifest.toolOverrides;
+    for (const name of Object.keys(overrides?.tools ?? {})) {
+      if (![...routing.values()].some((route) => route.name === name))
+        throw new Error(`Unknown tool override: ${name}`);
+    }
+    const messages: Message[] = [{ role: 'user', content: case_.scenario }];
+    for (;;) {
+      const response = await withinDeadline(
+        fetch('https://api.anthropic.com/v1/messages', {
+          method: 'POST',
+          signal: controller.signal,
+          headers: {
+            'content-type': 'application/json',
+            'anthropic-version': '2023-06-01',
+            'x-api-key': apiKey,
+          },
+          body: JSON.stringify({
+            model: config.model,
+            max_tokens: 4096,
+            messages,
+            ...(tools.length ? { tools } : {}),
+          }),
+        })
+      );
+      const body = (await withinDeadline(response.json())) as ApiResponse;
+      if (!response.ok)
+        throw new Error(
+          body.error?.message ?? `Anthropic API returned ${response.status}.`
+        );
+      const content = body.content ?? [];
+      text = content
+        .filter((block) => block.type === 'text')
+        .map((block) => (typeof block.text === 'string' ? block.text : ''))
+        .join('\n');
+      inputTokens += body.usage?.input_tokens ?? 0;
+      outputTokens += body.usage?.output_tokens ?? 0;
+      const calls = content.filter((block) => block.type === 'tool_use');
+      if (calls.length === 0) break;
+      messages.push({ role: 'assistant', content });
+      const results: ContentBlock[] = [];
+      for (const call of calls) {
+        if (toolCalls.length >= config.maxToolCalls)
+          throw new Error(
+            `Tool call budget exhausted (${config.maxToolCalls}).`
+          );
+        if (typeof call.name !== 'string' || typeof call.id !== 'string')
+          throw new Error('Malformed Anthropic tool use.');
+        const route = routing.get(call.name);
+        if (!route) throw new Error(`Unknown tool requested: ${call.name}`);
+        const args =
+          call.input &&
+          typeof call.input === 'object' &&
+          !Array.isArray(call.input)
+            ? (call.input as Record<string, unknown>)
+            : {};
+        const result = await withinDeadline(
+          route.client.callTool(
+            { name: route.name, arguments: args },
+            undefined,
+            { signal: controller.signal }
+          )
+        );
+        toolCalls.push({
+          name:
+            options.servers.length > 1
+              ? `${route.label}.${route.name}`
+              : route.name,
+          arguments: args,
+          id: call.id,
+          output: JSON.stringify(result),
+        });
+        results.push({
+          type: 'tool_result',
+          tool_use_id: call.id,
+          content: JSON.stringify(result),
+          is_error: Boolean(result.isError),
+        });
+      }
+      messages.push({ role: 'user', content: results });
+    }
+  } catch (cause) {
+    error = cause instanceof Error ? cause.message : String(cause);
+  } finally {
+    // Session termination can itself issue an HTTP request. Keep teardown under
+    // the same deadline, and force transport closure if it stalls.
+    try {
+      await withinDeadline(Promise.allSettled(clients.map(closeMCPClient)));
+    } catch {
+      error ??= timeoutError.message;
+      controller.abort(timeoutError);
+      await Promise.allSettled(clients.map((client) => client.close()));
+    } finally {
+      clearTimeout(timer);
+      controller.abort();
+    }
+  }
+  const usage = {
+    inputTokens,
+    outputTokens,
+    totalCostUsd: 0,
+    durationMs: Date.now() - started,
+  };
+  const response: MCPHostSimulationResult = {
+    success: !error,
+    response: text,
+    toolCalls,
+    usage,
+    ...(error ? { error } : {}),
+  };
+  return simulationToHostTrace(response, input.servers);
+}
+
+export const ANTHROPIC_API_HOST: HostDefinition = {
+  name: 'anthropic-api',
+  schema: HostSchema,
+  evidence: 'structured',
+  createConfig(options = {}): MCPHostConfig {
+    return {
+      hostType: 'sdk',
+      provider: 'anthropic',
+      model:
+        typeof options.model === 'string' ? options.model : 'claude-sonnet-4-6',
+      maxToolCalls:
+        typeof options.maxToolCalls === 'number' ? options.maxToolCalls : 20,
+    };
+  },
+  run: runAnthropicApiHost,
+};

--- a/src/evals/anthropicApiHost.ts
+++ b/src/evals/anthropicApiHost.ts
@@ -15,6 +15,7 @@ import type {
 } from './mcpHost/mcpHostTypes.js';
 
 import type { HostConfig } from './evalManifest.js';
+import type { MCPConfig } from '../config/mcpConfig.js';
 import { simulationToHostTrace } from './hostTrace.js';
 
 interface ContentBlock {
@@ -50,8 +51,13 @@ async function runAnthropicApiHost(
   context: HostRunContext
 ): Promise<HostRunResult> {
   const options = { ...input, ...context, host };
-  const config = HostSchema.parse({ ...options.manifest, ...options.host });
-  const apiKey = process.env[config.apiKeyEnv];
+  const config = HostSchema.parse({
+    ...options.manifest,
+    ...options.host,
+    ...(context.mcpHostConfig ?? {}),
+  });
+  const env = { ...process.env, ...context.env, ...input.env };
+  const apiKey = env[config.apiKeyEnv];
   if (!apiKey)
     throw new Error(`Anthropic API key ${config.apiKeyEnv} is not set.`);
   const case_ = { scenario: input.scenario };
@@ -86,6 +92,14 @@ async function runAnthropicApiHost(
       { client: Client; name: string; label?: string }
     >();
     const tools: Array<Record<string, unknown>> = [];
+    const toolEntries: Array<{
+      server: MCPConfig;
+      tool: {
+        name: string;
+        description?: string;
+        inputSchema: Record<string, unknown>;
+      };
+    }> = [];
     for (const server of options.servers) {
       const client = await withinDeadline(
         createMCPClientForConfig(server).then(async (connected) => {
@@ -109,21 +123,39 @@ async function runAnthropicApiHost(
         if (routing.has(name))
           throw new Error(`Duplicate host tool name: ${name}`);
         routing.set(name, { client, name: tool.name, label: server.label });
-        const overrides =
-          options.arm?.toolOverrides ?? options.manifest.toolOverrides;
-        const override = overrides?.tools[tool.name];
-        tools.push({
-          name,
-          description: override?.description ?? tool.description,
-          input_schema: override?.inputSchema ?? tool.inputSchema,
-        });
+        toolEntries.push({ server, tool });
       }
     }
     const overrides =
       options.arm?.toolOverrides ?? options.manifest.toolOverrides;
     for (const name of Object.keys(overrides?.tools ?? {})) {
-      if (![...routing.values()].some((route) => route.name === name))
+      const matches = toolEntries.filter(
+        ({ server, tool }) =>
+          name === tool.name || name === `${server.label}.${tool.name}`
+      );
+      if (matches.length === 0)
         throw new Error(`Unknown tool override: ${name}`);
+      if (matches.length > 1)
+        throw new Error(`Ambiguous tool override: ${name}`);
+    }
+    for (const { server, tool } of toolEntries) {
+      const qualified = `${server.label}.${String(tool.name)}`;
+      const override =
+        overrides?.tools[qualified] ??
+        (toolEntries.filter(
+          ({ tool: candidate }) => candidate.name === tool.name
+        ).length === 1
+          ? overrides?.tools[String(tool.name)]
+          : undefined);
+      const name =
+        options.servers.length > 1
+          ? `${server.label}__${tool.name}`
+          : String(tool.name);
+      tools.push({
+        name,
+        description: override?.description ?? tool.description,
+        input_schema: override?.inputSchema ?? tool.inputSchema,
+      });
     }
     const messages: Message[] = [{ role: 'user', content: case_.scenario }];
     for (;;) {

--- a/src/evals/builtinHosts.ts
+++ b/src/evals/builtinHosts.ts
@@ -25,6 +25,7 @@ import type { HostConfig } from './evalManifest.js';
 import { simulationToHostTrace } from './hostTrace.js';
 import { getHost, registerHost } from './frameworkRegistries.js';
 import type { MCPHostConfig } from './mcpHost/mcpHostTypes.js';
+import { ANTHROPIC_API_HOST } from './anthropicApiHost.js';
 
 async function runBuiltinHost(
   input: HostRunInput,
@@ -268,6 +269,7 @@ export function registerBuiltinHosts(): void {
         runBuiltinHost(input, config, context, factory),
     });
   }
+  registerHost(ANTHROPIC_API_HOST);
   builtinsRegistered = true;
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -279,6 +279,7 @@ export type {
   MetricValue,
   ResultStoreDefinition,
   RunSummary,
+  RunTelemetry,
   EvalSummaryGenerator,
 } from './evals/evalFrameworkTypes.js';
 export {


### PR DESCRIPTION
## Stack

Stacked on [#264](https://github.com/gleanwork/mcp-server-tester/pull/264).

## Scope

- Dispatch manifests to runtime hosts.
- Load runtime secrets for local and CI execution.
- Add the direct Anthropic API host and endpoint enforcement.
- Preserve failure semantics for failed evaluations.

This is the runtime integration layer above the core tester framework.