### PR TITLE
[Evals] Add production GCS datasets and result stores

### DIFF
--- a/scripts/test-eval-review.mjs
+++ b/scripts/test-eval-review.mjs
@@ -5,6 +5,7 @@ import path from 'node:path';
 import { pathToFileURL } from 'node:url';
 import { spawnSync } from 'node:child_process';
 import assert from 'node:assert/strict';
+import { build } from 'esbuild';
 
 const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'eval-review-'));
 try {
@@ -106,16 +107,34 @@ export function register() {registerMetric({name:'local-plugin-metric',schema:z.
       })),
     })
   );
+  // Keep the documented plain-Node smoke portable to Node 22 without a TS loader.
+  const legacyPlugin = path.join(dir, 'legacy-plugin.mjs');
+  await build({
+    entryPoints: ['examples/plugins/legacy-glean-datasets.ts'],
+    outfile: legacyPlugin,
+    bundle: true,
+    platform: 'node',
+    format: 'esm',
+    target: 'node22',
+    plugins: [
+      {
+        name: 'built-public-api',
+        setup(builder) {
+          builder.onResolve(
+            { filter: /^@gleanwork\/mcp-server-tester$/ },
+            () => ({ path: path.resolve('dist/index.js'), external: true })
+          );
+        },
+      },
+    ],
+  });
   const legacyManifest = path.join(dir, 'legacy-manifest.json');
   await fs.writeFile(
     legacyManifest,
     JSON.stringify({
       ...manifest,
       name: 'legacy-adapter',
-      plugins: [
-        ...manifest.plugins,
-        path.resolve('examples/plugins/legacy-glean-datasets.ts'),
-      ],
+      plugins: [...manifest.plugins, legacyPlugin],
       datasets: [
         {
           type: 'glean-legacy',
@@ -140,13 +159,13 @@ export function register() {registerMetric({name:'local-plugin-metric',schema:z.
   );
   dataset.cases[0].expect.containsText = 'deliberately impossible';
   await fs.writeFile(datasetPath, JSON.stringify(dataset));
-  cli(
+  const failedRun = cli(
     ['run', '--manifest', paths[0], '--output-dir', path.join(dir, 'failure')],
     1
   );
-  const summary = JSON.parse(
-    await fs.readFile(path.join(dir, 'failure', 'results.json'), 'utf8')
-  );
+  const summaryPath = /^Output: (.+)$/m.exec(failedRun)?.[1];
+  assert.ok(summaryPath, 'CLI must print the unique execution result path');
+  const summary = JSON.parse(await fs.readFile(summaryPath, 'utf8'));
   assert.equal(summary.metrics.failed, 1);
   assert.equal(summary.metrics.passed, 4);
   assert.equal(summary.metrics['local-plugin-metric_rate'], 0.8);

--- a/scripts/test-eval-review.mjs
+++ b/scripts/test-eval-review.mjs
@@ -1,0 +1,156 @@
+// Offline integration smoke for the built CLI. Run after building: node scripts/test-eval-review.mjs
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { spawnSync } from 'node:child_process';
+import assert from 'node:assert/strict';
+
+const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'eval-review-'));
+try {
+  const serverPath = path.join(dir, 'server.mjs');
+  await fs.writeFile(
+    serverPath,
+    `import { Server } from ${JSON.stringify(import.meta.resolve('@modelcontextprotocol/sdk/server/index.js'))};
+import { StdioServerTransport } from ${JSON.stringify(import.meta.resolve('@modelcontextprotocol/sdk/server/stdio.js'))};
+import { ListToolsRequestSchema, CallToolRequestSchema } from ${JSON.stringify(import.meta.resolve('@modelcontextprotocol/sdk/types.js'))};
+const server = new Server({name:'local-review-fixture',version:'1'}, {capabilities:{tools:{}}});
+server.setRequestHandler(ListToolsRequestSchema, async () => ({tools:[{name:'echo',description:'Local echo',inputSchema:{type:'object',properties:{text:{type:'string'}}}}]}));
+server.setRequestHandler(CallToolRequestSchema, async (request) => ({content:[{type:'text',text:request.params.arguments.text}]}));
+await server.connect(new StdioServerTransport());`
+  );
+  const pluginPath = path.join(dir, 'plugin.mjs');
+  await fs.writeFile(
+    pluginPath,
+    `import {registerMetric} from ${JSON.stringify(pathToFileURL(path.resolve('dist/index.js')).href)};
+import {z} from ${JSON.stringify(import.meta.resolve('zod'))};
+export function register() {registerMetric({name:'local-plugin-metric',schema:z.object({}).passthrough(),kind:'binary',compute(result){return result.pass;}});}`
+  );
+  const datasetPath = path.join(dir, 'dataset.json');
+  await fs.writeFile(
+    datasetPath,
+    JSON.stringify({
+      name: 'local-five',
+      cases: Array.from({ length: 5 }, (_, i) => ({
+        id: 'case-' + i,
+        toolName: 'echo',
+        args: { text: 'local success ' + i },
+        expect: { containsText: 'local success' },
+      })),
+    })
+  );
+  const manifestDir = path.join(dir, 'manifests');
+  await fs.mkdir(manifestDir);
+  const paths = [];
+  for (let i = 0; i < 4; i++) {
+    const file = path.join(manifestDir, `run-${i}.json`);
+    paths.push(file);
+    await fs.writeFile(
+      file,
+      JSON.stringify({
+        name: `local-${i}`,
+        datasets: [datasetPath],
+        servers: [
+          { transport: 'stdio', command: process.execPath, args: [serverPath] },
+        ],
+        host: { type: 'vercel-sdk' },
+        concurrency: 8,
+        plugins: [pluginPath],
+        metrics: ['local-plugin-metric'],
+        results: { store: { type: 'file', dir: path.join(dir, `store-${i}`) } },
+      })
+    );
+  }
+  function cli(args, expected = 0) {
+    const result = spawnSync(process.execPath, ['dist/cli/index.js', ...args], {
+      encoding: 'utf8',
+      timeout: 60000,
+    });
+    assert.equal(result.status, expected, `${result.stdout}\n${result.stderr}`);
+    return result.stdout;
+  }
+  const batchArgs = [
+    'batch',
+    '--manifest-dir',
+    manifestDir,
+    '--workers',
+    '4',
+    '--output-root',
+    path.join(dir, 'batch'),
+  ];
+  assert.match(cli(batchArgs), /4 passed, 0 failed, 0 skipped/);
+  console.log(
+    'PASS: 4 concurrent manifests × 5 cases, concurrency=8, real local stdio MCP server.'
+  );
+  assert.match(cli([...batchArgs, '--skip-existing']), /4 skipped/);
+  console.log('PASS: resume skipped four matching completed results.');
+  const manifest = JSON.parse(await fs.readFile(paths[0], 'utf8'));
+  manifest.model = 'changed-identity';
+  await fs.writeFile(paths[0], JSON.stringify(manifest));
+  assert.match(
+    cli([...batchArgs, '--skip-existing']),
+    /1 passed, 0 failed, 3 skipped/
+  );
+  console.log(
+    'PASS: a changed manifest reran; three matching runs remained skipped.'
+  );
+  const dataset = JSON.parse(await fs.readFile(datasetPath, 'utf8'));
+  const legacyPath = path.join(dir, 'legacy.json');
+  await fs.writeFile(
+    legacyPath,
+    JSON.stringify({
+      ...dataset,
+      cases: dataset.cases.map(({ toolName, ...item }) => ({
+        ...item,
+        tool: toolName,
+      })),
+    })
+  );
+  const legacyManifest = path.join(dir, 'legacy-manifest.json');
+  await fs.writeFile(
+    legacyManifest,
+    JSON.stringify({
+      ...manifest,
+      name: 'legacy-adapter',
+      plugins: [
+        ...manifest.plugins,
+        path.resolve('examples/plugins/legacy-glean-datasets.ts'),
+      ],
+      datasets: [
+        {
+          type: 'glean-legacy',
+          format: 'tool-call',
+          transport: { type: 'file', path: legacyPath },
+        },
+      ],
+    })
+  );
+  assert.match(
+    cli([
+      'run',
+      '--manifest',
+      legacyManifest,
+      '--output-dir',
+      path.join(dir, 'legacy-output'),
+    ]),
+    /5\/5 passed/
+  );
+  console.log(
+    'PASS: opt-in legacy source plugin converted five cases through the built CLI.'
+  );
+  dataset.cases[0].expect.containsText = 'deliberately impossible';
+  await fs.writeFile(datasetPath, JSON.stringify(dataset));
+  cli(
+    ['run', '--manifest', paths[0], '--output-dir', path.join(dir, 'failure')],
+    1
+  );
+  const summary = JSON.parse(
+    await fs.readFile(path.join(dir, 'failure', 'results.json'), 'utf8')
+  );
+  assert.equal(summary.metrics.failed, 1);
+  assert.equal(summary.metrics.passed, 4);
+  assert.equal(summary.metrics['local-plugin-metric_rate'], 0.8);
+  console.log('PASS: wrong assertion failed, plugin metric=0.8, CLI exit=1.');
+} finally {
+  await fs.rm(dir, { recursive: true, force: true });
+}

--- a/src/cli/commands/batch/index.ts
+++ b/src/cli/commands/batch/index.ts
@@ -11,6 +11,7 @@ export interface BatchOptions {
   rootDir?: string;
   outputRoot?: string;
   workers?: number;
+  secretsFile?: string;
   skipExisting?: boolean;
   plugins?: string[];
   dryRun?: boolean;
@@ -33,6 +34,7 @@ export async function batch(options: BatchOptions): Promise<void> {
     rootDir: options.rootDir,
     outputRoot: options.outputRoot,
     workers: options.workers,
+    secretsFile: options.secretsFile,
     skipExisting: options.skipExisting,
     pluginPaths: options.plugins,
     dryRun: options.dryRun,

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -96,6 +96,7 @@ program
     '.'
   )
   .option('--output-root <dir>', 'Root directory for evaluation results')
+  .option('--secrets-file <path>', 'JSON or dotenv-style runtime secrets file')
   .option('--workers <number>', 'Maximum number of parallel manifest runs')
   .option('--skip-existing', 'Skip manifests with an existing result')
   .option('--dry-run', 'Validate manifests without executing evaluations')
@@ -106,6 +107,7 @@ program
       plugins: options.plugins,
       rootDir: options.rootDir,
       outputRoot: options.outputRoot,
+      secretsFile: options.secretsFile,
       workers: options.workers ? Number(options.workers) : undefined,
       skipExisting: options.skipExisting,
       dryRun: options.dryRun,

--- a/src/evals/builtinDatasetSources.test.ts
+++ b/src/evals/builtinDatasetSources.test.ts
@@ -1,0 +1,96 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { registerBuiltinDatasetSources } from './builtinDatasetSources.js';
+import { getDatasetSource } from './frameworkRegistries.js';
+import type { EvalManifest } from './evalManifest.js';
+
+const gcs = vi.hoisted(() => ({
+  download: vi.fn(),
+  bucket: vi.fn(),
+  file: vi.fn(),
+}));
+vi.mock('@google-cloud/storage', () => ({
+  Storage: class {
+    bucket(name: string) {
+      gcs.bucket(name);
+      return {
+        file(name: string) {
+          gcs.file(name);
+          return { download: gcs.download };
+        },
+      };
+    }
+  },
+}));
+registerBuiltinDatasetSources();
+
+describe('canonical built-in dataset sources', () => {
+  let rootDir: string;
+  const manifest: EvalManifest = { name: 'source-tests', datasets: [] };
+  beforeEach(async () => {
+    rootDir = await fs.mkdtemp(path.join(os.tmpdir(), 'dataset-source-'));
+    vi.clearAllMocks();
+  });
+  afterEach(async () => {
+    await fs.rm(rootDir, { recursive: true, force: true });
+  });
+
+  for (const type of ['file', 'dir', 'gcs'] as const) {
+    describe(type, () => {
+      async function load(raw: unknown) {
+        // The suite expands dir into paths; this exercises each entry's loader.
+        const source =
+          type === 'gcs'
+            ? { type, uri: 'gs://datasets/cases.json' }
+            : { type, path: 'cases.json' };
+        await fs.writeFile(
+          path.join(rootDir, 'cases.json'),
+          JSON.stringify(raw)
+        );
+        gcs.download.mockResolvedValue([Buffer.from(JSON.stringify(raw))]);
+        return getDatasetSource(type).load(source, { rootDir, manifest });
+      }
+      it('loads minimal direct JSON with no mode, expect, args, or host', async () => {
+        const raw = {
+          name: 'canonical',
+          cases: [{ id: 'search', toolName: 'search' }],
+        };
+        expect((await load(raw)).cases).toEqual(raw.cases);
+        if (type === 'gcs') {
+          expect(gcs.bucket).toHaveBeenCalledWith('datasets');
+          expect(gcs.file).toHaveBeenCalledWith('cases.json');
+          expect(gcs.download).toHaveBeenCalledTimes(1);
+        }
+      });
+      it('preserves canonical host mode, per-case host, iterations and judges', async () => {
+        const case_ = {
+          id: 'question',
+          mode: 'host',
+          scenario: 'Find policy',
+          host: { type: 'custom-host', option: true },
+          iterations: 3,
+          expect: { passesJudge: { judge: 'custom-quality', threshold: 0.8 } },
+        };
+        expect(
+          (await load({ name: 'canonical', cases: [case_] })).cases[0]
+        ).toEqual(case_);
+      });
+      it.each([
+        { id: 'question', scenario: 'What is our policy?' },
+        { id: 'selection', scenario: 'Find policy', expected_tool: 'search' },
+        { id: 'call', tool: 'search', expect: { isError: false } },
+      ])(
+        'rejects legacy cases rather than inferring a shape',
+        async (case_) => {
+          await expect(
+            load({ name: 'legacy', cases: [case_] })
+          ).rejects.toThrow(
+            /canonical EvalDataset.*explicit dataset source adapter/
+          );
+        }
+      );
+    });
+  }
+});

--- a/src/evals/builtinDatasetSources.ts
+++ b/src/evals/builtinDatasetSources.ts
@@ -14,6 +14,12 @@ const FileDatasetSchema = z
     recursive: z.boolean().optional(),
   })
   .passthrough();
+const GCSDatasetSchema = z
+  .object({
+    type: z.literal('gcs'),
+    uri: z.string().regex(/^gs:\/\/[^/]+\/.+/),
+  })
+  .passthrough();
 
 async function loadFileDataset(
   config: DatasetConfig,
@@ -23,8 +29,45 @@ async function loadFileDataset(
   const filePath = path.isAbsolute(source.path)
     ? source.path
     : path.resolve(context.rootDir, source.path);
-  const raw = JSON.parse(await fs.readFile(filePath, 'utf8')) as unknown;
-  return buildEvalDataset(raw, context.hostConfig, context.manifest);
+  return buildEvalDataset(
+    JSON.parse(await fs.readFile(filePath, 'utf8')) as unknown,
+    context.hostConfig,
+    context.manifest
+  );
+}
+
+interface GCSStorage {
+  bucket(name: string): {
+    file(name: string): { download(): Promise<[Buffer]> };
+  };
+}
+async function loadGCSDataset(
+  config: DatasetConfig,
+  context: DatasetSourceContext
+): Promise<EvalDataset> {
+  const { uri } = GCSDatasetSchema.parse(config);
+  const match = /^gs:\/\/([^/]+)\/(.+)$/.exec(uri);
+  if (!match) throw new Error(`Invalid GCS dataset URI: ${uri}`);
+  let Storage: new () => GCSStorage;
+  try {
+    ({ Storage } = (await import('@google-cloud/storage')) as unknown as {
+      Storage: new () => GCSStorage;
+    });
+  } catch (error) {
+    throw new Error(
+      'GCS datasets require the optional `@google-cloud/storage` package. ' +
+        `Original error: ${error instanceof Error ? error.message : String(error)}`
+    );
+  }
+  const [buffer] = await new Storage()
+    .bucket(match[1]!)
+    .file(match[2]!)
+    .download();
+  return buildEvalDataset(
+    JSON.parse(buffer.toString('utf8')) as unknown,
+    context.hostConfig,
+    context.manifest
+  );
 }
 
 async function loadDirectoryDataset(
@@ -33,10 +76,8 @@ async function loadDirectoryDataset(
 ): Promise<EvalDataset> {
   const source = FileDatasetSchema.parse(config);
   const directory = path.resolve(context.rootDir, source.path);
-  if (!(await fs.stat(directory)).isDirectory()) {
+  if (!(await fs.stat(directory)).isDirectory())
     return loadFileDataset(config, context);
-  }
-
   async function collect(dir: string): Promise<string[]> {
     const entries = (await fs.readdir(dir, { withFileTypes: true })).sort(
       (a, b) => a.name.localeCompare(b.name)
@@ -44,21 +85,18 @@ async function loadDirectoryDataset(
     const files: string[] = [];
     for (const entry of entries) {
       const entryPath = path.join(dir, entry.name);
-      if (entry.isDirectory() && source.recursive) {
+      if (entry.isDirectory() && source.recursive)
         files.push(...(await collect(entryPath)));
-      } else if (entry.isFile() && entry.name.endsWith('.json')) {
+      else if (entry.isFile() && entry.name.endsWith('.json'))
         files.push(entryPath);
-      }
     }
     return files;
   }
-
   const files = await collect(directory);
-  if (files.length === 0) {
+  if (!files.length)
     throw new Error(
       `Dataset directory contains no JSON datasets: ${directory}`
     );
-  }
   const datasets = await Promise.all(
     files.map((filePath) =>
       loadFileDataset(
@@ -86,8 +124,6 @@ async function loadDirectoryDataset(
 }
 
 let registered = false;
-
-/** Register source-owned canonical file and recursive directory readers. */
 export function registerBuiltinDatasetSources(): void {
   if (registered) return;
   registerDatasetSource({
@@ -99,6 +135,11 @@ export function registerBuiltinDatasetSources(): void {
     name: 'dir',
     schema: FileDatasetSchema,
     load: loadDirectoryDataset,
+  });
+  registerDatasetSource({
+    name: 'gcs',
+    schema: GCSDatasetSchema,
+    load: loadGCSDataset,
   });
   registered = true;
 }

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -21,6 +21,7 @@ export default defineConfig([
       '@ai-sdk/deepseek',
       '@openrouter/ai-sdk-provider',
       '@ai-sdk/xai',
+      '@google-cloud/storage',
     ],
   },
   // CLI build
@@ -35,6 +36,7 @@ export default defineConfig([
     outDir: 'dist/cli',
     tsconfig: './tsconfig.build.json',
     shims: true,
+    external: ['@google-cloud/storage'],
     banner: {
       js: '#!/usr/bin/env node',
     },


### PR DESCRIPTION
## Stack

Stacked on [#265](https://github.com/gleanwork/mcp-server-tester/pull/265).

## Scope

- Add the built-in GCS dataset source.
- Add file and GCS result-store registrations.
- Persist canonical artifacts through the configured manifest result store.
- Forward batch runtime secrets.
- Externalize the GCS SDK from the CLI bundle for Cloud Run.

## Validation

- Clean typecheck, lint, format check, and tsup build pass.
- 62 test files / 1048 tests pass.
- GitHub Runner and Cloud Run smoke tests passed with 5/5 cases and GCS result objects present.