### PR TITLE
fix(evals): reuse source host for first comparison arm

### DIFF
--- a/src/evals/runEvalSuite.test.ts
+++ b/src/evals/runEvalSuite.test.ts
@@ -167,6 +167,54 @@ describe('suite review regressions', () => {
     ).rejects.toThrow('SUITE_DUMMY_TOKEN');
   });
 
+  it('reuses the source host configuration for the first comparison arm', async () => {
+    const hostType = `arm-host-${sequence++}`;
+    const sourceType = `arm-source-${sequence++}`;
+    const configurations: Record<string, unknown>[] = [];
+    registerHost({
+      name: hostType,
+      schema: z.object({ type: z.string(), model: z.string() }).passthrough(),
+      createConfig(options = {}) {
+        configurations.push(options);
+        return {
+          hostType: 'sdk',
+          model: options.model as string | undefined,
+        };
+      },
+      run: async () => ({ finalText: 'OK', events: [] }),
+    });
+    registerDatasetSource({
+      name: sourceType,
+      schema: z.object({ type: z.string() }),
+      load: async () => ({
+        name: 'shared',
+        cases: [{ id: 'case', mode: 'host', scenario: 'hello' }],
+      }),
+    });
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'suite-arms-'));
+    dirs.push(dir);
+    const manifestPath = path.join(dir, 'manifest.json');
+    await fs.writeFile(
+      manifestPath,
+      JSON.stringify({
+        name: 'arm-configs',
+        datasets: [{ type: sourceType }],
+        host: { type: hostType, model: 'base' },
+        arms: [
+          { name: 'base-arm' },
+          { name: 'variant-arm', host: { type: hostType, model: 'variant' } },
+        ],
+      })
+    );
+
+    await runEvalSuite({ manifestPath, rootDir: dir });
+
+    expect(configurations.map((options) => options.model)).toEqual([
+      'base',
+      'variant',
+    ]);
+  });
+
   it.each(['manifest', 'override'] as const)(
     'resolves %s server credentials before creating the source CLI config',
     async (serverSource) => {

--- a/src/evals/runEvalSuite.ts
+++ b/src/evals/runEvalSuite.ts
@@ -405,7 +405,13 @@ export async function runEvalSuite(
       resolveServerSecrets(server, env)
     );
     resolvedServers.forEach((server) => assertEvalEndpoint(server, manifest));
-    const host = resolveHost(manifest, arm, resolvedServers, env);
+    // The first arm's resolved host was already needed to load the shared
+    // datasets. Reuse it for that arm so source loading does not invoke a
+    // stateful host factory twice or create a configuration that is discarded.
+    const host =
+      arm === sourceArm
+        ? sourceHost
+        : resolveHost(manifest, arm, resolvedServers, env);
     const effectiveManifest: EvalManifest = {
       ...manifest,
       ...arm,


### PR DESCRIPTION
## Summary

Reuse the already-created source host for the first comparison arm in `runEvalSuite`.

Without this reuse, the first comparison arm creates a duplicate host instance, producing factory call sequences such as:

```text
base, base, variant
```

The fix preserves the suite host lifecycle contract while avoiding the duplicate factory call.

## Validation

- MST tests: 1,330 passing
- Typecheck: passing
- Lint: passing
- Format check: passing
- Documentation checks: passing
- Focused review probes: 21/21 passing
- Scio integration currently pins this commit while validating the merged tester stack

— sent via Glean Tau
